### PR TITLE
Fetch the full faculty roll, not just the first 12 per department

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -48,7 +48,7 @@ jobs:
             const c = require("./public/data/campus.json");
             const fail = (m) => { console.error("FAIL: " + m); process.exit(1) };
             if (c.pois.length < 200) fail(`only ${c.pois.length} POIs`);
-            if ((c.faculty?.items.length ?? 0) < 200) fail(`only ${c.faculty?.items.length ?? 0} faculty`);
+            if ((c.faculty?.items.length ?? 0) < 600) fail(`only ${c.faculty?.items.length ?? 0} faculty`);
             if ((c.mess?.items.length ?? 0) < 100) fail(`only ${c.mess?.items.length ?? 0} mess menus`);
             console.log(`ok: ${c.pois.length} pois, ${c.faculty.items.length} faculty, ${c.mess.items.length} menus`);
           '

--- a/README.md
+++ b/README.md
@@ -47,12 +47,15 @@ and what each gap needs.
 |---|---|---|
 | Places, geometry, opening hours, wheelchair tags | [OpenStreetMap](https://www.openstreetmap.org/relation/52434888) (ODbL) | 276 places, 20 lecture halls |
 | Walking & cycling network | OpenStreetMap paths, footways, corridors, steps | 1145 nodes / 1294 edges |
-| Faculty directory | [iitk.ac.in/iitk-faculty](https://www.iitk.ac.in/iitk-faculty) + profile pages | 305 people, 164 placed on the map |
+| Faculty directory | [iitk.ac.in/iitk-faculty](https://www.iitk.ac.in/iitk-faculty) + profile pages | 663 people, 445 placed on the map |
 | Mess menus | [campusmess.in](https://campusmess.in) public API | 189 menus, 14 halls |
 
-The faculty listing shows at most **12 people per department**, so it is a
-subset, not the full roll — the app states this rather than implying coverage
-it does not have.
+The faculty listing renders 12 people per department and hides the rest behind
+a Load More button that POSTs to `/loadmore-faculty?count=N&taxon=T`. The
+fetcher walks that endpoint for all 21 paged departments, so this is the whole
+roll — 663 people, of whom 59 hold joint appointments and are stored once with
+every department they belong to. A smoke test fails the build if the count
+drops back toward 305 or any department comes back short.
 
 Deliberately **not** used: `iitk.ac.in/counsel/family_tree/data.json`. It is a
 mentor/mentee tree of named students with roll numbers from the 2008–09 batches.
@@ -101,7 +104,7 @@ people, mess menus, layers, commands. Ranking is exact-key, then prefix, then a
 subsequence match with contiguity and word-boundary bonuses, then all-words-present,
 then substring. `mess dinner` is intercepted before generic ranking so it answers
 with tonight's food rather than a list of halls. Typical query: **under 0.3 ms**
-over 613 documents.
+over 971 documents.
 
 **Opening hours** are parsed by a deliberately partial `opening_hours` reader
 that returns `null` for anything it does not understand. A wrong "open now" is

--- a/data/live/faculty.json
+++ b/data/live/faculty.json
@@ -1,38 +1,17 @@
 {
  "_source": "https://www.iitk.ac.in/iitk-faculty",
- "_fetched": "2026-08-11T21:39:01.886Z",
- "_note": "Public faculty directory published by IIT Kanpur. The listing page shows up to 12 people per department, so this is a subset, not the full faculty roll.",
- "_capped_departments": [
-  "Economic Sciences",
-  "Aerospace Engineering",
-  "Biological Sciences & Bioengineering",
-  "Chemical Engineering",
-  "Civil Engineering",
-  "Computer Science & Engineering",
-  "Design",
-  "Electrical Engineering",
-  "Intelligent Systems",
-  "Materials Science & Engineering",
-  "Management Sciences",
-  "Mechanical Engineering",
-  "Space, Planetary and Astronomical Sciences and Engineering",
-  "Sustainable Energy Engineering",
-  "Humanities and Social Sciences",
-  "Materials Science Programme",
-  "Photonics Science and Engineering Programme",
-  "Kotak School of Sustainability",
-  "Wadhwani School of AI & Intelligent Systems (WSAIS)",
-  "Chemistry",
-  "Earth Sciences",
-  "Mathematics",
-  "Physics"
- ],
+ "_fetched": "2026-08-11T22:32:25.710Z",
+ "_note": "Public faculty directory published by IIT Kanpur. The listing page shows 12 per department and hides the rest behind a Load More button; this walks that endpoint, so it is the full roll.",
+ "_incomplete_departments": [],
  "items": [
   {
    "name": "Aditya Vikram",
    "title": "Assistant Professor, Department of Economic Sciences",
    "dept": "Economic Sciences",
    "url": "https://www.iitk.ac.in/aditya-vikram",
+   "depts": [
+    "Economic Sciences"
+   ],
    "email": "vikrama@iitk.ac.in",
    "phone": "0512-259-2311",
    "web": "https://sites.google.com/site/88avikram",
@@ -45,6 +24,9 @@
    "title": "Assistant Professor, Department of Economic Sciences",
    "dept": "Economic Sciences",
    "url": "https://www.iitk.ac.in/anna-thottappilly",
+   "depts": [
+    "Economic Sciences"
+   ],
    "email": "annat@iitk.ac.in",
    "research": "Agricultural economics, climate change, nutrition",
    "qualification": "PhD (Cornell University)"
@@ -53,13 +35,19 @@
    "name": "Anujit Chakraborty",
    "title": "Visiting Assistant Professor, Department of Economic Sciences",
    "dept": "Economic Sciences",
-   "url": "https://www.iitk.ac.in/anujit-chakraborty"
+   "url": "https://www.iitk.ac.in/anujit-chakraborty",
+   "depts": [
+    "Economic Sciences"
+   ]
   },
   {
    "name": "Bikramaditya Datta",
    "title": "Associate Professor, Department of Economic Sciences",
    "dept": "Economic Sciences",
    "url": "https://www.iitk.ac.in/bikramaditya-datta",
+   "depts": [
+    "Economic Sciences"
+   ],
    "email": "bikramd@iitk.ac.in",
    "phone": "+91-512-259-7476",
    "web": "https://sites.google.com/site/bikramdatta14/bikramaditya-datta",
@@ -72,6 +60,10 @@
    "title": "Assistant Professor, Department of Humanities and Social Sciences + Economic Sciences Adjunct Faculty",
    "dept": "Economic Sciences",
    "url": "https://www.iitk.ac.in/esha-chatterjee",
+   "depts": [
+    "Economic Sciences",
+    "Humanities and Social Sciences"
+   ],
    "email": "eshachat@iitk.ac.in",
    "web": "https://sites.google.com/view/eshachatterjee/",
    "research": "My past and ongoing projects examine the relationship between women’s employment and education; fertility intentions, behaviour and maternal health, unmet need for contraception, and internal migration in the Indian context.",
@@ -82,6 +74,9 @@
    "title": "Assistant Professor, Department of Economic Sciences",
    "dept": "Economic Sciences",
    "url": "https://www.iitk.ac.in/hargungeet-singh",
+   "depts": [
+    "Economic Sciences"
+   ],
    "email": "hargungeet@iitk.ac.in",
    "research": "Microeconomic Theory and Corporate Finance",
    "qualification": "PhD (New York University)"
@@ -91,6 +86,9 @@
    "title": "Professor, Department of Economic Sciences",
    "dept": "Economic Sciences",
    "url": "https://www.iitk.ac.in/joydeep-dutta",
+   "depts": [
+    "Economic Sciences"
+   ],
    "email": "jdutta@iitk.ac.in",
    "phone": "0512-259-7568",
    "web": "https://home.iitk.ac.in/~jdutta",
@@ -102,13 +100,19 @@
    "name": "Kumar Alok",
    "title": "Visiting Professor of Practice, Department of Economic Sciences",
    "dept": "Economic Sciences",
-   "url": "https://www.iitk.ac.in/kumar-alok"
+   "url": "https://www.iitk.ac.in/kumar-alok",
+   "depts": [
+    "Economic Sciences"
+   ]
   },
   {
    "name": "Mahamitra Das",
    "title": "Assistant Professor, Department of Economic Sciences",
    "dept": "Economic Sciences",
    "url": "https://www.iitk.ac.in/mahamitra-das",
+   "depts": [
+    "Economic Sciences"
+   ],
    "email": "mahamitra@iitk.ac.in",
    "web": "https://sites.google.com/view/mahamitradas/",
    "office": "Office Room No. - 503H-F, Diamond Jubilee Academic Complex",
@@ -120,6 +124,9 @@
    "title": "Assistant Professor, Department of Economic Sciences",
    "dept": "Economic Sciences",
    "url": "https://www.iitk.ac.in/malabika-koley",
+   "depts": [
+    "Economic Sciences"
+   ],
    "email": "malabika@iitk.ac.in",
    "research": "Econometrics, Spatial Econometrics, Regional Science.",
    "qualification": "Ph.D. , University of Illinois at Urbana Champaign"
@@ -129,6 +136,9 @@
    "title": "Assistant Professor, Department of Economic Sciences",
    "dept": "Economic Sciences",
    "url": "https://www.iitk.ac.in/manpreet-singh",
+   "depts": [
+    "Economic Sciences"
+   ],
    "email": "manpreets@iitk.ac.in"
   },
   {
@@ -136,6 +146,9 @@
    "title": "Associate Professor, Department of Economic Sciences",
    "dept": "Economic Sciences",
    "url": "https://www.iitk.ac.in/mohammad-arshad-rahman",
+   "depts": [
+    "Economic Sciences"
+   ],
    "email": "marshad@iitk.ac.in",
    "phone": "0512-259-7010",
    "web": "https://www.arshadrahman.com",
@@ -148,6 +161,9 @@
    "title": "Professor, Department of Aerospace Engineering",
    "dept": "Aerospace Engineering",
    "url": "https://www.iitk.ac.in/dr-abhijit-kushari",
+   "depts": [
+    "Aerospace Engineering"
+   ],
    "email": "akushari@iitk.ac.in",
    "phone": "0512-259-7126",
    "web": "https://iitk.ac.in/aero/faculty/akushari/",
@@ -159,6 +175,9 @@
    "title": "Professor, Department of Aerospace Engineering",
    "dept": "Aerospace Engineering",
    "url": "https://www.iitk.ac.in/dr-abhishek",
+   "depts": [
+    "Aerospace Engineering"
+   ],
    "email": "abhish@iitk.ac.in",
    "phone": "0512-259-7515",
    "web": "https://home.iitk.ac.in/~abhish/",
@@ -171,6 +190,9 @@
    "title": "Associate Professor, Department of Aerospace Engineering",
    "dept": "Aerospace Engineering",
    "url": "https://www.iitk.ac.in/ajay-vikram-singh",
+   "depts": [
+    "Aerospace Engineering"
+   ],
    "email": "ajayvs@iitk.ac.in",
    "phone": "512-259-2006",
    "web": "https://www.ajayvsaero.com/",
@@ -182,6 +204,10 @@
    "title": "Associate Professor, Department of Mechanical Engineering + AE Adjunct Faculty",
    "dept": "Aerospace Engineering",
    "url": "https://www.iitk.ac.in/akhilesh-mimani",
+   "depts": [
+    "Aerospace Engineering",
+    "Mechanical Engineering"
+   ],
    "email": "amimani@iitk.ac.in",
    "phone": "0512-259-2088",
    "web": "https://home.iitk.ac.in/~amimani/",
@@ -193,6 +219,9 @@
    "title": "Professor, Department of Aerospace Engineering",
    "dept": "Aerospace Engineering",
    "url": "https://www.iitk.ac.in/alakesh-chandra-mandal",
+   "depts": [
+    "Aerospace Engineering"
+   ],
    "email": "alakeshm@iitk.ac.in",
    "phone": "0512-259-7062",
    "research": "Experimental aerodynamics, Flow instability and transition, Turbulent shear flows",
@@ -203,6 +232,9 @@
    "title": "Associate Professor, Department of Aerospace Engineering",
    "dept": "Aerospace Engineering",
    "url": "https://www.iitk.ac.in/arnab-samanta",
+   "depts": [
+    "Aerospace Engineering"
+   ],
    "email": "asamanta@iitk.ac.in",
    "phone": "0512-259-2182",
    "web": "https://sites.google.com/view/fpcal",
@@ -215,6 +247,9 @@
    "title": "Associate Professor, Department of Aerospace Engineering",
    "dept": "Aerospace Engineering",
    "url": "https://www.iitk.ac.in/arun-kumar-perumal",
+   "depts": [
+    "Aerospace Engineering"
+   ],
    "email": "akp@iitk.ac.in",
    "phone": "0512-259-2155",
    "office": "Department of Aerospace Engineering",
@@ -226,6 +261,9 @@
    "title": "Professor, Department of Aerospace Engineering",
    "dept": "Aerospace Engineering",
    "url": "https://www.iitk.ac.in/dr-ashish-tewari",
+   "depts": [
+    "Aerospace Engineering"
+   ],
    "email": "ashtew@iitk.ac.in",
    "phone": "0512-259-7868",
    "web": "https://home.iitk.ac.in/~ashtew/",
@@ -237,6 +275,9 @@
    "title": "Professor, Department of Aerospace Engineering",
    "dept": "Aerospace Engineering",
    "url": "https://www.iitk.ac.in/dr-ashok-de",
+   "depts": [
+    "Aerospace Engineering"
+   ],
    "email": "ashoke@iitk.ac.in",
    "phone": "0512-259-7863",
    "web": "https://home.iitk.ac.in/~ashoke/",
@@ -248,6 +289,9 @@
    "title": "Professor, Department of Aerospace Engineering",
    "dept": "Aerospace Engineering",
    "url": "https://www.iitk.ac.in/dr-c-s-upadhyay",
+   "depts": [
+    "Aerospace Engineering"
+   ],
    "email": "shekhar@iitk.ac.in",
    "phone": "0512-259-7936",
    "qualification": "PhD (Texas A&M)"
@@ -257,6 +301,9 @@
    "title": "Assistant Professor, Department of Aerospace Engineering",
    "dept": "Aerospace Engineering",
    "url": "https://www.iitk.ac.in/d-chaitanya-kumar-rao",
+   "depts": [
+    "Aerospace Engineering"
+   ],
    "email": "chaitanya@iitk.ac.in",
    "phone": "0512-259-2338",
    "web": "https://chaitanyarao.in/",
@@ -269,6 +316,9 @@
    "title": "Professor, Department of Aerospace Engineering",
    "dept": "Aerospace Engineering",
    "url": "https://www.iitk.ac.in/dr-d-p-mishra",
+   "depts": [
+    "Aerospace Engineering"
+   ],
    "email": "mishra@iitk.ac.in",
    "phone": "0512-259-7125",
    "research": "Combustion, CFD of Chemically Reacting Flows, Spray",
@@ -279,6 +329,9 @@
    "title": "Professor, Department of Biological Sciences & Bioengineering",
    "dept": "Biological Sciences & Bioengineering",
    "url": "https://www.iitk.ac.in/amitabha-bandyopadhyay",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
    "email": "abandopa@iitk.ac.in",
    "phone": "0512-259-4055",
    "web": "https://iitk.ac.in/bsbe/amitabha-bandyopadhyay",
@@ -290,6 +343,9 @@
    "title": "Assistant Professor, Department of Biological Sciences & Bioengineering",
    "dept": "Biological Sciences & Bioengineering",
    "url": "https://www.iitk.ac.in/anusmita-sahoo",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
    "email": "asahoo@iitk.ac.in",
    "phone": "0512-259-2351",
    "research": "Protein Engineering, Vaccine design, Immunology, Antibody glycosylation",
@@ -300,6 +356,9 @@
    "title": "Associate Professor, Department of Biological Sciences & Bioengineering",
    "dept": "Biological Sciences & Bioengineering",
    "url": "https://www.iitk.ac.in/appu-kumar-singh",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
    "email": "singhappu@iitk.ac.in",
    "phone": "0512-259-2142",
    "research": "Ion-channels, calcium signaling, Cryo-electron microscopy, X-ray crystallography, electrophysiology, fluorescence spectroscopy",
@@ -310,6 +369,9 @@
    "title": "Assistant Professor, Department of Biological Sciences & Bioengineering",
    "dept": "Biological Sciences & Bioengineering",
    "url": "https://www.iitk.ac.in/arjun-ramakrishnan",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
    "email": "arjunr@iitk.ac.in",
    "phone": "0512-259-2150",
    "research": "Systems neuroscience, decision making, mental health, electrophysiology, EEG, cognition"
@@ -319,6 +381,9 @@
    "title": "Professor, Department of Biological Sciences & Bioengineering",
    "dept": "Biological Sciences & Bioengineering",
    "url": "https://www.iitk.ac.in/arun-k-shukla",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
    "email": "arshukla@iitk.ac.in",
    "phone": "0512-259-4251",
    "research": "Structural and functional elucidation of GPCR signaling pathways and novel drug discovery.",
@@ -329,6 +394,9 @@
    "title": "Professor, Department of Biological Sciences & Bioengineering",
    "dept": "Biological Sciences & Bioengineering",
    "url": "https://www.iitk.ac.in/dr-ashok-kumar",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
    "email": "ashokkum@iitk.ac.in",
    "phone": "0512-259-4051",
    "web": "https://www.iitk.ac.in/bsbe/ashok-kumar",
@@ -339,6 +407,9 @@
    "title": "Professor, Department of Biological Sciences & Bioengineering",
    "dept": "Biological Sciences & Bioengineering",
    "url": "https://www.iitk.ac.in/ashwani-kumar-thakur",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
    "email": "akthakur@iitk.ac.in",
    "phone": "0512-259-4077",
    "qualification": "PhD (I.M.T. & Punjab University)"
@@ -348,6 +419,9 @@
    "title": "Professor, Department of Biological Sciences & Bioengineering",
    "dept": "Biological Sciences & Bioengineering",
    "url": "https://www.iitk.ac.in/bushra-ateeq",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
    "email": "bushra@iitk.ac.in",
    "phone": "+915122597701",
    "office": "Indian Institute of Technology Kanpur",
@@ -358,6 +432,9 @@
    "title": "Assistant Professor, Department of Biological Sciences & Bioengineering",
    "dept": "Biological Sciences & Bioengineering",
    "url": "https://www.iitk.ac.in/debanjan-dasgupta",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
    "email": "debanjand@iitk.ac.in",
    "research": "Neurophysiology, Circuits and Systems Neuroscience, Behavioural assay, Electrophysiology",
    "qualification": "PhD (Indian Institute of Science, Bangalore)"
@@ -367,6 +444,9 @@
    "title": "Assistant Professor, Department of Biological Sciences & Bioengineering",
    "dept": "Biological Sciences & Bioengineering",
    "url": "https://www.iitk.ac.in/debdeep-dutta",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
    "email": "ddutta@iitk.ac.in"
   },
   {
@@ -374,6 +454,9 @@
    "title": "Professor, Department of Biological Sciences & Bioengineering, Currently on Deputation as Director, IIT Goa.",
    "dept": "Biological Sciences & Bioengineering",
    "url": "https://www.iitk.ac.in/dhirendra-s-katti",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
    "email": "dsk@iitk.ac.in",
    "phone": "0512-259-4028",
    "web": "https://iitk.ac.in/bsbe/dhirendra-s-katti",
@@ -386,6 +469,9 @@
    "title": "Associate Professor, Department of Biological Sciences & Bioengineering",
    "dept": "Biological Sciences & Bioengineering",
    "url": "https://www.iitk.ac.in/dibyendu-kumar-das",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
    "email": "dkdas@iitk.ac.in",
    "phone": "0512-259-4064",
    "web": "https://sites.google.com/view/daslabiitkanpur/dibyendu",
@@ -397,6 +483,9 @@
    "title": "Assistant Professor, Department of Chemical Engineering",
    "dept": "Chemical Engineering",
    "url": "https://www.iitk.ac.in/akash-choudhary",
+   "depts": [
+    "Chemical Engineering"
+   ],
    "email": "achoudhary@iitk.ac.in",
    "phone": "0512-679-2386",
    "web": "https://sites.google.com/view/akashchoudhary",
@@ -408,6 +497,9 @@
    "title": "Professor, Department of Chemical Engineering",
    "dept": "Chemical Engineering",
    "url": "https://www.iitk.ac.in/animangsu-ghatak",
+   "depts": [
+    "Chemical Engineering"
+   ],
    "email": "aghatak@iitk.ac.in",
    "phone": "0512-259-7146",
    "web": "https://iitk.ac.in/che/old/ag.htm",
@@ -419,6 +511,9 @@
    "title": "Professor, Department of Chemical Engineering",
    "dept": "Chemical Engineering",
    "url": "https://www.iitk.ac.in/anurag-tripathi",
+   "depts": [
+    "Chemical Engineering"
+   ],
    "email": "anuragt@iitk.ac.in",
    "phone": "0512-259-6591",
    "office": "Office FB 456,",
@@ -429,13 +524,22 @@
    "name": "Arijit Bose",
    "title": "Distinguished Visiting Professor, Department of Chemical Engineering",
    "dept": "Chemical Engineering",
-   "url": "https://www.iitk.ac.in/arijit-bose"
+   "url": "https://www.iitk.ac.in/arijit-bose",
+   "depts": [
+    "Chemical Engineering"
+   ]
   },
   {
    "name": "Ashutosh Sharma",
    "title": "Professor, Department of Chemical Engineering + Adjunct Faculty in MSP (Materials Science Programme) + SEE + Kotak School of Sustainability (KSS)",
    "dept": "Chemical Engineering",
    "url": "https://www.iitk.ac.in/ashutosh-sharma",
+   "depts": [
+    "Chemical Engineering",
+    "Sustainable Energy Engineering",
+    "Materials Science Programme",
+    "Kotak School of Sustainability"
+   ],
    "email": "ashutos@iitk.ac.in",
    "phone": "0512-259-7026",
    "office": "Office NL2-106,",
@@ -447,6 +551,9 @@
    "title": "Associate Professor, Department of Chemical Engineering",
    "dept": "Chemical Engineering",
    "url": "https://www.iitk.ac.in/dipin-s-pillai",
+   "depts": [
+    "Chemical Engineering"
+   ],
    "email": "dipinsp@iitk.ac.in",
    "phone": "0512-679-2109",
    "research": "Stability Theory, Nonlinear Dynamics, Reduced-Order Modeling, Hydrodynamic Stability, Thin Films, Electrohydrodynamics, Multiphase flows",
@@ -456,13 +563,19 @@
    "name": "Dr. Samiran Mahapatra",
    "title": "Adjunct Professor, Department of Chemical Engineering",
    "dept": "Chemical Engineering",
-   "url": "https://www.iitk.ac.in/dr-samiran-mahapatra"
+   "url": "https://www.iitk.ac.in/dr-samiran-mahapatra",
+   "depts": [
+    "Chemical Engineering"
+   ]
   },
   {
    "name": "Goutam Deo",
    "title": "Professor, Department of Chemical Engineering",
    "dept": "Chemical Engineering",
    "url": "https://www.iitk.ac.in/goutam-deo",
+   "depts": [
+    "Chemical Engineering"
+   ],
    "email": "goutam@iitk.ac.in",
    "web": "https://www.iitk.ac.in/che/old/gd.htm",
    "office": "Office CL-201B",
@@ -473,6 +586,9 @@
    "title": "Assistant Professor, Department of Chemical Engineering",
    "dept": "Chemical Engineering",
    "url": "https://www.iitk.ac.in/harshwardhan-h-katkar",
+   "depts": [
+    "Chemical Engineering"
+   ],
    "email": "hkatkar@iitk.ac.in",
    "phone": "0512-679-2095",
    "research": "Soft matter, Biophysics, Nanopores, Bacterial Assemblies, Fluid Mechanics, Multiscale modeling, Bottom-up coarse-graining, Enhanced sampling."
@@ -482,6 +598,10 @@
    "title": "Associate Professor, Department of Chemical Engineering + SEE Adjunct Faculty",
    "dept": "Chemical Engineering",
    "url": "https://www.iitk.ac.in/himanshu-sharma",
+   "depts": [
+    "Chemical Engineering",
+    "Sustainable Energy Engineering"
+   ],
    "email": "sharmah@iitk.ac.in",
    "phone": "0512-679-2073",
    "research": "Flow through porous media,Enhanced oil recovery, Colloids & interfaces, Nanotechnology.",
@@ -492,6 +612,9 @@
    "title": "Associate Professor, Department of Chemical Engineering",
    "dept": "Chemical Engineering",
    "url": "https://www.iitk.ac.in/indranil-saha-dalal",
+   "depts": [
+    "Chemical Engineering"
+   ],
    "email": "indrasd@iitk.ac.in",
    "phone": "0512-259-6702",
    "web": "https://iitk.ac.in/che/isd.htm",
@@ -504,6 +627,9 @@
    "title": "Assistant Professor, Department of Chemical Engineering",
    "dept": "Chemical Engineering",
    "url": "https://www.iitk.ac.in/ishan-bajaj",
+   "depts": [
+    "Chemical Engineering"
+   ],
    "email": "ibajaj@iitk.ac.in",
    "phone": "0512-679-2375",
    "research": "Process systems engineering, Nonlinear optimization, Technoeconomic and life-cycle analyses, Energy system modeling, Operations research",
@@ -514,6 +640,9 @@
    "title": "Professor, Department of Civil Engineering",
    "dept": "Civil Engineering",
    "url": "https://www.iitk.ac.in/abhas-singh",
+   "depts": [
+    "Civil Engineering"
+   ],
    "email": "abhas@iitk.ac.in",
    "phone": "0512-259-7665",
    "web": "https://home.iitk.ac.in/~abhas/",
@@ -525,6 +654,10 @@
    "title": "Assistant Professor, Department of Civil Engineering + Adjunct Faculty in Kotak School of Sustainable",
    "dept": "Civil Engineering",
    "url": "https://www.iitk.ac.in/abhijith-g-r",
+   "depts": [
+    "Civil Engineering",
+    "Kotak School of Sustainability"
+   ],
    "email": "abhijith@iitk.ac.in",
    "phone": "0512-259-2427",
    "web": "https://scholar.google.co.in/citations?user=RjxTUZ8AAAAJ&amp;hl=en",
@@ -536,6 +669,9 @@
    "title": "Assistant Professor, Departement of Civil Engineering",
    "dept": "Civil Engineering",
    "url": "https://www.iitk.ac.in/aditya-medury",
+   "depts": [
+    "Civil Engineering"
+   ],
    "email": "amedury@iitk.ac.in",
    "phone": "0512-259-2175",
    "office": "Office WLE 112A,",
@@ -546,6 +682,9 @@
    "title": "Assistant Professor, Department of Civil Engineering",
    "dept": "Civil Engineering",
    "url": "https://www.iitk.ac.in/amar-nath-roy-chowdhury",
+   "depts": [
+    "Civil Engineering"
+   ],
    "email": "amarrc@iitk.ac.in",
    "phone": "0512-259-2144",
    "web": "https://sites.google.com/view/amarstructuresiitk/bio",
@@ -558,6 +697,9 @@
    "title": "Professor, Department of Civil Engineering",
    "dept": "Civil Engineering",
    "url": "https://www.iitk.ac.in/animesh-das",
+   "depts": [
+    "Civil Engineering"
+   ],
    "email": "adas@iitk.ac.in",
    "phone": "0512-259-7477",
    "web": "https://home.iitk.ac.in/~adas/",
@@ -570,6 +712,10 @@
    "title": "Professor, Department of Civil Engineering + Department of Sustainable Energy Engineering (joint appointment)",
    "dept": "Civil Engineering",
    "url": "https://www.iitk.ac.in/anubha-goel",
+   "depts": [
+    "Civil Engineering",
+    "Sustainable Energy Engineering"
+   ],
    "email": "anubha@iitk.ac.in",
    "phone": "0512-259-7027",
    "web": "https://home.iitk.ac.in/~anubha/",
@@ -581,6 +727,9 @@
    "title": "Professor, Department of Civil Engineering",
    "dept": "Civil Engineering",
    "url": "https://www.iitk.ac.in/arghya-das",
+   "depts": [
+    "Civil Engineering"
+   ],
    "email": "arghya@iitk.ac.in",
    "phone": "0512-259-6978",
    "web": "https://sites.google.com/view/arghyadas",
@@ -593,6 +742,9 @@
    "title": "Associate Professor, Department of Civil Engineering",
    "dept": "Civil Engineering",
    "url": "https://www.iitk.ac.in/balaji-devaraju",
+   "depts": [
+    "Civil Engineering"
+   ],
    "email": "dbalaji@iitk.ac.in",
    "phone": "0 512 259 2047",
    "office": "Office Engineering Sciences Building I, #503",
@@ -604,6 +756,10 @@
    "title": "Professor, Department of Civil Engineering + Photonics Science and Engineering",
    "dept": "Civil Engineering",
    "url": "https://www.iitk.ac.in/bharat-lohani",
+   "depts": [
+    "Civil Engineering",
+    "Photonics Science and Engineering Programme"
+   ],
    "email": "blohani@iitk.ac.in",
    "phone": "0512-259-7413",
    "web": "https://home.iitk.ac.in/~blohani/educational_record.htm",
@@ -615,6 +771,9 @@
    "title": "Assistant Professor, Department of Civil Engineering",
    "dept": "Civil Engineering",
    "url": "https://www.iitk.ac.in/bipin-kumar-gupta",
+   "depts": [
+    "Civil Engineering"
+   ],
    "email": "bkgupta@iitk.ac.in",
    "phone": "0512-259-2143",
    "web": "https://scholar.google.com/citations?user=j_x0z50AAAAJ&amp;hl=en",
@@ -627,6 +786,9 @@
    "title": "Assistant Professor, Department of Civil Engineering",
    "dept": "Civil Engineering",
    "url": "https://www.iitk.ac.in/chinmoy-kolay",
+   "depts": [
+    "Civil Engineering"
+   ],
    "email": "ckolay@iitk.ac.in",
    "phone": "+91-512-259-6282",
    "web": "https://sites.google.com/view/ckolay",
@@ -639,6 +801,9 @@
    "title": "Assistant Professor, Department of Civil Engineering",
    "dept": "Civil Engineering",
    "url": "https://www.iitk.ac.in/chirag-kothari",
+   "depts": [
+    "Civil Engineering"
+   ],
    "email": "ckothari@iitk.ac.in",
    "research": "Infrastructure Asset Management, Construction Management, Digital Twins for Civil Infrastructure Systems, Sustainable Smart Cities"
   },
@@ -647,6 +812,9 @@
    "title": "Assistant Professor, Department of Computer Science & Engineering",
    "dept": "Computer Science & Engineering",
    "url": "https://www.iitk.ac.in/adithya-vadapalli",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
    "email": "avadapalli@iitk.ac.in",
    "phone": "+91-512-259-2422",
    "web": "https://avadapal.github.io",
@@ -658,6 +826,11 @@
    "title": "Professor, Department of Computer Science and Engineering + Joint Appointment in Department of Intelligent Systems (DIS) in Wadhwani School of AI & Intelligent Systems (WSAIS)",
    "dept": "Computer Science & Engineering",
    "url": "https://www.iitk.ac.in/dr-amey-karkare",
+   "depts": [
+    "Computer Science & Engineering",
+    "Intelligent Systems",
+    "Wadhwani School of AI & Intelligent Systems (WSAIS)"
+   ],
    "email": "karkare@iitk.ac.in",
    "phone": "0512-259-7520",
    "web": "https://www.cse.iitk.ac.in/users/karkare/",
@@ -670,6 +843,9 @@
    "title": "Assistant Professor, Department of Computer Science & Engineering",
    "dept": "Computer Science & Engineering",
    "url": "https://www.iitk.ac.in/amitangshu-pal",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
    "email": "amitangshu@iitk.ac.in",
    "phone": "0512-259-2236",
    "research": "Wireless and Sensor Networks, Sensing and Communication for Internet of Things (IoTs) and Building IoT Solutions for Smart Cities",
@@ -680,6 +856,10 @@
    "title": "Assistant Professor, Department of Computer Science & Engineering + Joint Appointment in Wadhwani School of AI & Intelligent Systems (WSAIS)",
    "dept": "Computer Science & Engineering",
    "url": "https://www.iitk.ac.in/angshuman-karmakar",
+   "depts": [
+    "Computer Science & Engineering",
+    "Wadhwani School of AI & Intelligent Systems (WSAIS)"
+   ],
    "email": "angshuman@iitk.ac.in",
    "phone": "0512-259-2358",
    "research": "Post Quantum Cryptography, Side-Channel attacks and Computation on encrypted data and Cryptology",
@@ -690,6 +870,9 @@
    "title": "Professor, Department of Computer Science and Engineering",
    "dept": "Computer Science & Engineering",
    "url": "https://www.iitk.ac.in/dr-anil-seth",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
    "email": "seth@iitk.ac.in",
    "phone": "0512-259-7231",
    "web": "https://www.cse.iitk.ac.in/users/seth/",
@@ -702,6 +885,9 @@
    "title": "Assistant Professor, Department of Computer Science & Engineering",
    "dept": "Computer Science & Engineering",
    "url": "https://www.iitk.ac.in/anshu-yadav",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
    "email": "anshuy@iitk.ac.in"
   },
   {
@@ -709,6 +895,9 @@
    "title": "Professor, Department of Computer Science and Engineering",
    "dept": "Computer Science & Engineering",
    "url": "https://www.iitk.ac.in/arnab-bhattacharya",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
    "email": "arnabb@iitk.ac.in",
    "phone": "0512-259-7650",
    "web": "https://www.cse.iitk.ac.in/users/arnabb/",
@@ -721,6 +910,9 @@
    "title": "Associate Professor, Department of Computer Science & Engineering",
    "dept": "Computer Science & Engineering",
    "url": "https://www.iitk.ac.in/ashutosh-modi",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
    "email": "ashutoshm@iitk.ac.in",
    "phone": "0512-259-2131",
    "research": "Natural Language Processing, Machine Learning and Affective Computing",
@@ -731,6 +923,9 @@
    "title": "Associate Professor, Department of Computer Science & Engineering",
    "dept": "Computer Science & Engineering",
    "url": "https://www.iitk.ac.in/debadatta-mishra",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
    "email": "debam@iitk.ac.in",
    "phone": "0512-259-2004",
    "research": "Operating Systems, Virtualization and Cloud Computing and Computer Networks",
@@ -741,6 +936,9 @@
    "title": "Assistant Professor, Department of Computer Science & Engineering",
    "dept": "Computer Science & Engineering",
    "url": "https://www.iitk.ac.in/debapriya-basu-roy",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
    "email": "dbroy@iitk.ac.in",
    "phone": "0512-259-2250",
    "research": "Hardware Security, VLSI for Cryptography and Post Quantum Cryptography",
@@ -750,19 +948,28 @@
    "name": "Dr. Amartya Sanyal",
    "title": "Adjunct Assistant Professor, Department of Computer Science & Engineering",
    "dept": "Computer Science & Engineering",
-   "url": "https://www.iitk.ac.in/dr-amartya-sanyal"
+   "url": "https://www.iitk.ac.in/dr-amartya-sanyal",
+   "depts": [
+    "Computer Science & Engineering"
+   ]
   },
   {
    "name": "Dr. Nisheeth K. Vishnoi",
    "title": "Visiting Professor, Department of Computer Science & Engineering",
    "dept": "Computer Science & Engineering",
-   "url": "https://www.iitk.ac.in/dr-nisheeth-k-vishnoi"
+   "url": "https://www.iitk.ac.in/dr-nisheeth-k-vishnoi",
+   "depts": [
+    "Computer Science & Engineering"
+   ]
   },
   {
    "name": "Abhishek Shrivastava",
    "title": "Associate Professor, Department of Design",
    "dept": "Design",
    "url": "https://www.iitk.ac.in/abhishek-shrivastava",
+   "depts": [
+    "Design"
+   ],
    "email": "shri@iitk.ac.in"
   },
   {
@@ -770,6 +977,9 @@
    "title": "Associate Professor, Department of Design",
    "dept": "Design",
    "url": "https://www.iitk.ac.in/amar-kumar-behera",
+   "depts": [
+    "Design"
+   ],
    "email": "amarkb@iitk.ac.in"
   },
   {
@@ -777,6 +987,9 @@
    "title": "Assistant Professor, Department of Design",
    "dept": "Design",
    "url": "https://www.iitk.ac.in/ashish-kumar-singh",
+   "depts": [
+    "Design"
+   ],
    "email": "ashish@iitk.ac.in"
   },
   {
@@ -784,6 +997,9 @@
    "title": "Professor of Practice, Department of Design",
    "dept": "Design",
    "url": "https://www.iitk.ac.in/girish-ishwar-lone",
+   "depts": [
+    "Design"
+   ],
    "email": "girishlone@iitk.ac.in"
   },
   {
@@ -791,6 +1007,9 @@
    "title": "Assistant Professor, Department of Design",
    "dept": "Design",
    "url": "https://www.iitk.ac.in/gowdham-prabhakar-p-g",
+   "depts": [
+    "Design"
+   ],
    "email": "gowdhampg@iitk.ac.in",
    "web": "https://home.iitk.ac.in/~gowdhampg/",
    "office": "605H, HIVE, Department of Design, DJAC, IIT Kanpur",
@@ -802,6 +1021,9 @@
    "title": "Assistant Professor, Department of Design",
    "dept": "Design",
    "url": "https://www.iitk.ac.in/himanshi-jangir",
+   "depts": [
+    "Design"
+   ],
    "email": "himanshi@iitk.ac.in"
   },
   {
@@ -809,6 +1031,9 @@
    "title": "Professor, Department of Design",
    "dept": "Design",
    "url": "https://www.iitk.ac.in/dr-j-ramkumar",
+   "depts": [
+    "Design"
+   ],
    "email": "jrkumar@iitk.ac.in",
    "phone": "0512-259-7546",
    "web": "https://home.iitk.ac",
@@ -821,6 +1046,9 @@
    "title": "Professor, Department of Design",
    "dept": "Design",
    "url": "https://www.iitk.ac.in/dr-mainak-das",
+   "depts": [
+    "Design"
+   ],
    "email": "mainakd@iitk.ac.in",
    "phone": "0512-259-4076",
    "web": "https://home.iitk.ac.in/~mainakd/mainak/Welcome.html",
@@ -830,13 +1058,19 @@
    "name": "Ms. Jhumkee Iyengar",
    "title": "Adjunct Professor, Department of Design",
    "dept": "Design",
-   "url": "https://www.iitk.ac.in/ms-jhumkee-iyengar"
+   "url": "https://www.iitk.ac.in/ms-jhumkee-iyengar",
+   "depts": [
+    "Design"
+   ]
   },
   {
    "name": "Nilutpal Borgohain",
    "title": "Assistant Professor, Department of Design",
    "dept": "Design",
    "url": "https://www.iitk.ac.in/nilutpal-borgohain",
+   "depts": [
+    "Design"
+   ],
    "email": "nilutpal@iitk.ac.in"
   },
   {
@@ -844,6 +1078,9 @@
    "title": "Professor of Practice, Department of Design",
    "dept": "Design",
    "url": "https://www.iitk.ac.in/rajeev-jindal",
+   "depts": [
+    "Design"
+   ],
    "email": "rajeevj@iitk.ac.in",
    "phone": "0512-679-2323",
    "research": "Energy Technology and Policy, Carbon Neutrality, c-Si Solar Cells and Metal-ion Batteries"
@@ -853,6 +1090,9 @@
    "title": "Assistant Professor, Department of Design",
    "dept": "Design",
    "url": "https://www.iitk.ac.in/saptarshi-kolay",
+   "depts": [
+    "Design"
+   ],
    "email": "skolay@iitk.ac.in"
   },
   {
@@ -860,6 +1100,9 @@
    "title": "Professor, Departement of Electrical Engineering",
    "dept": "Electrical Engineering",
    "url": "https://www.iitk.ac.in/a-r-harish",
+   "depts": [
+    "Electrical Engineering"
+   ],
    "email": "arh@iitk.ac.in",
    "phone": "512-259-7569",
    "office": "Office ACES 225B ,",
@@ -871,6 +1114,9 @@
    "title": "Professor, Department of Electrical Engineering",
    "dept": "Electrical Engineering",
    "url": "https://www.iitk.ac.in/abheejeet-mohapatra",
+   "depts": [
+    "Electrical Engineering"
+   ],
    "email": "abheem@iitk.ac.in",
    "phone": "0512-259-7152",
    "web": "https://sites.google.com/view/abheejeetmohapatra",
@@ -882,6 +1128,9 @@
    "title": "Assistant Professor, Department of Electrical Engineering.",
    "dept": "Electrical Engineering",
    "url": "https://www.iitk.ac.in/abhilash-patel",
+   "depts": [
+    "Electrical Engineering"
+   ],
    "email": "apatel@iitk.ac.in",
    "phone": "+91-512-679-2322",
    "web": "https://home.iitk.ac.in/~apatel/",
@@ -893,6 +1142,9 @@
    "title": "Associate Professor, Department of Electrical Engineering",
    "dept": "Electrical Engineering",
    "url": "https://www.iitk.ac.in/abhishek-k-gupta",
+   "depts": [
+    "Electrical Engineering"
+   ],
    "email": "gkrabhi@iitk.ac.in",
    "phone": "0512-259-2001",
    "web": "https://home.iitk.ac.in/~gkrabhi/",
@@ -905,6 +1157,9 @@
    "title": "Visiting Faculty, Department of Electrical Engineering",
    "dept": "Electrical Engineering",
    "url": "https://www.iitk.ac.in/abhyudai-singh",
+   "depts": [
+    "Electrical Engineering"
+   ],
    "email": "absingh@udel.edu",
    "office": "ACES, 202, IIT Kanpur",
    "research": "Modelling and inference of biomedical systems with applications to systems biology, virology, medicine, and neuroscience.",
@@ -915,6 +1170,9 @@
    "title": "Professor, Department of Electrical Engineering",
    "dept": "Electrical Engineering",
    "url": "https://www.iitk.ac.in/aditya-k-jagannatham",
+   "depts": [
+    "Electrical Engineering"
+   ],
    "email": "adityaj@iitk.ac.in",
    "phone": "0512-259-7494",
    "web": "https://home.iitk.ac.in/~adityaj/",
@@ -927,6 +1185,9 @@
    "title": "Professor, Department of Electrical Engineering",
    "dept": "Electrical Engineering",
    "url": "https://www.iitk.ac.in/adrish-banerjee",
+   "depts": [
+    "Electrical Engineering"
+   ],
    "email": "adrish@iitk.ac.in",
    "phone": "0512-259-7991",
    "web": "https://home.iitk.ac.in/~adrish/",
@@ -939,6 +1200,9 @@
    "title": "Professor, Department of Electrical Engineering",
    "dept": "Electrical Engineering",
    "url": "https://www.iitk.ac.in/ajit-kumar-chaturvedi",
+   "depts": [
+    "Electrical Engineering"
+   ],
    "email": "akc@iitk.ac.in",
    "phone": "0512-259-7613",
    "web": "https://home.iitk.ac.in/~akc/",
@@ -951,6 +1215,9 @@
    "title": "Associate Professor, Department of Electrical Engineering",
    "dept": "Electrical Engineering",
    "url": "https://www.iitk.ac.in/alok-ranjan-verma",
+   "depts": [
+    "Electrical Engineering"
+   ],
    "email": "arverma@iitk.ac.in",
    "phone": "0512-259-2097",
    "web": "https://home.iitk.ac.in/~arverma/",
@@ -963,6 +1230,10 @@
    "title": "Associate Professor, Department of Electrical Engineering + MSP Adjunct Faculty",
    "dept": "Electrical Engineering",
    "url": "https://www.iitk.ac.in/amit-verma",
+   "depts": [
+    "Electrical Engineering",
+    "Materials Science Programme"
+   ],
    "email": "amitkver@iitk.ac.in",
    "phone": "0512-259-6432",
    "office": "WL-132",
@@ -973,13 +1244,19 @@
    "name": "Anirudh Gautam",
    "title": "Professor of Practice, Department of Electrical Engineering",
    "dept": "Electrical Engineering",
-   "url": "https://www.iitk.ac.in/anirudh-gautam"
+   "url": "https://www.iitk.ac.in/anirudh-gautam",
+   "depts": [
+    "Electrical Engineering"
+   ]
   },
   {
    "name": "Ankush Sharma",
    "title": "Professor, Department of Electrical Engineering",
    "dept": "Electrical Engineering",
    "url": "https://www.iitk.ac.in/ankush-sharma",
+   "depts": [
+    "Electrical Engineering"
+   ],
    "email": "ansharma@iitk.ac.in",
    "phone": "+91-512-2592012",
    "office": "Office ACES 104",
@@ -987,22 +1264,15 @@
    "qualification": "PhD (IIT Kanpur)"
   },
   {
-   "name": "Amey Karkare",
-   "title": "Professor, Department of Computer Science and Engineering + Joint Appointment in Department of Intelligent Systems (DIS) in Wadhwani School of AI & Intelligent Systems (WSAIS)",
-   "dept": "Intelligent Systems",
-   "url": "https://www.iitk.ac.in/dr-amey-karkare",
-   "email": "karkare@iitk.ac.in",
-   "phone": "0512-259-7520",
-   "web": "https://www.cse.iitk.ac.in/users/karkare/",
-   "office": "Office Room No. 401, Rajeev Motwani Building, Department of Computer Science and Engineering IIT Kanpur, Kanpur 208016",
-   "research": "Compilers, Functional Programming, Program Analysis & Code Optimization, Programming Languages and Education.",
-   "qualification": "PhD (IIT Bombay)"
-  },
-  {
    "name": "Indranil Saha",
    "title": "Professor, Department of Computer Science and Engineering + Department of Intelligent Systems (DIS) in Wadhwani School of AI & Intelligent Systems (WSAIS) Joint Appointment",
    "dept": "Intelligent Systems",
    "url": "https://www.iitk.ac.in/indranil-saha",
+   "depts": [
+    "Intelligent Systems",
+    "Wadhwani School of AI & Intelligent Systems (WSAIS)",
+    "Computer Science & Engineering"
+   ],
    "email": "isaha@cse.iitk.ac.in",
    "phone": "0512-259-6343",
    "web": "https://www.cse.iitk.ac.in/users/isaha/",
@@ -1015,6 +1285,12 @@
    "title": "Professor, Department of Electrical Engineering + AE Adjunct Faculty + Joint Appointment in Department of Intelligent Systems (DIS) in Wadhwani School of AI & Intelligent Systems (WSAIS)",
    "dept": "Intelligent Systems",
    "url": "https://www.iitk.ac.in/ketan-rajawat",
+   "depts": [
+    "Intelligent Systems",
+    "Wadhwani School of AI & Intelligent Systems (WSAIS)",
+    "Aerospace Engineering",
+    "Electrical Engineering"
+   ],
    "email": "ketan@iitk.ac.in",
    "phone": "0512-259-7337",
    "web": "https://home.iitk.ac.in/~ketan/",
@@ -1027,6 +1303,11 @@
    "title": "Professor, Department of Computer Science and Engineering + Department of Intelligent Systems (DIS) in Wadhwani School of AI & Intelligent Systems (WSAIS) Joint Appointment",
    "dept": "Intelligent Systems",
    "url": "https://www.iitk.ac.in/manindra-agrawal",
+   "depts": [
+    "Intelligent Systems",
+    "Wadhwani School of AI & Intelligent Systems (WSAIS)",
+    "Computer Science & Engineering"
+   ],
    "email": "manindra@iitk.ac.in",
    "phone": "0512-259-7338",
    "web": "https://sites.google.com/view/manindra/home",
@@ -1039,6 +1320,12 @@
    "title": "Professor, Department of Computer Science and Engineering + Department of Cognitive Science (joint appointment) + Department of Intelligent Systems (DIS) in Wadhwani School of AI & Intelligent Systems (WSAIS) Joint Appointment",
    "dept": "Intelligent Systems",
    "url": "https://www.iitk.ac.in/nisheeth-srivastava",
+   "depts": [
+    "Intelligent Systems",
+    "Wadhwani School of AI & Intelligent Systems (WSAIS)",
+    "Cognitive Science",
+    "Computer Science & Engineering"
+   ],
    "email": "nsrivast@iitk.ac.in",
    "phone": "0512-259-7916",
    "web": "https://home.iitk.ac.in/~nsrivast/",
@@ -1050,6 +1337,11 @@
    "title": "Dean, Department of Wadhwani School of AI & Intelligent Systems + Professor, Department of Computer Science and Engineering + Joint Appointment in Department of Intelligent Systems (DIS)",
    "dept": "Intelligent Systems",
    "url": "https://www.iitk.ac.in/dr-nitin-saxena",
+   "depts": [
+    "Intelligent Systems",
+    "Wadhwani School of AI & Intelligent Systems (WSAIS)",
+    "Computer Science & Engineering"
+   ],
    "email": "nitin@iitk.ac.in",
    "phone": "0512-259-7588",
    "web": "https://www.cse.iitk.ac.in/users/nitin/",
@@ -1062,6 +1354,11 @@
    "title": "Professor, Department of Computer Science and Engineering + Joint Appointment in Department of Intelligent Systems (DIS) in Wadhwani School of AI & Intelligent Systems (WSAIS)",
    "dept": "Intelligent Systems",
    "url": "https://www.iitk.ac.in/piyush-rai",
+   "depts": [
+    "Intelligent Systems",
+    "Wadhwani School of AI & Intelligent Systems (WSAIS)",
+    "Computer Science & Engineering"
+   ],
    "email": "rpiyush@iitk.ac.in",
    "phone": "0512-259-6894",
    "web": "https://www.cse.iitk.ac.in/users/piyush/",
@@ -1074,6 +1371,9 @@
    "title": "Associate Professor, Department of Intelligent Systems",
    "dept": "Intelligent Systems",
    "url": "https://www.iitk.ac.in/rajiv-ratn-shah",
+   "depts": [
+    "Intelligent Systems"
+   ],
    "email": "rajivratn@iitk.ac.in"
   },
   {
@@ -1081,6 +1381,11 @@
    "title": "Professor, Department of Electrical Engineering + Joint Appointment in Department of Intelligent Systems (DIS) in Wadhwani School of AI & Intelligent Systems (WSAIS)",
    "dept": "Intelligent Systems",
    "url": "https://www.iitk.ac.in/rohit-budhiraja",
+   "depts": [
+    "Intelligent Systems",
+    "Wadhwani School of AI & Intelligent Systems (WSAIS)",
+    "Electrical Engineering"
+   ],
    "email": "rohitbr@iitk.ac.in",
    "phone": "0512-259-6927",
    "web": "https://home.iitk.ac.in/~rohitbr/",
@@ -1092,6 +1397,11 @@
    "title": "Professor, Department of Mechanical Engineering + Joint Appointment in Department of Intelligent Systems (DIS) in Wadhwani School of AI & Intelligent Systems (WSAIS)",
    "dept": "Intelligent Systems",
    "url": "https://www.iitk.ac.in/shakti-s-gupta",
+   "depts": [
+    "Intelligent Systems",
+    "Wadhwani School of AI & Intelligent Systems (WSAIS)",
+    "Mechanical Engineering"
+   ],
    "email": "ssgupta@iitk.ac.in",
    "phone": "0512-259-6110",
    "web": "https://home.iitk.ac.in/~ssgupta/",
@@ -1104,6 +1414,12 @@
    "title": "Professor, Department of Electrical Engineering + AE Adjunct Faculty + Joint Appointment in Department of Intelligent Systems (DIS) in Wadhwani School of AI & Intelligent Systems (WSAIS)",
    "dept": "Intelligent Systems",
    "url": "https://www.iitk.ac.in/soumya-ranjan-sahoo",
+   "depts": [
+    "Intelligent Systems",
+    "Aerospace Engineering",
+    "Electrical Engineering",
+    "Wadhwani School of AI & Intelligent Systems (WSAIS)"
+   ],
    "email": "srsahoo@iitk.ac.in",
    "phone": "0512-259-6202",
    "web": "https://home.iitk.ac.in/~srsahoo/",
@@ -1116,6 +1432,11 @@
    "title": "Professor, Department of Economic Sciences + Joint Appointment in Department of Intelligent Systems (DIS) in Wadhwani School of AI & Intelligent Systems (WSAIS)",
    "dept": "Intelligent Systems",
    "url": "https://www.iitk.ac.in/vimal-kumar",
+   "depts": [
+    "Intelligent Systems",
+    "Economic Sciences",
+    "Wadhwani School of AI & Intelligent Systems (WSAIS)"
+   ],
    "email": "vk@iitk.ac.in",
    "phone": "0512-259-7501",
    "office": "660, Faculty Building",
@@ -1127,6 +1448,9 @@
    "title": "Professor, Department of Materials Science and Engineering",
    "dept": "Materials Science & Engineering",
    "url": "https://www.iitk.ac.in/amarendra-kumar-singh",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
    "email": "amarendra@iitk.ac.in",
    "phone": "0512-679-6810",
    "web": "https://home.iitk.ac.in/~amarendra/index.php",
@@ -1138,6 +1462,9 @@
    "title": "Professor, Department of Materials Science and Engineering",
    "dept": "Materials Science & Engineering",
    "url": "https://www.iitk.ac.in/anish-upadhyaya",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
    "email": "anishu@iitk.ac.in",
    "phone": "0512-259-7672",
    "office": "Office Department of MSE",
@@ -1149,6 +1476,9 @@
    "title": "Associate Professor, Department of Materials Science and Engineering",
    "dept": "Materials Science & Engineering",
    "url": "https://www.iitk.ac.in/anshu-gaur",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
    "email": "agaur@iitk.ac.in",
    "phone": "0512-259-7600",
    "web": "https://home.iitk.ac.in/~agaur/",
@@ -1161,6 +1491,9 @@
    "title": "Assistant Professor, Department of Materials Science and Engineering",
    "dept": "Materials Science & Engineering",
    "url": "https://www.iitk.ac.in/arunabh-meshram",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
    "email": "arunabhm@iitk.ac.in",
    "phone": "0512-259-2268",
    "research": "Recovery of valuable products, Industrial Waste Management, Electronic waste recycling",
@@ -1171,6 +1504,9 @@
    "title": "Emeritus Fellow, Department of MSE",
    "dept": "Materials Science & Engineering",
    "url": "https://www.iitk.ac.in/dipak-mazumdar",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
    "email": "dipak@iitk.ac.in",
    "phone": "0512-259-7328",
    "web": "https://home.iitk.ac.in/~dipak/",
@@ -1183,6 +1519,9 @@
    "title": "Assistant Professor, Department of Materials Science and Engineering",
    "dept": "Materials Science & Engineering",
    "url": "https://www.iitk.ac.in/heena-khanchandani",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
    "email": "heenak@iitk.ac.in",
    "web": "https://scholar.google.com/citations?user=Ci5e_W4AAAAJ&amp;hl=en",
    "office": "Old SAC building, 107"
@@ -1192,6 +1531,9 @@
    "title": "Professor, Department of Materials Science and Engineering",
    "dept": "Materials Science & Engineering",
    "url": "https://www.iitk.ac.in/kallol-mondal",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
    "email": "kallol@iitk.ac.in",
    "phone": "0512-259-6156",
    "web": "https://home.iitk.ac.in/~kallol/",
@@ -1203,6 +1545,9 @@
    "title": "Professor, Department of Materials Science and Engineering",
    "dept": "Materials Science & Engineering",
    "url": "https://www.iitk.ac.in/kantesh-balani",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
    "email": "kbalani@iitk.ac.in",
    "phone": "0512-259-6194",
    "web": "https://home.iitk.ac.in/~kbalani/",
@@ -1214,6 +1559,9 @@
    "title": "Professor, Department of Materials Science and Engineering",
    "dept": "Materials Science & Engineering",
    "url": "https://www.iitk.ac.in/kaustubh-kulkarni",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
    "email": "kkaustub@iitk.ac.in",
    "phone": "0512-259-6102",
    "web": "https://home.iitk.ac.in/~kkaustub/",
@@ -1226,6 +1574,9 @@
    "title": "Professor, Department of Materials Science and Engineering",
    "dept": "Materials Science & Engineering",
    "url": "https://www.iitk.ac.in/krishanu-biswas",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
    "email": "kbiswas@iitk.ac.in",
    "phone": "0512-259-6180",
    "web": "https://home.iitk.ac.in/~kbiswas/",
@@ -1238,6 +1589,9 @@
    "title": "Professor, Department of Materials Science and Engineering",
    "dept": "Materials Science & Engineering",
    "url": "https://www.iitk.ac.in/monica-katiyar",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
    "email": "mk@iitk.ac.in",
    "phone": "0512-259-7941",
    "web": "https://iitk.ac.in/mse/mk/",
@@ -1250,6 +1604,9 @@
    "title": "Professor, Department of Materials Science and Engineering",
    "dept": "Materials Science & Engineering",
    "url": "https://www.iitk.ac.in/nilesh-prakash-gurao",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
    "email": "npgurao@iitk.ac.in",
    "phone": "0512-259-6688",
    "web": "https://home.iitk.ac.in/~npgurao/index.php",
@@ -1262,6 +1619,9 @@
    "title": "Assistant Professor, Department of Management Sciences",
    "dept": "Management Sciences",
    "url": "https://www.iitk.ac.in/abhinava-tripathi",
+   "depts": [
+    "Management Sciences"
+   ],
    "email": "abhinavat@iitk.ac.in",
    "phone": "0512-259-2339",
    "office": "Office Room No. DoMS-313,",
@@ -1272,6 +1632,9 @@
    "title": "Associate Professor, Department of Management Sciences",
    "dept": "Management Sciences",
    "url": "https://www.iitk.ac.in/amit-shukla",
+   "depts": [
+    "Management Sciences"
+   ],
    "email": "skamit@iitk.ac.in",
    "phone": "512-259-6876",
    "office": "Office #208, Department of Management Sciences,",
@@ -1283,6 +1646,9 @@
    "title": "Professor, Department of Management Sciences",
    "dept": "Management Sciences",
    "url": "https://www.iitk.ac.in/anoop-singh",
+   "depts": [
+    "Management Sciences"
+   ],
    "email": "anoops@iitk.ac.in",
    "phone": "0512-259-7679",
    "web": "https://iitk.ac.in/doms/anoops/",
@@ -1295,6 +1661,9 @@
    "title": "Assistant Professor, Department of Management Sciences",
    "dept": "Management Sciences",
    "url": "https://www.iitk.ac.in/avijit-khanra",
+   "depts": [
+    "Management Sciences"
+   ],
    "email": "kavijit@iitk.ac.in",
    "phone": "+915126796180",
    "office": "Office 306, Department of Management Sciences",
@@ -1306,6 +1675,9 @@
    "title": "Professor, Department of Management Sciences",
    "dept": "Management Sciences",
    "url": "https://www.iitk.ac.in/b-v-phani",
+   "depts": [
+    "Management Sciences"
+   ],
    "email": "bvphani@iitk.ac.in",
    "phone": "+91-512-679-4425",
    "web": "https://webnew.iitk.ac.in/main/b-v-phani",
@@ -1318,6 +1690,9 @@
    "title": "Professor, Department of Management Sciences",
    "dept": "Management Sciences",
    "url": "https://www.iitk.ac.in/deepu-philip",
+   "depts": [
+    "Management Sciences"
+   ],
    "email": "dphilip@iitk.ac.in",
    "phone": "0512-259-7460",
    "office": "Office Department of Management Sciences",
@@ -1329,6 +1704,10 @@
    "title": "Professor, Department of Management Sciences + Adjunct Faculty in Kotak School of Sustainable (KSS)",
    "dept": "Management Sciences",
    "url": "https://www.iitk.ac.in/devlina-chatterjee",
+   "depts": [
+    "Management Sciences",
+    "Kotak School of Sustainability"
+   ],
    "email": "devlina@iitk.ac.in",
    "phone": "0512-259-6600",
    "web": "https://www.iitk.ac.in/ime/devlina/index.html",
@@ -1340,13 +1719,19 @@
    "name": "Dr. Ram Sewak Sharma",
    "title": "Distinguished Visiting Professor, Department of Management Sciences",
    "dept": "Management Sciences",
-   "url": "https://www.iitk.ac.in/dr-ram-sewak-sharma"
+   "url": "https://www.iitk.ac.in/dr-ram-sewak-sharma",
+   "depts": [
+    "Management Sciences"
+   ]
   },
   {
    "name": "Faiz Hamid",
    "title": "Associate Professor, Department of Management Sciences",
    "dept": "Management Sciences",
    "url": "https://www.iitk.ac.in/faiz-hamid",
+   "depts": [
+    "Management Sciences"
+   ],
    "email": "fhamid@iitk.ac.in",
    "phone": "0512-679-6431",
    "office": "Office Department of Management Sciences",
@@ -1358,6 +1743,9 @@
    "title": "Assistant Professor, Department of Management Sciences",
    "dept": "Management Sciences",
    "url": "https://www.iitk.ac.in/v-giridhar",
+   "depts": [
+    "Management Sciences"
+   ],
    "email": "giridhar@iitk.ac.in",
    "phone": "0512-259-2267",
    "office": "Office R. No: 314,",
@@ -1369,6 +1757,9 @@
    "title": "Assistant Professor, Department of Management Sciences",
    "dept": "Management Sciences",
    "url": "https://www.iitk.ac.in/harshal-rajan-mulay",
+   "depts": [
+    "Management Sciences"
+   ],
    "email": "hrmulay@iitk.ac.in",
    "phone": "512-259-6708",
    "office": "Office 308, Department of Management Sciences",
@@ -1380,6 +1771,9 @@
    "title": "Assistant Professor, Department of Management Sciences",
    "dept": "Management Sciences",
    "url": "https://www.iitk.ac.in/jitender-kumar",
+   "depts": [
+    "Management Sciences"
+   ],
    "email": "krjiten@iitk.ac.in",
    "phone": "0512-259-2161",
    "office": "Room 209, Department of Management Sciences",
@@ -1391,6 +1785,9 @@
    "title": "Assistant Professor, Department of Mechanical Engineering",
    "dept": "Mechanical Engineering",
    "url": "https://www.iitk.ac.in/abhishek-sarkar",
+   "depts": [
+    "Mechanical Engineering"
+   ],
    "email": "abhisheks@iitk.ac.in",
    "phone": "0512-259-7980",
    "qualification": "(PhD, Iowa State University)"
@@ -1400,6 +1797,9 @@
    "title": "Assistant Professor, Department of Mechanical Engineering",
    "dept": "Mechanical Engineering",
    "url": "https://www.iitk.ac.in/aditya-saurabh",
+   "depts": [
+    "Mechanical Engineering"
+   ],
    "email": "asaurabh@iitk.ac.in",
    "phone": "0512-259-2070",
    "office": "Office FB-438",
@@ -1407,21 +1807,13 @@
    "qualification": "PhD (Technical University Berlin)"
   },
   {
-   "name": "Akhilesh Mimani",
-   "title": "Associate Professor, Department of Mechanical Engineering + AE Adjunct Faculty",
-   "dept": "Mechanical Engineering",
-   "url": "https://www.iitk.ac.in/akhilesh-mimani",
-   "email": "amimani@iitk.ac.in",
-   "phone": "0512-259-2088",
-   "web": "https://home.iitk.ac.in/~amimani/",
-   "research": "Array processing methods for acoustic source localization, Computational Acoustics and Aeroacoustics, Duct and Muffler acoustics, Noise Control Engineering, Mechanical/Structural Vibration",
-   "qualification": "PhD (IISc Bangalore)"
-  },
-  {
    "name": "Anikesh Pal",
    "title": "Associate Professor, Department of Mechanical Engineering",
    "dept": "Mechanical Engineering",
    "url": "https://www.iitk.ac.in/anikesh-pal",
+   "depts": [
+    "Mechanical Engineering"
+   ],
    "email": "pala@iitk.ac.in",
    "research": "Turbulence, Machine Learning, Computational Fluid Dynamics (CFD), Atmospheric and Oceanic flows and Climate dynamics.",
    "qualification": "PhD (University of California San Diego, CA, USA)"
@@ -1431,6 +1823,9 @@
    "title": "Professor, Department of Mechanical Engineering",
    "dept": "Mechanical Engineering",
    "url": "https://www.iitk.ac.in/anindya-chatterjee",
+   "depts": [
+    "Mechanical Engineering"
+   ],
    "email": "anindya@iitk.ac.in",
    "phone": "0512-259-6961",
    "web": "https://home.iitk.ac.in/~anindya/",
@@ -1442,6 +1837,9 @@
    "title": "Professor, Department of Mechanical Engineering",
    "dept": "Mechanical Engineering",
    "url": "https://www.iitk.ac.in/anupam-saxena",
+   "depts": [
+    "Mechanical Engineering"
+   ],
    "email": "anupams@iitk.ac.in",
    "phone": "0512-259-7397",
    "web": "https://home.iitk.ac.in/~anupams/#/",
@@ -1454,6 +1852,9 @@
    "title": "Professor, Department of Mechanical Engineering",
    "dept": "Mechanical Engineering",
    "url": "https://www.iitk.ac.in/anurag-gupta",
+   "depts": [
+    "Mechanical Engineering"
+   ],
    "email": "ag@iitk.ac.in",
    "phone": "0512-259-6161",
    "web": "https://sites.google.com/view/anurag-gupta-iitk",
@@ -1465,6 +1866,9 @@
    "title": "Professor, Department of Mechanical Engineering",
    "dept": "Mechanical Engineering",
    "url": "https://www.iitk.ac.in/dr-arun-k-saha",
+   "depts": [
+    "Mechanical Engineering"
+   ],
    "email": "aksaha@iitk.ac.in",
    "phone": "0512-259-7869",
    "web": "https://home.iitk.ac.in/~aksaha/",
@@ -1477,6 +1881,9 @@
    "title": "Professor, Department of Mechanical Engineering",
    "dept": "Mechanical Engineering",
    "url": "https://www.iitk.ac.in/arvind-kumar",
+   "depts": [
+    "Mechanical Engineering"
+   ],
    "email": "arvindkr@iitk.ac.in",
    "phone": "0512-259-7484",
    "web": "https://home.iitk.ac.in/~arvindkr/",
@@ -1488,6 +1895,9 @@
    "title": "Professor, Department of Mechanical Engineering",
    "dept": "Mechanical Engineering",
    "url": "https://www.iitk.ac.in/ashish-dutta",
+   "depts": [
+    "Mechanical Engineering"
+   ],
    "email": "adutta@iitk.ac.in",
    "phone": "0512-259-7562",
    "web": "https://home.iitk.ac.in/~adutta/",
@@ -1500,6 +1910,9 @@
    "title": "Assistant Professor, Department of Mechanical Engineering",
    "dept": "Mechanical Engineering",
    "url": "https://www.iitk.ac.in/atanu-dolai",
+   "depts": [
+    "Mechanical Engineering"
+   ],
    "email": "adolai@iitk.ac.in"
   },
   {
@@ -1507,6 +1920,9 @@
    "title": "Professor (Mechanical Engineering), Currently on Deputation as Director, IIT Jodhpur",
    "dept": "Mechanical Engineering",
    "url": "https://www.iitk.ac.in/avinash-kumar-agarwal",
+   "depts": [
+    "Mechanical Engineering"
+   ],
    "email": "akag@iitk.ac.in",
    "phone": "0512-259-7982",
    "web": "https://home.iitk.ac.in/~akag/",
@@ -1518,6 +1934,9 @@
    "title": "Adjunct Professor, Department of SPASE",
    "dept": "Space, Planetary and Astronomical Sciences and Engineering",
    "url": "https://www.iitk.ac.in/abhay-gupta",
+   "depts": [
+    "Space, Planetary and Astronomical Sciences and Engineering"
+   ],
    "email": "abhaygupta@iitk.ac.in",
    "web": "https://www.abhayg.com/",
    "office": "E.S.B - 2 Building , 6th floor ,",
@@ -1529,6 +1948,9 @@
    "title": "Professor, Department of Space, Planetary & Astronomical Sciences & Engineering",
    "dept": "Space, Planetary and Astronomical Sciences and Engineering",
    "url": "https://www.iitk.ac.in/amitesh-omar",
+   "depts": [
+    "Space, Planetary and Astronomical Sciences and Engineering"
+   ],
    "email": "aomar@iitk.ac.in"
   },
   {
@@ -1536,25 +1958,38 @@
    "title": "Assistant Professor, Department of Space, Planetary and Astronomical Sciences and Engineering",
    "dept": "Space, Planetary and Astronomical Sciences and Engineering",
    "url": "https://www.iitk.ac.in/chhavi-jain",
+   "depts": [
+    "Space, Planetary and Astronomical Sciences and Engineering"
+   ],
    "email": "chhavij@iitk.ac.in"
   },
   {
    "name": "Dr. Arun K. Misra",
    "title": "Distinguished Visiting Professor, Department of Space, Planetary & Astronomical Sciences & Engineering",
    "dept": "Space, Planetary and Astronomical Sciences and Engineering",
-   "url": "https://www.iitk.ac.in/dr-arun-k-misra"
+   "url": "https://www.iitk.ac.in/dr-arun-k-misra",
+   "depts": [
+    "Space, Planetary and Astronomical Sciences and Engineering"
+   ]
   },
   {
    "name": "Dr. Hiroaki Katsuragi",
    "title": "Visiting Professor of Practice, Department of Space, Planetary & Astronomical Sciences & Engineering",
    "dept": "Space, Planetary and Astronomical Sciences and Engineering",
-   "url": "https://www.iitk.ac.in/dr-hiroaki-katsuragi"
+   "url": "https://www.iitk.ac.in/dr-hiroaki-katsuragi",
+   "depts": [
+    "Space, Planetary and Astronomical Sciences and Engineering"
+   ]
   },
   {
    "name": "Ishan Sharma",
    "title": "Professor, Department of Mechanical Engineering + Department of Space, Planetary and Astronomical Sciences and Engineering (joint appointment)",
    "dept": "Space, Planetary and Astronomical Sciences and Engineering",
    "url": "https://www.iitk.ac.in/ishan-sharma",
+   "depts": [
+    "Space, Planetary and Astronomical Sciences and Engineering",
+    "Mechanical Engineering"
+   ],
    "email": "ishans@iitk.ac.in",
    "phone": "0512-259-6152",
    "web": "https://home.iitk.ac.in/~ishans/i/Welcome.html",
@@ -1566,13 +2001,19 @@
    "name": "J. S. Yadav",
    "title": "Visiting Professor, Department of Space, Planetary & Astronomical Sciences & Engineering",
    "dept": "Space, Planetary and Astronomical Sciences and Engineering",
-   "url": "https://www.iitk.ac.in/j-s-yadav"
+   "url": "https://www.iitk.ac.in/j-s-yadav",
+   "depts": [
+    "Space, Planetary and Astronomical Sciences and Engineering"
+   ]
   },
   {
    "name": "Kunal Prakash Mooley",
    "title": "Assistant Professor, Department of Space, Planetary & Astronomical Sciences & Engineering",
    "dept": "Space, Planetary and Astronomical Sciences and Engineering",
    "url": "https://www.iitk.ac.in/kunal-prakash-mooley",
+   "depts": [
+    "Space, Planetary and Astronomical Sciences and Engineering"
+   ],
    "email": "kmooley@iitk.ac.in"
   },
   {
@@ -1580,6 +2021,9 @@
    "title": "Assistant Professor, Department of Space, Planetary & Astronomical Sciences & Engineering",
    "dept": "Space, Planetary and Astronomical Sciences and Engineering",
    "url": "https://www.iitk.ac.in/mohit-bhardwaj",
+   "depts": [
+    "Space, Planetary and Astronomical Sciences and Engineering"
+   ],
    "email": "mohitb@iitk.ac.in",
    "phone": "+91-512-259-2641",
    "web": "https://www.mohit-bhardwaj.com/",
@@ -1592,6 +2036,9 @@
    "title": "Assistant Professor, Department of Space, Planetary & Astronomical Sciences & Engineering",
    "dept": "Space, Planetary and Astronomical Sciences and Engineering",
    "url": "https://www.iitk.ac.in/mugundhan-vijayaraghavan",
+   "depts": [
+    "Space, Planetary and Astronomical Sciences and Engineering"
+   ],
    "email": "mugundhanv@iitk.ac.in"
   },
   {
@@ -1599,6 +2046,9 @@
    "title": "Emeritus Fellow, Department of Space, Planetary & Astronomical Sciences & Engineering",
    "dept": "Space, Planetary and Astronomical Sciences and Engineering",
    "url": "https://www.iitk.ac.in/pankaj-jain",
+   "depts": [
+    "Space, Planetary and Astronomical Sciences and Engineering"
+   ],
    "email": "pkjain@iitk.ac.in",
    "phone": "0512-259-7663",
    "web": "https://iitk.ac.in/data/publications-29-01-26.pdf",
@@ -1611,6 +2061,9 @@
    "title": "Assistant Professor, Department of Space, Planetary & Astronomical Sciences & Engineering",
    "dept": "Space, Planetary and Astronomical Sciences and Engineering",
    "url": "https://www.iitk.ac.in/prashant-pathak",
+   "depts": [
+    "Space, Planetary and Astronomical Sciences and Engineering"
+   ],
    "email": "ppathak@iitk.ac.in",
    "phone": "0512-259-2429",
    "web": "https://sites.google.com/view/prashantpathak/",
@@ -1623,6 +2076,9 @@
    "title": "Associate Professor, Department of Sustainable Energy Engineering",
    "dept": "Sustainable Energy Engineering",
    "url": "https://www.iitk.ac.in/aakash-chand-rai",
+   "depts": [
+    "Sustainable Energy Engineering"
+   ],
    "email": "aakashrai@iitk.ac.in",
    "phone": "0512-679-2305",
    "web": "https://sites.google.com/view/aakashrai",
@@ -1635,27 +2091,22 @@
    "title": "Assistant Professor, Department of Sustainable Energy Engineering",
    "dept": "Sustainable Energy Engineering",
    "url": "https://www.iitk.ac.in/amarendra-edpuganti",
+   "depts": [
+    "Sustainable Energy Engineering"
+   ],
    "email": "amarendrae@iitk.ac.in",
    "phone": "0512-679-2368",
    "research": "Power electronics applications in renewable energy, electric vehicles, and fuel cell vehicles.",
    "qualification": "PhD (National University of Singapore, Singapore)"
   },
   {
-   "name": "Anubha Goel",
-   "title": "Professor, Department of Civil Engineering + Department of Sustainable Energy Engineering (joint appointment)",
-   "dept": "Sustainable Energy Engineering",
-   "url": "https://www.iitk.ac.in/anubha-goel",
-   "email": "anubha@iitk.ac.in",
-   "phone": "0512-259-7027",
-   "web": "https://home.iitk.ac.in/~anubha/",
-   "research": "Characterization of emissions from vehicular exhaust, Indoor and ambient air quality assessment, Size segregated distribution of particulates and organic pollutants on aerosols, Health risk assessment, Solid Waste Management; Agricultural impact on climate change.",
-   "qualification": "PhD (University of Maryland)"
-  },
-  {
    "name": "Arunavo Mukerjee",
    "title": "Visiting Professor of Practice, Department of Sustainable Energy Engineering",
    "dept": "Sustainable Energy Engineering",
    "url": "https://www.iitk.ac.in/arunavo-mukerjee",
+   "depts": [
+    "Sustainable Energy Engineering"
+   ],
    "email": "arunavo@iitk.ac.in"
   },
   {
@@ -1663,6 +2114,9 @@
    "title": "Professor, Department of Sustainable Energy Engineering",
    "dept": "Sustainable Energy Engineering",
    "url": "https://www.iitk.ac.in/ashish-garg",
+   "depts": [
+    "Sustainable Energy Engineering"
+   ],
    "email": "ashishg@iitk.ac.in",
    "phone": "0512-259-7904",
    "web": "https://sites.google.com/view/ashish-garg-iitk-group/",
@@ -1671,21 +2125,14 @@
    "qualification": "PhD (University of Cambridge)"
   },
   {
-   "name": "Ashutosh Sharma",
-   "title": "Professor, Department of Chemical Engineering + Adjunct Faculty in MSP (Materials Science Programme) + SEE + Kotak School of Sustainability (KSS)",
-   "dept": "Sustainable Energy Engineering",
-   "url": "https://www.iitk.ac.in/ashutosh-sharma",
-   "email": "ashutos@iitk.ac.in",
-   "phone": "0512-259-7026",
-   "office": "Office NL2-106,",
-   "research": "Nanofabrication and patterning; Colloids & interfaces; Functional and nano-materials; Self-organized patterns and instabilities in thin films; electrospun materials; Wetting, adhesion and friction at soft interfaces; Biomaterials & biosurfaces; Multiscale MEMS/NEMS & Microfluidic Systems; Carbon micro/nanostructures and composites in environment, health and energy.",
-   "qualification": "PhD (SUNY Buffalo)"
-  },
-  {
    "name": "Debopam Das",
    "title": "Professor, Department of Aerospace Engineering + Department of Sustainable Energy Engineering (joint appointment)",
    "dept": "Sustainable Energy Engineering",
    "url": "https://www.iitk.ac.in/debopam-das",
+   "depts": [
+    "Sustainable Energy Engineering",
+    "Aerospace Engineering"
+   ],
    "email": "das@iitk.ac.in",
    "phone": "0512-259-7227",
    "web": "https://home.iitk.ac.in/~das/",
@@ -1697,6 +2144,9 @@
    "title": "Assistant Professor, Department of Sustainable Energy Engineering",
    "dept": "Sustainable Energy Engineering",
    "url": "https://www.iitk.ac.in/deepika-swami",
+   "depts": [
+    "Sustainable Energy Engineering"
+   ],
    "email": "dswami@iitk.ac.in",
    "phone": "0512-259-2270",
    "web": "https://sites.google.com/view/deepikaswami/",
@@ -1708,29 +2158,28 @@
    "name": "Dr. Satyam S. Sahay",
    "title": "Visiting Professor of Practice, Department of Sustainable Energy Engineering",
    "dept": "Sustainable Energy Engineering",
-   "url": "https://www.iitk.ac.in/dr-satyam-s-sahay"
+   "url": "https://www.iitk.ac.in/dr-satyam-s-sahay",
+   "depts": [
+    "Sustainable Energy Engineering"
+   ]
   },
   {
    "name": "Hari Mohan Upadhyaya",
    "title": "Visiting Professor, Department of Sustainable Energy Engineering",
    "dept": "Sustainable Energy Engineering",
-   "url": "https://www.iitk.ac.in/hari-mohan-upadhyaya"
-  },
-  {
-   "name": "Himanshu Sharma",
-   "title": "Associate Professor, Department of Chemical Engineering + SEE Adjunct Faculty",
-   "dept": "Sustainable Energy Engineering",
-   "url": "https://www.iitk.ac.in/himanshu-sharma",
-   "email": "sharmah@iitk.ac.in",
-   "phone": "0512-679-2073",
-   "research": "Flow through porous media,Enhanced oil recovery, Colloids & interfaces, Nanotechnology.",
-   "qualification": "PhD (University of Texas at Austin)"
+   "url": "https://www.iitk.ac.in/hari-mohan-upadhyaya",
+   "depts": [
+    "Sustainable Energy Engineering"
+   ]
   },
   {
    "name": "Indu Shekhar Chaturvedi",
    "title": "Visiting Professor, Department of Sustainable Energy Engineering",
    "dept": "Sustainable Energy Engineering",
    "url": "https://www.iitk.ac.in/indu-shekhar-chaturvedi",
+   "depts": [
+    "Sustainable Energy Engineering"
+   ],
    "email": "indus@iitk.ac.in",
    "research": "Renewable Energy"
   },
@@ -1739,6 +2188,10 @@
    "title": "Professor, Department of Humanities and Social Sciences + Adjunct Faculty in Kotak School of Sustainable (KSS)",
    "dept": "Humanities and Social Sciences",
    "url": "https://www.iitk.ac.in/anindita-chakrabarti",
+   "depts": [
+    "Humanities and Social Sciences",
+    "Kotak School of Sustainability"
+   ],
    "email": "aninditac@iitk.ac.in",
    "phone": "0512-259-7277",
    "web": "https://www.aninditac.in/home",
@@ -1751,6 +2204,9 @@
    "title": "Professor, Department of Humanities and Social Sciences",
    "dept": "Humanities and Social Sciences",
    "url": "https://www.iitk.ac.in/braj-bhushan",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
    "email": "brajb@iitk.ac.in",
    "phone": "0512-259-7024",
    "web": "https://home.iitk.ac.in/~brajb/",
@@ -1763,6 +2219,9 @@
    "title": "Associate Professor, Department of Humanities and Social Sciences",
    "dept": "Humanities and Social Sciences",
    "url": "https://www.iitk.ac.in/chaithra-puttaswamy",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
    "email": "chai@iitk.ac.in",
    "phone": "0512-259-7931",
    "office": "Office",
@@ -1774,6 +2233,9 @@
    "title": "Assistant Professor, Department of Humanities and Social Sciences",
    "dept": "Humanities and Social Sciences",
    "url": "https://www.iitk.ac.in/chinmay-dharurkar",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
    "email": "chinmayd@iitk.ac.in",
    "phone": "+91-512-259-2373",
    "office": "Office FB623, Faculty Building",
@@ -1781,20 +2243,13 @@
    "qualification": "Ph.D, Indian Institute of Technology (IIT) Bombay, 2018"
   },
   {
-   "name": "Esha Chatterjee",
-   "title": "Assistant Professor, Department of Humanities and Social Sciences + Economic Sciences Adjunct Faculty",
-   "dept": "Humanities and Social Sciences",
-   "url": "https://www.iitk.ac.in/esha-chatterjee",
-   "email": "eshachat@iitk.ac.in",
-   "web": "https://sites.google.com/view/eshachatterjee/",
-   "research": "My past and ongoing projects examine the relationship between women’s employment and education; fertility intentions, behaviour and maternal health, unmet need for contraception, and internal migration in the Indian context.",
-   "qualification": "PhD, University of Maryland, College Park, 2020"
-  },
-  {
    "name": "Gurumurthy Neelakantan",
    "title": "Emeritus Fellow, Department of Humanities and Social Sciences",
    "dept": "Humanities and Social Sciences",
    "url": "https://www.iitk.ac.in/gurumurthy-neelakantan",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
    "email": "gn@iitk.ac.in",
    "phone": "0512-259-7872",
    "web": "https://home.iitk.ac.in/~gn/",
@@ -1805,6 +2260,9 @@
    "title": "Associate Professor, Department of Humanities and Social Sciences",
    "dept": "Humanities and Social Sciences",
    "url": "https://www.iitk.ac.in/jillet-sarah-sam",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
    "email": "jssam@iitk.ac.in",
    "phone": "0512-259-7084",
    "web": "https://sites.google.com/view/jillet-sarah-sam/home?authuser=0",
@@ -1817,6 +2275,9 @@
    "title": "Associate Professor, Department of Humanities & Social Sciences",
    "dept": "Humanities and Social Sciences",
    "url": "https://www.iitk.ac.in/koumudi-patil",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
    "email": "kppatil@iitk.ac.in",
    "phone": "0512-259-7616",
    "office": "Office: Frugal Innovation for Design and Innovation for Grassroot Communities,",
@@ -1828,6 +2289,9 @@
    "title": "Professor, Department of Humanities and Social Sciences",
    "dept": "Humanities and Social Sciences",
    "url": "https://www.iitk.ac.in/kumar-ravi-priya",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
    "email": "krp@iitk.ac.in",
    "phone": "0512-259-7750",
    "web": "http://home.iitk.ac.in/~krp/",
@@ -1840,6 +2304,9 @@
    "title": "Assistant Professor, Department of Humanities and Social Sciences",
    "dept": "Humanities and Social Sciences",
    "url": "https://www.iitk.ac.in/lakshmana-rao-p",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
    "email": "lakshman@iitk.ac.in",
    "phone": "0512-259-2207",
    "web": "https://sites.google.com/view/lakshmana",
@@ -1851,6 +2318,9 @@
    "title": "Associate Professor, Department of Humanities and Social Sciences",
    "dept": "Humanities and Social Sciences",
    "url": "https://www.iitk.ac.in/lalit-saraswat",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
    "email": "lalits@iitk.ac.in",
    "phone": "0512-259-2093",
    "office": "Office Motwani Building 603",
@@ -1862,6 +2332,9 @@
    "title": "Professor, Department of Humanities and Social Sciences",
    "dept": "Humanities and Social Sciences",
    "url": "https://www.iitk.ac.in/mini-chandran",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
    "email": "minic@iitk.ac.in",
    "phone": "0512-259-7191",
    "web": "https://www.minichandran.com/",
@@ -1870,32 +2343,14 @@
    "qualification": "PhD (University of Kerala)"
   },
   {
-   "name": "Amit Verma",
-   "title": "Associate Professor, Department of Electrical Engineering + MSP Adjunct Faculty",
-   "dept": "Materials Science Programme",
-   "url": "https://www.iitk.ac.in/amit-verma",
-   "email": "amitkver@iitk.ac.in",
-   "phone": "0512-259-6432",
-   "office": "WL-132",
-   "research": "Materials Growth for semiconductor device fabrication, characterization and modeling",
-   "qualification": "PhD (University of Notre Dame, USA)"
-  },
-  {
-   "name": "Ashutosh Sharma",
-   "title": "Professor, Department of Chemical Engineering + Adjunct Faculty in MSP (Materials Science Programme) + SEE + Kotak School of Sustainability (KSS)",
-   "dept": "Materials Science Programme",
-   "url": "https://www.iitk.ac.in/ashutosh-sharma",
-   "email": "ashutos@iitk.ac.in",
-   "phone": "0512-259-7026",
-   "office": "Office NL2-106,",
-   "research": "Nanofabrication and patterning; Colloids & interfaces; Functional and nano-materials; Self-organized patterns and instabilities in thin films; electrospun materials; Wetting, adhesion and friction at soft interfaces; Biomaterials & biosurfaces; Multiscale MEMS/NEMS & Microfluidic Systems; Carbon micro/nanostructures and composites in environment, health and energy.",
-   "qualification": "PhD (SUNY Buffalo)"
-  },
-  {
    "name": "Kamal Krishna Kar",
    "title": "Professor, Department of Mechanical Engineering + MSP (Joint Appointment)",
    "dept": "Materials Science Programme",
    "url": "https://www.iitk.ac.in/kamal-k-kar",
+   "depts": [
+    "Materials Science Programme",
+    "Mechanical Engineering"
+   ],
    "email": "kamalkk@iitk.ac.in",
    "phone": "0512-259-7687",
    "web": "https://home.iitk.ac.in/~kamalkk/",
@@ -1907,6 +2362,10 @@
    "title": "Professor, Department of Electrical Engineering + MSP (Joint Appointment)",
    "dept": "Materials Science Programme",
    "url": "https://www.iitk.ac.in/m-j-akhtar",
+   "depts": [
+    "Materials Science Programme",
+    "Electrical Engineering"
+   ],
    "email": "mjakhtar@iitk.ac.in",
    "phone": "0512-259-6523",
    "web": "https://home.iitk.ac.in/~mjakhtar/",
@@ -1919,6 +2378,10 @@
    "title": "Professor, Department of Aerospace Engineering + MSP Adjunct Faculty",
    "dept": "Materials Science Programme",
    "url": "https://www.iitk.ac.in/pritam-chakraborty",
+   "depts": [
+    "Materials Science Programme",
+    "Aerospace Engineering"
+   ],
    "email": "cpritam@iitk.ac.in",
    "phone": "0512-259-7951",
    "web": "https://scholar.google.com/citations?hl=en&amp;user=9SfPwSQAAAAJ&amp;view_op=list_works&amp;sortby=pubdate",
@@ -1931,6 +2394,11 @@
    "title": "Professor, Department of Chemical Engineering + MSP (Joint Appointment)",
    "dept": "Materials Science Programme",
    "url": "https://www.iitk.ac.in/raj-ganesh-s-pala",
+   "depts": [
+    "Materials Science Programme",
+    "Nuclear Engineering & Technology",
+    "Chemical Engineering"
+   ],
    "email": "rpala@iitk.ac.in",
    "phone": "0512-259-6143",
    "web": "https://www.iitk.ac.in/che/rp.htm",
@@ -1942,6 +2410,10 @@
    "title": "Professor, Department of Physics + MSP (Joint Appointment)",
    "dept": "Materials Science Programme",
    "url": "https://www.iitk.ac.in/dr-rajeev-gupta",
+   "depts": [
+    "Materials Science Programme",
+    "Physics"
+   ],
    "email": "guptaraj@iitk.ac.in",
    "phone": "0512-259-6095",
    "web": "https://home.iitk.ac.in/~guptaraj",
@@ -1953,6 +2425,10 @@
    "title": "Assistant Professor, Department of Physics + MSP (Joint Appointment)",
    "dept": "Materials Science Programme",
    "url": "https://www.iitk.ac.in/rohit-medwal",
+   "depts": [
+    "Materials Science Programme",
+    "Physics"
+   ],
    "email": "rmedwal@iitk.ac.in",
    "phone": "+91-512-259-2309",
    "office": "Office SL-204,",
@@ -1964,6 +2440,10 @@
    "title": "Professor, Department of Chemical Engineering + MSP (Joint Appointment)",
    "dept": "Materials Science Programme",
    "url": "https://www.iitk.ac.in/siddhartha-panda",
+   "depts": [
+    "Materials Science Programme",
+    "Chemical Engineering"
+   ],
    "email": "spanda@iitk.ac.in",
    "phone": "0512-259-6146",
    "web": "https://www.iitk.ac.in/che/spanda.htm",
@@ -1975,6 +2455,10 @@
    "title": "Professor, Department of Chemical Engineering + MSP (Joint Appointment)",
    "dept": "Materials Science Programme",
    "url": "https://www.iitk.ac.in/sri-sivakumar",
+   "depts": [
+    "Materials Science Programme",
+    "Chemical Engineering"
+   ],
    "email": "srisiva@iitk.ac.in",
    "phone": "0512-259-7697",
    "web": "https://www.iitk.ac.in/che/ss.htm",
@@ -1986,6 +2470,10 @@
    "title": "Emeritus Fellow, Department of Physics + MSP (Joint Appointment)",
    "dept": "Materials Science Programme",
    "url": "https://www.iitk.ac.in/dr-yashowanta-n-mohapatra",
+   "depts": [
+    "Materials Science Programme",
+    "Physics"
+   ],
    "email": "ynm@iitk.ac.in",
    "phone": "0512-259-7033",
    "web": "https://home.iitk.ac.in/~ynm/",
@@ -1997,6 +2485,10 @@
    "title": "Professor, Department of Chemical Engineering + Materials Science Programme Adjunct Faculty",
    "dept": "Materials Science Programme",
    "url": "https://www.iitk.ac.in/yogesh-m-joshi",
+   "depts": [
+    "Materials Science Programme",
+    "Chemical Engineering"
+   ],
    "email": "joshi@iitk.ac.in",
    "phone": "0512-259-7993",
    "web": "https://www.iitk.ac.in/che/yj.htm",
@@ -2008,6 +2500,10 @@
    "title": "Professor, Department of Mechanical Engineering",
    "dept": "Nuclear Engineering & Technology",
    "url": "https://www.iitk.ac.in/pankaj-wahi",
+   "depts": [
+    "Nuclear Engineering & Technology",
+    "Mechanical Engineering"
+   ],
    "email": "wahi@iitk.ac.in",
    "phone": "0512-259-6092",
    "office": "Office FB-357,",
@@ -2015,32 +2511,14 @@
    "qualification": "PhD (IISc Bangalore)"
   },
   {
-   "name": "Raj Ganesh Santharam Pala",
-   "title": "Professor, Department of Chemical Engineering + MSP (Joint Appointment)",
-   "dept": "Nuclear Engineering & Technology",
-   "url": "https://www.iitk.ac.in/raj-ganesh-s-pala",
-   "email": "rpala@iitk.ac.in",
-   "phone": "0512-259-6143",
-   "web": "https://www.iitk.ac.in/che/rp.htm",
-   "office": "Office NL-II 304",
-   "qualification": "PhD (University of Utah)"
-  },
-  {
-   "name": "Bharat Lohani",
-   "title": "Professor, Department of Civil Engineering + Photonics Science and Engineering",
-   "dept": "Photonics Science and Engineering Programme",
-   "url": "https://www.iitk.ac.in/bharat-lohani",
-   "email": "blohani@iitk.ac.in",
-   "phone": "0512-259-7413",
-   "web": "https://home.iitk.ac.in/~blohani/educational_record.htm",
-   "office": "Office Room: 113 ,",
-   "qualification": "PhD (ESSC, University of Reading, UK)"
-  },
-  {
    "name": "Debabrata Goswami",
    "title": "Professor, Department of Chemistry + Photonics Science and Engineering",
    "dept": "Photonics Science and Engineering Programme",
    "url": "https://www.iitk.ac.in/debabrata-goswami",
+   "depts": [
+    "Photonics Science and Engineering Programme",
+    "Chemistry"
+   ],
    "email": "dgoswami@iitk.ac.in",
    "phone": "0512-259-6101",
    "web": "http://home.iitk.ac.in/~dgoswami/",
@@ -2052,6 +2530,10 @@
    "title": "Professor, Department of Physics + Photonics Science and Engineering",
    "dept": "Photonics Science and Engineering Programme",
    "url": "https://www.iitk.ac.in/dr-harshawardhan-wanare",
+   "depts": [
+    "Photonics Science and Engineering Programme",
+    "Physics"
+   ],
    "email": "hwanare@iitk.ac.in",
    "phone": "0512-259-7885",
    "web": "https://home.iitk.ac.in/~hwanare/",
@@ -2063,6 +2545,10 @@
    "title": "Emeritus Fellow, Department of Mechanical Engineering + Photonics Science and Engineering",
    "dept": "Photonics Science and Engineering Programme",
    "url": "https://www.iitk.ac.in/k-muralidhar",
+   "depts": [
+    "Photonics Science and Engineering Programme",
+    "Mechanical Engineering"
+   ],
    "email": "kmurli@iitk.ac.in",
    "phone": "0512-259-7182",
    "web": "https://home.iitk.ac.in/~kmurli/",
@@ -2075,6 +2561,10 @@
    "title": "Associate Professor, Department of Aerospace Engineering + Department of Photonics Science and Engineering Programme (joint appointment)",
    "dept": "Photonics Science and Engineering Programme",
    "url": "https://www.iitk.ac.in/mohammed-ibrahim-sugarno",
+   "depts": [
+    "Photonics Science and Engineering Programme",
+    "Aerospace Engineering"
+   ],
    "email": "ibrahim@iitk.ac.in",
    "phone": "0512-259-6345",
    "web": "https://sites.google.com/view/heal-iitk/home?authuser=0",
@@ -2086,6 +2576,10 @@
    "title": "Professor, Departement of Electrical Engineering + Photonics Science and Engineering",
    "dept": "Photonics Science and Engineering Programme",
    "url": "https://www.iitk.ac.in/naren-naik",
+   "depts": [
+    "Photonics Science and Engineering Programme",
+    "Electrical Engineering"
+   ],
    "email": "nnaik@iitk.ac.in",
    "phone": "0512-259-6518",
    "web": "https://home.iitk.ac.in/~nnaik/",
@@ -2098,6 +2592,10 @@
    "title": "Professor, Department of Electrical Engineering + Photonics Science and Engineering",
    "dept": "Photonics Science and Engineering Programme",
    "url": "https://www.iitk.ac.in/pradeep-kumar",
+   "depts": [
+    "Photonics Science and Engineering Programme",
+    "Electrical Engineering"
+   ],
    "email": "pradeepk@iitk.ac.in",
    "phone": "0512-259-7570",
    "web": "https://home.iitk.ac.in/~pradeepk/",
@@ -2110,6 +2608,10 @@
    "title": "Professor, Department of Mechanical Engineering + Photonics Science and Engineering",
    "dept": "Photonics Science and Engineering Programme",
    "url": "https://www.iitk.ac.in/p-k-panigrahi",
+   "depts": [
+    "Photonics Science and Engineering Programme",
+    "Mechanical Engineering"
+   ],
    "email": "panig@iitk.ac.in",
    "phone": "0512-259-7686",
    "web": "https://home.iitk.ac.in/~panig/",
@@ -2122,6 +2624,10 @@
    "title": "Professor (HAG), Department of Chemistry + Photonics Science and Engineering",
    "dept": "Photonics Science and Engineering Programme",
    "url": "https://www.iitk.ac.in/pratik-sen",
+   "depts": [
+    "Photonics Science and Engineering Programme",
+    "Chemistry"
+   ],
    "email": "psen@iitk.ac.in",
    "phone": "0512-259-6312",
    "web": "https://home.iitk.ac.in/~psen/",
@@ -2134,6 +2640,10 @@
    "title": "Professor, Department of Physics + Photonics Science and Engineering",
    "dept": "Photonics Science and Engineering Programme",
    "url": "https://www.iitk.ac.in/dr-r-vijaya",
+   "depts": [
+    "Photonics Science and Engineering Programme",
+    "Physics"
+   ],
    "email": "rvijaya@iitk.ac.in",
    "phone": "0512-259-7552",
    "web": "https://rvijaya.wixsite.com/vijayaramarao",
@@ -2146,6 +2656,10 @@
    "title": "Professor, Department of Electrical Engineering + Photonics Science and Engineering",
    "dept": "Photonics Science and Engineering Programme",
    "url": "https://www.iitk.ac.in/gannavarpu-rajshekhar",
+   "depts": [
+    "Photonics Science and Engineering Programme",
+    "Electrical Engineering"
+   ],
    "email": "gshekhar@iitk.ac.in",
    "phone": "0512-259-6477",
    "web": "https://home.iitk.ac.in/~gshekhar/",
@@ -2158,6 +2672,10 @@
    "title": "Assistant Professor, Department of Physics + Department of Photonics Science and Engineering Programme (joint appointment)",
    "dept": "Photonics Science and Engineering Programme",
    "url": "https://www.iitk.ac.in/sapam-ranjita-chanu",
+   "depts": [
+    "Photonics Science and Engineering Programme",
+    "Physics"
+   ],
    "email": "sranjita@iitk.ac.in",
    "phone": "0512-259-2406",
    "web": "https://sites.google.com/view/ciqtliitk/team/team-leader",
@@ -2169,107 +2687,91 @@
    "name": "Alok Bajpai",
    "title": "Visiting Professor of Practice, Gangwal School of Medical Sciences and Technology",
    "dept": "Gangwal School of Medical Sci. & Tech.",
-   "url": "https://www.iitk.ac.in/alok-bajpai"
+   "url": "https://www.iitk.ac.in/alok-bajpai",
+   "depts": [
+    "Gangwal School of Medical Sci. & Tech."
+   ]
   },
   {
    "name": "Dr. Nazneen Aziz",
    "title": "Visiting Professor, Gangwal School of Medical Sciences and Technology",
    "dept": "Gangwal School of Medical Sci. & Tech.",
-   "url": "https://www.iitk.ac.in/dr-nazneen-aziz"
+   "url": "https://www.iitk.ac.in/dr-nazneen-aziz",
+   "depts": [
+    "Gangwal School of Medical Sci. & Tech."
+   ]
   },
   {
    "name": "Dr. Prashant Kumar",
    "title": "Adjunct Professor, Gangwal School of Medical Sciences and Technology",
    "dept": "Gangwal School of Medical Sci. & Tech.",
-   "url": "https://www.iitk.ac.in/dr-prashant-kumar"
+   "url": "https://www.iitk.ac.in/dr-prashant-kumar",
+   "depts": [
+    "Gangwal School of Medical Sci. & Tech."
+   ]
   },
   {
    "name": "Dr. Richard Anthony Strugnell",
    "title": "Distinguished Visiting Professor, Gangwal School of Medical Sciences and Technology",
    "dept": "Gangwal School of Medical Sci. & Tech.",
-   "url": "https://www.iitk.ac.in/dr-richard-anthony-strugnell"
+   "url": "https://www.iitk.ac.in/dr-richard-anthony-strugnell",
+   "depts": [
+    "Gangwal School of Medical Sci. & Tech."
+   ]
   },
   {
    "name": "Dr. Sridhar Sivasubbu",
    "title": "Adjunct Professor, Gangwal School of Medical Sciences and Technology",
    "dept": "Gangwal School of Medical Sci. & Tech.",
-   "url": "https://www.iitk.ac.in/dr-sridhar-sivasubbu"
+   "url": "https://www.iitk.ac.in/dr-sridhar-sivasubbu",
+   "depts": [
+    "Gangwal School of Medical Sci. & Tech."
+   ]
   },
   {
    "name": "Dr. Venkataramanan Ramachandran",
    "title": "Adjunct Professor, Gangwal School of Medical Sciences and Technology",
    "dept": "Gangwal School of Medical Sci. & Tech.",
-   "url": "https://www.iitk.ac.in/dr-venkataramanan-ramachandran"
+   "url": "https://www.iitk.ac.in/dr-venkataramanan-ramachandran",
+   "depts": [
+    "Gangwal School of Medical Sci. & Tech."
+   ]
   },
   {
    "name": "Dr. Vinod Scaria",
    "title": "Adjunct Professor, Gangwal School of Medical Sciences and Technology",
    "dept": "Gangwal School of Medical Sci. & Tech.",
-   "url": "https://www.iitk.ac.in/dr-vinod-scaria"
+   "url": "https://www.iitk.ac.in/dr-vinod-scaria",
+   "depts": [
+    "Gangwal School of Medical Sci. & Tech."
+   ]
   },
   {
    "name": "Prof. Jaideep Srivastava",
    "title": "Distinguished Visiting Professor, Gangwal School of Medical Sciences and Technology",
    "dept": "Gangwal School of Medical Sci. & Tech.",
-   "url": "https://www.iitk.ac.in/prof-jaideep-srivastava"
-  },
-  {
-   "name": "Abhijith G. R.",
-   "title": "Assistant Professor, Department of Civil Engineering + Adjunct Faculty in Kotak School of Sustainable",
-   "dept": "Kotak School of Sustainability",
-   "url": "https://www.iitk.ac.in/abhijith-g-r",
-   "email": "abhijith@iitk.ac.in",
-   "phone": "0512-259-2427",
-   "web": "https://scholar.google.co.in/citations?user=RjxTUZ8AAAAJ&amp;hl=en",
-   "office": "Office",
-   "qualification": "Ph.D. (Indian Institute of Technology Madras)"
-  },
-  {
-   "name": "Anindita Chakrabarti",
-   "title": "Professor, Department of Humanities and Social Sciences + Adjunct Faculty in Kotak School of Sustainable (KSS)",
-   "dept": "Kotak School of Sustainability",
-   "url": "https://www.iitk.ac.in/anindita-chakrabarti",
-   "email": "aninditac@iitk.ac.in",
-   "phone": "0512-259-7277",
-   "web": "https://www.aninditac.in/home",
-   "office": "FB-325,",
-   "research": "sociology of law, sociology of religion, economic sociology with a focus on sociology of work, wealth accumulation, inheritance and entrepreneurship",
-   "qualification": "PhD (University of Delhi)"
-  },
-  {
-   "name": "Ashutosh Sharma",
-   "title": "Professor, Department of Chemical Engineering + Adjunct Faculty in MSP (Materials Science Programme) + SEE + Kotak School of Sustainability (KSS)",
-   "dept": "Kotak School of Sustainability",
-   "url": "https://www.iitk.ac.in/ashutosh-sharma",
-   "email": "ashutos@iitk.ac.in",
-   "phone": "0512-259-7026",
-   "office": "Office NL2-106,",
-   "research": "Nanofabrication and patterning; Colloids & interfaces; Functional and nano-materials; Self-organized patterns and instabilities in thin films; electrospun materials; Wetting, adhesion and friction at soft interfaces; Biomaterials & biosurfaces; Multiscale MEMS/NEMS & Microfluidic Systems; Carbon micro/nanostructures and composites in environment, health and energy.",
-   "qualification": "PhD (SUNY Buffalo)"
+   "url": "https://www.iitk.ac.in/prof-jaideep-srivastava",
+   "depts": [
+    "Gangwal School of Medical Sci. & Tech."
+   ]
   },
   {
    "name": "Corey Glickman",
    "title": "Visiting Professor of Practice, Kotak School of Sustainability",
    "dept": "Kotak School of Sustainability",
-   "url": "https://www.iitk.ac.in/corey-glickman"
-  },
-  {
-   "name": "Devlina Chatterjee",
-   "title": "Professor, Department of Management Sciences + Adjunct Faculty in Kotak School of Sustainable (KSS)",
-   "dept": "Kotak School of Sustainability",
-   "url": "https://www.iitk.ac.in/devlina-chatterjee",
-   "email": "devlina@iitk.ac.in",
-   "phone": "0512-259-6600",
-   "web": "https://www.iitk.ac.in/ime/devlina/index.html",
-   "office": "Office Room No.- 100/211",
-   "research": "Consumer finance, tourism economics, resilience of social systems, empirical finance",
-   "qualification": "PhD (IISc Bangalore)"
+   "url": "https://www.iitk.ac.in/corey-glickman",
+   "depts": [
+    "Kotak School of Sustainability"
+   ]
   },
   {
    "name": "Dr. Praneet Prakash",
    "title": "Assistant Professor, Kotak School of Sustainability (KSS)",
    "dept": "Kotak School of Sustainability",
    "url": "https://www.iitk.ac.in/praneet-prakash",
+   "depts": [
+    "Kotak School of Sustainability"
+   ],
    "email": "praneet@iitk.ac.in",
    "phone": "0512-679-6224",
    "web": "https://sites.google.com/view/praneetiitk",
@@ -2281,19 +2783,29 @@
    "name": "Durga Shanker Mishra",
    "title": "Visiting Professor of Practice, Kotak School of Sustainable",
    "dept": "Kotak School of Sustainability",
-   "url": "https://www.iitk.ac.in/durga-shanker-mishra"
+   "url": "https://www.iitk.ac.in/durga-shanker-mishra",
+   "depts": [
+    "Kotak School of Sustainability"
+   ]
   },
   {
    "name": "G. Asok Kumar",
    "title": "Professor of Practice, Kotak School of Sustainability",
    "dept": "Kotak School of Sustainability",
-   "url": "https://www.iitk.ac.in/g-asok-kumar"
+   "url": "https://www.iitk.ac.in/g-asok-kumar",
+   "depts": [
+    "Kotak School of Sustainability"
+   ]
   },
   {
    "name": "Mahendra Kumar Verma",
    "title": "Professor, Department of Physics + Department of Kotak School of Sustainability (joint appointment)",
    "dept": "Kotak School of Sustainability",
    "url": "https://www.iitk.ac.in/dr-mahendra-k-verma",
+   "depts": [
+    "Kotak School of Sustainability",
+    "Physics"
+   ],
    "email": "mkv@iitk.ac.in",
    "phone": "0512-259-7396",
    "web": "https://sites.google.com/view/mahendra-verma/",
@@ -2305,6 +2817,10 @@
    "title": "Associate Professor, Department of Civil Engineering + Adjunct Faculty in Kotak School of Sustainable",
    "dept": "Kotak School of Sustainability",
    "url": "https://www.iitk.ac.in/manoj-kumar-tiwari",
+   "depts": [
+    "Kotak School of Sustainability",
+    "Civil Engineering"
+   ],
    "email": "mktiwari@iitk.ac.in",
    "phone": "0512-259-2423",
    "office": "Office",
@@ -2316,6 +2832,9 @@
    "title": "Assistant Professor, Kotak School Of Sustainability",
    "dept": "Kotak School of Sustainability",
    "url": "https://www.iitk.ac.in/nanditha-j-s",
+   "depts": [
+    "Kotak School of Sustainability"
+   ],
    "email": "nandithajs@iitk.ac.in",
    "phone": "+91-512-259-6937",
    "web": "https://sites.google.com/view/nandithajs/home",
@@ -2328,6 +2847,10 @@
    "title": "Assistant Professor, Department of Civil Engineering + Adjunct Faculty in Kotak School of Sustainable (KSS)",
    "dept": "Kotak School of Sustainability",
    "url": "https://www.iitk.ac.in/pranamesh-chakraborty",
+   "depts": [
+    "Kotak School of Sustainability",
+    "Civil Engineering"
+   ],
    "email": "pranames@iitk.ac.in",
    "phone": "+91-512 259 2146",
    "web": "https://pranamesh.github.io/",
@@ -2336,32 +2859,13 @@
    "qualification": "PhD. (Iowa State University)"
   },
   {
-   "name": "Amey Karkare",
-   "title": "Professor, Department of Computer Science and Engineering + Joint Appointment in Department of Intelligent Systems (DIS) in Wadhwani School of AI & Intelligent Systems (WSAIS)",
-   "dept": "Wadhwani School of AI & Intelligent Systems (WSAIS)",
-   "url": "https://www.iitk.ac.in/dr-amey-karkare",
-   "email": "karkare@iitk.ac.in",
-   "phone": "0512-259-7520",
-   "web": "https://www.cse.iitk.ac.in/users/karkare/",
-   "office": "Office Room No. 401, Rajeev Motwani Building, Department of Computer Science and Engineering IIT Kanpur, Kanpur 208016",
-   "research": "Compilers, Functional Programming, Program Analysis & Code Optimization, Programming Languages and Education.",
-   "qualification": "PhD (IIT Bombay)"
-  },
-  {
-   "name": "Angshuman Karmakar",
-   "title": "Assistant Professor, Department of Computer Science & Engineering + Joint Appointment in Wadhwani School of AI & Intelligent Systems (WSAIS)",
-   "dept": "Wadhwani School of AI & Intelligent Systems (WSAIS)",
-   "url": "https://www.iitk.ac.in/angshuman-karmakar",
-   "email": "angshuman@iitk.ac.in",
-   "phone": "0512-259-2358",
-   "research": "Post Quantum Cryptography, Side-Channel attacks and Computation on encrypted data and Cryptology",
-   "qualification": "PhD"
-  },
-  {
    "name": "Anirban Roy",
    "title": "Professor of Practice, Wadhwani School of AI & Intelligent Systems (WSAIS)",
    "dept": "Wadhwani School of AI & Intelligent Systems (WSAIS)",
    "url": "https://www.iitk.ac.in/anirban-roy",
+   "depts": [
+    "Wadhwani School of AI & Intelligent Systems (WSAIS)"
+   ],
    "email": "anirbanr@iitk.ac.in",
    "phone": "0512-259-2625",
    "qualification": "Ph.D. IIT Dhanbad"
@@ -2371,107 +2875,19 @@
    "title": "Visiting Professor of Practice, Wadhwani School of AI & Intelligent Systems (WSAIS)",
    "dept": "Wadhwani School of AI & Intelligent Systems (WSAIS)",
    "url": "https://www.iitk.ac.in/dr-arun-dixit",
+   "depts": [
+    "Wadhwani School of AI & Intelligent Systems (WSAIS)"
+   ],
    "email": "arund@iitk.ac.in"
-  },
-  {
-   "name": "Indranil Saha",
-   "title": "Professor, Department of Computer Science and Engineering + Department of Intelligent Systems (DIS) in Wadhwani School of AI & Intelligent Systems (WSAIS) Joint Appointment",
-   "dept": "Wadhwani School of AI & Intelligent Systems (WSAIS)",
-   "url": "https://www.iitk.ac.in/indranil-saha",
-   "email": "isaha@cse.iitk.ac.in",
-   "phone": "0512-259-6343",
-   "web": "https://www.cse.iitk.ac.in/users/isaha/",
-   "office": "Department of Computer Science and Engineering",
-   "research": "Embedded and Cyber-Physical Systems Robotics Artificial Intelligence Formal Methods",
-   "qualification": "Ph.D. in Computer Science"
-  },
-  {
-   "name": "Ketan Rajawat",
-   "title": "Professor, Department of Electrical Engineering + AE Adjunct Faculty + Joint Appointment in Department of Intelligent Systems (DIS) in Wadhwani School of AI & Intelligent Systems (WSAIS)",
-   "dept": "Wadhwani School of AI & Intelligent Systems (WSAIS)",
-   "url": "https://www.iitk.ac.in/ketan-rajawat",
-   "email": "ketan@iitk.ac.in",
-   "phone": "0512-259-7337",
-   "web": "https://home.iitk.ac.in/~ketan/",
-   "office": "Office ACES 305C,",
-   "research": "My research interests include: 1. Optimization algorithms in communications 2. Dynamic network measurement and cartography 3. Network Localization 4. Network Optimization",
-   "qualification": "PhD (University of Minnesota)"
-  },
-  {
-   "name": "Manindra Agrawal",
-   "title": "Professor, Department of Computer Science and Engineering + Department of Intelligent Systems (DIS) in Wadhwani School of AI & Intelligent Systems (WSAIS) Joint Appointment",
-   "dept": "Wadhwani School of AI & Intelligent Systems (WSAIS)",
-   "url": "https://www.iitk.ac.in/manindra-agrawal",
-   "email": "manindra@iitk.ac.in",
-   "phone": "0512-259-7338",
-   "web": "https://sites.google.com/view/manindra/home",
-   "office": "Office CS-225,",
-   "research": "Computational Complexity Theory, Computational Number Theory and Algebra",
-   "qualification": "PhD (IIT Kanpur)"
-  },
-  {
-   "name": "Nisheeth Srivastava",
-   "title": "Professor, Department of Computer Science and Engineering + Department of Cognitive Science (joint appointment) + Department of Intelligent Systems (DIS) in Wadhwani School of AI & Intelligent Systems (WSAIS) Joint Appointment",
-   "dept": "Wadhwani School of AI & Intelligent Systems (WSAIS)",
-   "url": "https://www.iitk.ac.in/nisheeth-srivastava",
-   "email": "nsrivast@iitk.ac.in",
-   "phone": "0512-259-7916",
-   "web": "https://home.iitk.ac.in/~nsrivast/",
-   "office": "KD 303",
-   "qualification": "PhD (University of Minnesota)"
-  },
-  {
-   "name": "Nitin Saxena",
-   "title": "Dean, Department of Wadhwani School of AI & Intelligent Systems + Professor, Department of Computer Science and Engineering + Joint Appointment in Department of Intelligent Systems (DIS)",
-   "dept": "Wadhwani School of AI & Intelligent Systems (WSAIS)",
-   "url": "https://www.iitk.ac.in/dr-nitin-saxena",
-   "email": "nitin@iitk.ac.in",
-   "phone": "0512-259-7588",
-   "web": "https://www.cse.iitk.ac.in/users/nitin/",
-   "office": "Office RM-203,",
-   "research": "Computational Complexity Theory, Algebra, Algebraic Geometry.",
-   "qualification": "PhD (IIT Kanpur)"
-  },
-  {
-   "name": "Piyush Rai",
-   "title": "Professor, Department of Computer Science and Engineering + Joint Appointment in Department of Intelligent Systems (DIS) in Wadhwani School of AI & Intelligent Systems (WSAIS)",
-   "dept": "Wadhwani School of AI & Intelligent Systems (WSAIS)",
-   "url": "https://www.iitk.ac.in/piyush-rai",
-   "email": "rpiyush@iitk.ac.in",
-   "phone": "0512-259-6894",
-   "web": "https://www.cse.iitk.ac.in/users/piyush/",
-   "office": "Office: KD-319, CSE Department, IIT Kanpur",
-   "research": "Latent Variable Models, Probabilistic Modeling, Approximate Inference, Nonparametric Bayesian Methods",
-   "qualification": "PhD (University of Utah)"
-  },
-  {
-   "name": "Rohit Budhiraja",
-   "title": "Professor, Department of Electrical Engineering + Joint Appointment in Department of Intelligent Systems (DIS) in Wadhwani School of AI & Intelligent Systems (WSAIS)",
-   "dept": "Wadhwani School of AI & Intelligent Systems (WSAIS)",
-   "url": "https://www.iitk.ac.in/rohit-budhiraja",
-   "email": "rohitbr@iitk.ac.in",
-   "phone": "0512-259-6927",
-   "web": "https://home.iitk.ac.in/~rohitbr/",
-   "office": "ACES 304,",
-   "qualification": "PhD (IIT Madras)"
-  },
-  {
-   "name": "Shakti Singh Gupta",
-   "title": "Professor, Department of Mechanical Engineering + Joint Appointment in Department of Intelligent Systems (DIS) in Wadhwani School of AI & Intelligent Systems (WSAIS)",
-   "dept": "Wadhwani School of AI & Intelligent Systems (WSAIS)",
-   "url": "https://www.iitk.ac.in/shakti-s-gupta",
-   "email": "ssgupta@iitk.ac.in",
-   "phone": "0512-259-6110",
-   "web": "https://home.iitk.ac.in/~ssgupta/",
-   "office": "Office SL -109 ,",
-   "research": "Linear/Nonlinear Structural Mechanics, Mechanics of Nanomaterials and their Characterization using Molecular Simulations",
-   "qualification": "PhD (Virginia Tech)"
   },
   {
    "name": "Amalendu Chandra",
    "title": "Professor, Department of Chemistry",
    "dept": "Chemistry",
    "url": "https://www.iitk.ac.in/amalendu-chandra",
+   "depts": [
+    "Chemistry"
+   ],
    "email": "amalen@iitk.ac.in",
    "phone": "0512-259-7241",
    "web": "https://home.iitk.ac.in/~amalen/",
@@ -2483,6 +2899,9 @@
    "title": "Professor, Department of Chemistry",
    "dept": "Chemistry",
    "url": "https://www.iitk.ac.in/anand-singh",
+   "depts": [
+    "Chemistry"
+   ],
    "email": "anands@iitk.ac.in",
    "phone": "0512-259-6788",
    "web": "https://www.anandsinghiitk.com/",
@@ -2494,6 +2913,9 @@
    "title": "Assistant Professor, Department of Chemistry",
    "dept": "Chemistry",
    "url": "https://www.iitk.ac.in/anantharaj-sengeni",
+   "depts": [
+    "Chemistry"
+   ],
    "email": "ananths@iitk.ac.in",
    "phone": "0512-259-2374",
    "web": "https://anantharajs.wixsite.com/official",
@@ -2506,6 +2928,9 @@
    "title": "Professor, Department of Chemistry",
    "dept": "Chemistry",
    "url": "https://www.iitk.ac.in/ganapathi-anantharaman",
+   "depts": [
+    "Chemistry"
+   ],
    "email": "garaman@iitk.ac.in",
    "phone": "0512-259-7517",
    "web": "https://home.iitk.ac.in/~garaman/",
@@ -2518,6 +2943,9 @@
    "title": "Associate Professor, Department of Chemistry",
    "dept": "Chemistry",
    "url": "https://www.iitk.ac.in/apparao-draksharapu",
+   "depts": [
+    "Chemistry"
+   ],
    "email": "appud@iitk.ac.in",
    "phone": "0512-259-2059",
    "web": "https://sites.google.com/view/appugroupiitk/home",
@@ -2529,6 +2957,9 @@
    "title": "Assistant Professor, Department of Chemistry",
    "dept": "Chemistry",
    "url": "https://www.iitk.ac.in/arnab-ghosh",
+   "depts": [
+    "Chemistry"
+   ],
    "email": "arnab@iitk.ac.in",
    "phone": "0512-259-2071",
    "web": "https://arnabkatwa.wixsite.com/arnab-ghosh-group",
@@ -2541,6 +2972,9 @@
    "title": "Professor, Department of Chemistry",
    "dept": "Chemistry",
    "url": "https://www.iitk.ac.in/ashis-k-patra",
+   "depts": [
+    "Chemistry"
+   ],
    "email": "akpatra@iitk.ac.in",
    "phone": "0512-259-6780",
    "web": "https://sites.google.com/site/ashiskpatra/",
@@ -2552,6 +2986,9 @@
    "title": "Professor, Department of Chemistry",
    "dept": "Chemistry",
    "url": "https://www.iitk.ac.in/basker-sundararaju",
+   "depts": [
+    "Chemistry"
+   ],
    "email": "basker@iitk.ac.in",
    "phone": "0512-259-6758",
    "web": "http://home.iitk.ac.in/~basker/Home.html",
@@ -2563,6 +3000,9 @@
    "title": "Associate Professor, Department of Chemistry",
    "dept": "Chemistry",
    "url": "https://www.iitk.ac.in/d-l-v-k-prasad",
+   "depts": [
+    "Chemistry"
+   ],
    "email": "dprasad@iitk.ac.in",
    "phone": "0512-259-7295",
    "web": "http://home.iitk.ac.in/~dprasad/",
@@ -2575,6 +3015,9 @@
    "title": "Professor, Department of Chemistry",
    "dept": "Chemistry",
    "url": "https://www.iitk.ac.in/d-h-dethe",
+   "depts": [
+    "Chemistry"
+   ],
    "email": "ddethe@iitk.ac.in",
    "phone": "0512-259-6537",
    "web": "https://ns3150807.wixsite.com/ddresearchgroup",
@@ -2582,21 +3025,13 @@
    "qualification": "PhD (IISc Bangalore)"
   },
   {
-   "name": "Debabrata Goswami",
-   "title": "Professor, Department of Chemistry + Photonics Science and Engineering",
-   "dept": "Chemistry",
-   "url": "https://www.iitk.ac.in/debabrata-goswami",
-   "email": "dgoswami@iitk.ac.in",
-   "phone": "0512-259-6101",
-   "web": "http://home.iitk.ac.in/~dgoswami/",
-   "office": "Office SL-216 ,",
-   "qualification": "PhD (Princeton University)"
-  },
-  {
    "name": "Devendra Mani",
    "title": "Assistant Professor, Department of Chemistry",
    "dept": "Chemistry",
    "url": "https://www.iitk.ac.in/devendra-mani",
+   "depts": [
+    "Chemistry"
+   ],
    "email": "dmani@iitk.ac.in",
    "phone": "0512-259-2160",
    "web": "https://sites.google.com/view/manilab/",
@@ -2609,6 +3044,9 @@
    "title": "Assistant Professor, Department of Cognitive Science",
    "dept": "Cognitive Science",
    "url": "https://www.iitk.ac.in/anveshna-srivastava",
+   "depts": [
+    "Cognitive Science"
+   ],
    "email": "anveshna@iitk.ac.in"
   },
   {
@@ -2616,6 +3054,9 @@
    "title": "Associate Professor, Department of Cognitive Science",
    "dept": "Cognitive Science",
    "url": "https://www.iitk.ac.in/ark-verma",
+   "depts": [
+    "Cognitive Science"
+   ],
    "email": "arkverma@iitk.ac.in",
    "phone": "0512-259-6847",
    "web": "https://www.iitk.ac.in/new/ark-verma",
@@ -2628,6 +3069,9 @@
    "title": "Associate Professor, Department of Cognitive Science",
    "dept": "Cognitive Science",
    "url": "https://www.iitk.ac.in/devpriya-kumar",
+   "depts": [
+    "Cognitive Science"
+   ],
    "email": "devpriya@iitk.ac.in",
    "phone": "0512-679-6841",
    "web": "https://sites.google.com/view/devpriya-kumar/home?pli=1",
@@ -2640,6 +3084,9 @@
    "title": "Assistant Professor, Department of Cognitive Science",
    "dept": "Cognitive Science",
    "url": "https://www.iitk.ac.in/himanshu-yadav",
+   "depts": [
+    "Cognitive Science"
+   ],
    "email": "himanshu@iitk.ac.in",
    "web": "https://sites.google.com/site/himanshuyadavjnu/",
    "office": "507, 4th floor, ESB 2, IIT Kanpur",
@@ -2651,25 +3098,20 @@
    "title": "Professor, Department of Cognitive Science",
    "dept": "Cognitive Science",
    "url": "https://www.iitk.ac.in/narayanan-srinivasan",
+   "depts": [
+    "Cognitive Science"
+   ],
    "email": "nsrini@iitk.ac.in",
    "qualification": "PhD in Psychology at University of Georgia, Athens, USA."
-  },
-  {
-   "name": "Nisheeth Srivastava",
-   "title": "Professor, Department of Computer Science and Engineering + Department of Cognitive Science (joint appointment) + Department of Intelligent Systems (DIS) in Wadhwani School of AI & Intelligent Systems (WSAIS) Joint Appointment",
-   "dept": "Cognitive Science",
-   "url": "https://www.iitk.ac.in/nisheeth-srivastava",
-   "email": "nsrivast@iitk.ac.in",
-   "phone": "0512-259-7916",
-   "web": "https://home.iitk.ac.in/~nsrivast/",
-   "office": "KD 303",
-   "qualification": "PhD (University of Minnesota)"
   },
   {
    "name": "Pragathi P. Balasubramani",
    "title": "Assistant Professor, Department of Cognitive Science",
    "dept": "Cognitive Science",
    "url": "https://www.iitk.ac.in/pragathi-p-balasubramani",
+   "depts": [
+    "Cognitive Science"
+   ],
    "email": "pbalasub@iitk.ac.in"
   },
   {
@@ -2677,6 +3119,9 @@
    "title": "Assistant Professor, Department of Cognitive Science",
    "dept": "Cognitive Science",
    "url": "https://www.iitk.ac.in/sharika-k-m",
+   "depts": [
+    "Cognitive Science"
+   ],
    "email": "sharika@iitk.ac.in"
   },
   {
@@ -2684,6 +3129,9 @@
    "title": "Associate Professor, Department of Earth Sciences",
    "dept": "Earth Sciences",
    "url": "https://www.iitk.ac.in/amar-agarwal",
+   "depts": [
+    "Earth Sciences"
+   ],
    "email": "amarag@iitk.ac.in",
    "phone": "05126792145",
    "web": "https://home.iitk.ac.in/~amarag/index.html",
@@ -2695,6 +3143,9 @@
    "title": "Associate Professor, Department of Earth Sciences",
    "dept": "Earth Sciences",
    "url": "https://www.iitk.ac.in/animesh-mandal",
+   "depts": [
+    "Earth Sciences"
+   ],
    "email": "animeshm@iitk.ac.in",
    "phone": "0512-259-6811",
    "web": "https://sites.google.com/view/animesh-mandal/home",
@@ -2706,6 +3157,9 @@
    "title": "Assistant Professor, Department of Earth Sciences",
    "dept": "Earth Sciences",
    "url": "https://www.iitk.ac.in/anupam-banerjee",
+   "depts": [
+    "Earth Sciences"
+   ],
    "email": "anupamb@iitk.ac.in"
   },
   {
@@ -2713,6 +3167,9 @@
    "title": "Professor, Departement of Earth Sciences",
    "dept": "Earth Sciences",
    "url": "https://www.iitk.ac.in/debajyoti-paul",
+   "depts": [
+    "Earth Sciences"
+   ],
    "email": "dpaul@iitk.ac.in",
    "phone": "0512-259-6169",
    "web": "https://home.iitk.ac.in/~dpaul/",
@@ -2724,6 +3181,9 @@
    "title": "Assistant Professor, Department of Earth Sciences",
    "dept": "Earth Sciences",
    "url": "https://www.iitk.ac.in/deepa-mele-veedu",
+   "depts": [
+    "Earth Sciences"
+   ],
    "email": "mvdeepa@iitk.ac.in",
    "phone": "+91-512-259-2325",
    "qualification": "Ph.D. (Nanyang Technological University, Singapore, 2019)"
@@ -2733,6 +3193,9 @@
    "title": "Associate Professor, Department of Earth Sciences",
    "dept": "Earth Sciences",
    "url": "https://www.iitk.ac.in/deepak-dhingra",
+   "depts": [
+    "Earth Sciences"
+   ],
    "email": "ddhingra@iitk.ac.in",
    "phone": "+91-512-259-7497",
    "web": "https://home.iitk.ac.in/~ddhingra/",
@@ -2744,6 +3207,9 @@
    "title": "Associate Professor, Department of Earth Sciences",
    "dept": "Earth Sciences",
    "url": "https://www.iitk.ac.in/dibakar-ghosal",
+   "depts": [
+    "Earth Sciences"
+   ],
    "email": "dghosal@iitk.ac.in",
    "phone": "0512-259-6909",
    "web": "https://home.iitk.ac.in/~dghosal/Home.html",
@@ -2755,6 +3221,9 @@
    "title": "Assistant Professor, Department of Earth Sciences",
    "dept": "Earth Sciences",
    "url": "https://www.iitk.ac.in/govindarao-boddepalli",
+   "depts": [
+    "Earth Sciences"
+   ],
    "email": "bgovind@iitk.ac.in",
    "phone": "+91-512-679-2285",
    "web": "https://home.iitk.ac.in/~bgovind/",
@@ -2767,6 +3236,9 @@
    "title": "Assistant Professor, Department of Earth Sciences",
    "dept": "Earth Sciences",
    "url": "https://www.iitk.ac.in/hiranya-sahoo",
+   "depts": [
+    "Earth Sciences"
+   ],
    "email": "hiranya@iitk.ac.in",
    "qualification": "Ph. D., University of New Orleans, USA, 2013"
   },
@@ -2775,6 +3247,9 @@
    "title": "Associate Professor, Department of Earth Sciences",
    "dept": "Earth Sciences",
    "url": "https://www.iitk.ac.in/indra-sekhar-sen",
+   "depts": [
+    "Earth Sciences"
+   ],
    "email": "isen@iitk.ac.in",
    "phone": "0512-679-6440",
    "web": "https://www.iitk.ac.in/geochemistry/",
@@ -2787,6 +3262,9 @@
    "title": "Assistant Professor, Department of Earth Sciences",
    "dept": "Earth Sciences",
    "url": "https://www.iitk.ac.in/ishwar-kumar-cukkemane",
+   "depts": [
+    "Earth Sciences"
+   ],
    "email": "ishwar@iitk.ac.in",
    "phone": "0512-259-6952",
    "web": "https://www.iitk.ac.in/july14esn/profile-ishwar-kumar",
@@ -2798,6 +3276,9 @@
    "title": "Professor, Department of Earth Sciences",
    "dept": "Earth Sciences",
    "url": "https://www.iitk.ac.in/javed-n-malik",
+   "depts": [
+    "Earth Sciences"
+   ],
    "email": "javed@iitk.ac.in",
    "phone": "0512-259-7723",
    "web": "https://home.iitk.ac.in/~javed/",
@@ -2810,6 +3291,9 @@
    "title": "Assistant Professor, Department of Mathematics",
    "dept": "Mathematics",
    "url": "https://www.iitk.ac.in/abhijit-biswas",
+   "depts": [
+    "Mathematics"
+   ],
    "email": "abhijit@iitk.ac.in"
   },
   {
@@ -2817,6 +3301,9 @@
    "title": "Associate Professor, Department of Mathematics",
    "dept": "Mathematics",
    "url": "https://www.iitk.ac.in/abhijit-pal",
+   "depts": [
+    "Mathematics"
+   ],
    "email": "abhipal@iitk.ac.in",
    "phone": "0512-259-6405",
    "web": "https://sites.google.com/site/abhijitwebpage/",
@@ -2828,13 +3315,19 @@
    "name": "Adimurthi Adi",
    "title": "Distinguished Visiting Professor, Department of Mathematics",
    "dept": "Mathematics",
-   "url": "https://www.iitk.ac.in/adimurthi-adi"
+   "url": "https://www.iitk.ac.in/adimurthi-adi",
+   "depts": [
+    "Mathematics"
+   ]
   },
   {
    "name": "Ajay Singh Ramdin Thakur",
    "title": "Associate Professor, Department of Mathematics",
    "dept": "Mathematics",
    "url": "https://www.iitk.ac.in/ajay-singh-thakur",
+   "depts": [
+    "Mathematics"
+   ],
    "email": "asthakur@iitk.ac.in",
    "phone": "0512-259-7287",
    "web": "https://home.iitk.ac.in/~asthakur/",
@@ -2847,6 +3340,9 @@
    "title": "Professor, Department of Mathematics",
    "dept": "Mathematics",
    "url": "https://www.iitk.ac.in/akash-anand",
+   "depts": [
+    "Mathematics"
+   ],
    "email": "akasha@iitk.ac.in",
    "phone": "0512-259-7880",
    "web": "https://home.iitk.ac.in/~akasha/",
@@ -2858,6 +3354,9 @@
    "title": "Professor, Department of Mathematics",
    "dept": "Mathematics",
    "url": "https://www.iitk.ac.in/alok-kumar-maloo",
+   "depts": [
+    "Mathematics"
+   ],
    "email": "akmaloo@iitk.ac.in",
    "phone": "0512-259-7813",
    "web": "https://www.iitk.ac.in/math/faculty/akmaloo/",
@@ -2870,6 +3369,9 @@
    "title": "Associate Professor, Department of Mathematics",
    "dept": "Mathematics",
    "url": "https://www.iitk.ac.in/amit-shekhar-kuber",
+   "depts": [
+    "Mathematics"
+   ],
    "email": "askuber@iitk.ac.in",
    "phone": "0512-259-6721",
    "web": "https://sites.google.com/view/exploring-infinity-within/",
@@ -2882,6 +3384,9 @@
    "title": "Emeritus Fellow, Department of Mathematics",
    "dept": "Mathematics",
    "url": "https://www.iitk.ac.in/dr-aparna-dar",
+   "depts": [
+    "Mathematics"
+   ],
    "email": "adar@iitk.ac.in",
    "phone": "0512-259-7926",
    "web": "https://home.iitk.ac.in/~adar/",
@@ -2894,6 +3399,9 @@
    "title": "Associate Professor, Department of Mathematics",
    "dept": "Mathematics",
    "url": "https://www.iitk.ac.in/arijit-ganguly",
+   "depts": [
+    "Mathematics"
+   ],
    "email": "aganguly@iitk.ac.in",
    "phone": "0512-259-4769",
    "web": "https://home.iitk.ac.in/~aganguly/",
@@ -2905,6 +3413,9 @@
    "title": "Associate Professor, Department of Mathematics",
    "dept": "Mathematics",
    "url": "https://www.iitk.ac.in/ashis-mandal",
+   "depts": [
+    "Mathematics"
+   ],
    "email": "amandal@iitk.ac.in",
    "phone": "0512-259-6783",
    "web": "https://sites.google.com/view/amandaliitk/home",
@@ -2917,6 +3428,9 @@
    "title": "Professor, Department of Mathematics",
    "dept": "Mathematics",
    "url": "https://www.iitk.ac.in/rathish-kumar-b-v",
+   "depts": [
+    "Mathematics"
+   ],
    "email": "bvrk@iitk.ac.in",
    "phone": "0512-259-7660",
    "office": "FB571",
@@ -2928,6 +3442,9 @@
    "title": "Associate Professor, Department of Mathematics",
    "dept": "Mathematics",
    "url": "https://www.iitk.ac.in/bidyut-sanki",
+   "depts": [
+    "Mathematics"
+   ],
    "email": "bidyut@iitk.ac.in",
    "phone": "0512-259-2085",
    "office": "Room No. IIT Kanpur-208016, Uttar Pradesh, India"
@@ -2937,6 +3454,9 @@
    "title": "Assistant Professor, Department of Physics",
    "dept": "Physics",
    "url": "https://www.iitk.ac.in/adhip-agarwala",
+   "depts": [
+    "Physics"
+   ],
    "email": "adhip@iitk.ac.in",
    "phone": "0512-259-2313",
    "web": "https://sites.google.com/view/stuffaroundus/home",
@@ -2949,6 +3469,9 @@
    "title": "Associate Professor, Department of Physics",
    "dept": "Physics",
    "url": "https://www.iitk.ac.in/aditya-h-kelkar",
+   "depts": [
+    "Physics"
+   ],
    "email": "akelkar@iitk.ac.in",
    "phone": "0512-259-7985",
    "office": "NL-T-105, Central Nuclear Laboratory",
@@ -2960,6 +3483,9 @@
    "title": "Professor, Department of Physics",
    "dept": "Physics",
    "url": "https://www.iitk.ac.in/dr-amit-kumar-agarwal",
+   "depts": [
+    "Physics"
+   ],
    "email": "amitag@iitk.ac.in",
    "phone": "0512-259-6981",
    "web": "https://sites.google.com/site/amitkag1/",
@@ -2972,6 +3498,9 @@
    "title": "Professor, Department of Physics",
    "dept": "Physics",
    "url": "https://www.iitk.ac.in/dr-anand-kumar-jha",
+   "depts": [
+    "Physics"
+   ],
    "email": "akjha@iitk.ac.in",
    "phone": "0512-259-7014",
    "web": "https://home.iitk.ac.in/~akjha/",
@@ -2984,6 +3513,9 @@
    "title": "Professor, Department of Physics",
    "dept": "Physics",
    "url": "https://www.iitk.ac.in/anjan-kumar-gupta",
+   "depts": [
+    "Physics"
+   ],
    "email": "anjankg@iitk.ac.in",
    "phone": "0512-259-7549",
    "web": "https://home.iitk.ac.in/~anjankg/",
@@ -2995,6 +3527,9 @@
    "title": "Assistant Professor, Department of Physics",
    "dept": "Physics",
    "url": "https://www.iitk.ac.in/apratim-kaviraj",
+   "depts": [
+    "Physics"
+   ],
    "email": "akaviraj@iitk.ac.in",
    "phone": "0512-259-2290",
    "office": "PEB-104,",
@@ -3006,6 +3541,9 @@
    "title": "Professor, Department of Physics",
    "dept": "Physics",
    "url": "https://www.iitk.ac.in/arijit-kundu",
+   "depts": [
+    "Physics"
+   ],
    "email": "kundua@iitk.ac.in",
    "web": "https://home.iitk.ac.in/~kundua/",
    "office": "FB 373",
@@ -3017,6 +3555,9 @@
    "title": "Professor, Department of Physics",
    "dept": "Physics",
    "url": "https://www.iitk.ac.in/arjun-bagchi",
+   "depts": [
+    "Physics"
+   ],
    "email": "abagchi@iitk.ac.in",
    "phone": "0512-259-6928",
    "web": "https://sites.google.com/view/arjunbagchi/",
@@ -3028,6 +3569,9 @@
    "title": "Emeritus Fellow, Department of Physics",
    "dept": "Physics",
    "url": "https://www.iitk.ac.in/dr-avinash-singh",
+   "depts": [
+    "Physics"
+   ],
    "email": "avinas@iitk.ac.in",
    "phone": "0512-259-7047",
    "web": "https://home.iitk.ac.in/~avinas/",
@@ -3040,6 +3584,9 @@
    "title": "Associate Professor, Department of Physics",
    "dept": "Physics",
    "url": "https://www.iitk.ac.in/dr-chanchal-sow",
+   "depts": [
+    "Physics"
+   ],
    "email": "chanchal@iitk.ac.in",
    "phone": "+91-512-259-4768",
    "web": "https://sites.google.com/view/qmlabiitk/home",
@@ -3052,6 +3599,9 @@
    "title": "Assistant Professor, Department of Physics",
    "dept": "Physics",
    "url": "https://www.iitk.ac.in/chandrima-banerjee",
+   "depts": [
+    "Physics"
+   ],
    "email": "cbanerjee@iitk.ac.in",
    "office": "Department of Physics",
    "research": "Experimental Condensed Matter Physics, magneto-optics, femtomagnetism, Ultrafast light-matter interaction, Optical pump-probe spectroscopy, Magneto-Optic Imaging, XUV spectroscopy.",
@@ -3062,6 +3612,9 @@
    "title": "Associate Professor, Department of Physics",
    "dept": "Physics",
    "url": "https://www.iitk.ac.in/debtosh-chowdhury",
+   "depts": [
+    "Physics"
+   ],
    "email": "debtoshc@iitk.ac.in",
    "phone": "0512-259-2151",
    "web": "https://home.iitk.ac.in/~debtoshc",
@@ -3074,6 +3627,9 @@
    "title": "Professor, Department of Statistics and Data Science",
    "dept": "Statistics and Data Science",
    "url": "https://www.iitk.ac.in/amit-mitra",
+   "depts": [
+    "Statistics and Data Science"
+   ],
    "email": "amitra@iitk.ac.in",
    "phone": "0512-259-6064",
    "web": "https://home.iitk.ac.in/~amitra/",
@@ -3086,6 +3642,9 @@
    "title": "Assistant Professor, Department of Statistics and Data Science",
    "dept": "Statistics and Data Science",
    "url": "https://www.iitk.ac.in/arnab-hazra",
+   "depts": [
+    "Statistics and Data Science"
+   ],
    "email": "ahazra@iitk.ac.in",
    "phone": "0512-259-2272",
    "web": "https://sites.google.com/view/arnabhazra09/",
@@ -3097,6 +3656,9 @@
    "title": "Professor, Department of Statistics and Data Science",
    "dept": "Statistics and Data Science",
    "url": "https://www.iitk.ac.in/debasis-kundu",
+   "depts": [
+    "Statistics and Data Science"
+   ],
    "email": "kundu@iitk.ac.in",
    "phone": "0512-259-7141",
    "web": "https://home.iitk.ac.in/~kundu/kundu.html",
@@ -3109,6 +3671,9 @@
    "title": "Associate Professor, Department of Statistics and Data Science",
    "dept": "Statistics and Data Science",
    "url": "https://www.iitk.ac.in/dootika-vats",
+   "depts": [
+    "Statistics and Data Science"
+   ],
    "email": "dootika@iitk.ac.in",
    "phone": "0512-259-2076",
    "web": "https://dvats.github.io/",
@@ -3121,6 +3686,9 @@
    "title": "Professor, Department of Statistics and Data Science",
    "dept": "Statistics and Data Science",
    "url": "https://www.iitk.ac.in/neeraj-misra",
+   "depts": [
+    "Statistics and Data Science"
+   ],
    "email": "neeraj@iitk.ac.in",
    "phone": "0512-259-7087",
    "web": "https://home.iitk.ac.in/~neeraj/",
@@ -3133,6 +3701,9 @@
    "title": "Assistant Professor, Department of Statistics and Data Science",
    "dept": "Statistics and Data Science",
    "url": "https://www.iitk.ac.in/satya-prakash-singh",
+   "depts": [
+    "Statistics and Data Science"
+   ],
    "email": "singhsp@iitk.ac.in",
    "phone": "0512-259-2254",
    "web": "https://home.iitk.ac.in/~singhsp/",
@@ -3144,6 +3715,9 @@
    "title": "Professor, Department of Statistics and Data Science",
    "dept": "Statistics and Data Science",
    "url": "https://www.iitk.ac.in/shalabh",
+   "depts": [
+    "Statistics and Data Science"
+   ],
    "email": "shalab@iitk.ac.in",
    "phone": "0512-259-7905",
    "web": "https://home.iitk.ac.in/~shalab/",
@@ -3156,6 +3730,9 @@
    "title": "Professor, Department of Statistics and Data Science",
    "dept": "Statistics and Data Science",
    "url": "https://www.iitk.ac.in/sharmishtha-mitra",
+   "depts": [
+    "Statistics and Data Science"
+   ],
    "email": "smitra@iitk.ac.in",
    "phone": "0512-259-6044",
    "web": "https://home.iitk.ac.in/~smitra/",
@@ -3168,6 +3745,9 @@
    "title": "Assistant Professor, Department of Statistics and Data Science",
    "dept": "Statistics and Data Science",
    "url": "https://www.iitk.ac.in/soumyarup-sadhukhan",
+   "depts": [
+    "Statistics and Data Science"
+   ],
    "email": "soumyarups@iitk.ac.in",
    "phone": "0512-259-2258",
    "web": "https://sites.google.com/view/soumyarups",
@@ -3180,6 +3760,9 @@
    "title": "Professor, Department of Statistics and Data Science",
    "dept": "Statistics and Data Science",
    "url": "https://www.iitk.ac.in/subhra-sankar-dhar",
+   "depts": [
+    "Statistics and Data Science"
+   ],
    "email": "subhra@iitk.ac.in",
    "phone": "0512-259-6950",
    "web": "https://sites.google.com/site/subhrasankardhar/home",
@@ -3192,12 +3775,5262 @@
    "title": "Associate Professor, Department of Statistics and Data Science",
    "dept": "Statistics and Data Science",
    "url": "https://www.iitk.ac.in/suprio-bhar",
+   "depts": [
+    "Statistics and Data Science"
+   ],
    "email": "suprio@iitk.ac.in",
    "phone": "0512-259 2016",
    "web": "https://home.iitk.ac.in/~suprio/",
    "office": "Room no FB509 (Faculty Building)",
    "research": "Stochastic Partial Differential Equations in infinite dimensional spaces, Hilbert valued Stochastic Processes, Rough paths and Regularity Structures.",
    "qualification": "PhD (Indian Statistical Institute, Bangalore)"
+  },
+  {
+   "name": "Murali Prasad Panta",
+   "title": "Professor, Department of Economic Sciences",
+   "dept": "Economic Sciences",
+   "url": "https://www.iitk.ac.in/p-murali-prasad",
+   "depts": [
+    "Economic Sciences"
+   ],
+   "email": "pmprasad@iitk.ac.in",
+   "phone": "0512-259-7693",
+   "web": "https://home.iitk.ac.in/~pmprasad/",
+   "research": "Law and Economics, Environmental Economics",
+   "qualification": "PhD (University of Hyderabad)"
+  },
+  {
+   "name": "Neelanjan Datta",
+   "title": "Assistant Professor, Department of Economic Sciences",
+   "dept": "Economic Sciences",
+   "url": "https://www.iitk.ac.in/neelanjan-datta",
+   "depts": [
+    "Economic Sciences"
+   ],
+   "email": "ndatta@iitk.ac.in",
+   "research": "Public Finance, Political Economy, Macro-Development",
+   "qualification": "PhD (Cornell University)"
+  },
+  {
+   "name": "Pradip Swarnakar",
+   "title": "Professor, Department of Humanities and Social Sciences + Economic Sciences Adjunct Faculty",
+   "dept": "Economic Sciences",
+   "url": "https://www.iitk.ac.in/pradip-swarnakar",
+   "depts": [
+    "Economic Sciences",
+    "Humanities and Social Sciences"
+   ],
+   "email": "spradip@iitk.ac.in",
+   "phone": "0512-259-2063",
+   "web": "https://home.iitk.ac.in/~spradip/",
+   "research": "Environmental Sociology, Climate Change Policy, Social Media, Social Networks, Sustainability Transition",
+   "qualification": "PhD (IIT Kanpur, 2008)"
+  },
+  {
+   "name": "Praveen Kulshreshtha",
+   "title": "Professor, Department of Economic Sciences",
+   "dept": "Economic Sciences",
+   "url": "https://www.iitk.ac.in/praveen-kulshreshtha",
+   "depts": [
+    "Economic Sciences"
+   ],
+   "email": "pravk@iitk.ac.in",
+   "phone": "0512-259-6546",
+   "office": "FB-669, Faculty Building,",
+   "research": "Microeconomics, Industrial Economics/Organization, Economics of Corruption, Governance, Business Ethics",
+   "qualification": "PhD (Cornell University)"
+  },
+  {
+   "name": "Raghvi Garg",
+   "title": "Assistant Professor, Department of Economic Sciences",
+   "dept": "Economic Sciences",
+   "url": "https://www.iitk.ac.in/raghvi-garg",
+   "depts": [
+    "Economic Sciences"
+   ],
+   "email": "raghvi@iitk.ac.in",
+   "research": "Choice Theory, Decision Theory, Behavioral Economics, Experimental Economics, Economics of Discrimination, Gender, Polarization and Conflict",
+   "qualification": "PhD (Ashoka University)"
+  },
+  {
+   "name": "Sanjiv Kumar",
+   "title": "Assistant Professor, Department of Economic Sciences",
+   "dept": "Economic Sciences",
+   "url": "https://www.iitk.ac.in/sanjiv-kumar",
+   "depts": [
+    "Economic Sciences"
+   ],
+   "email": "sanjiv@iitk.ac.in"
+  },
+  {
+   "name": "Sarani Saha",
+   "title": "Professor, Department of Economic Sciences",
+   "dept": "Economic Sciences",
+   "url": "https://www.iitk.ac.in/sarani-saha",
+   "depts": [
+    "Economic Sciences"
+   ],
+   "email": "sarani@iitk.ac.in",
+   "phone": "0512-679-7064",
+   "office": "Department of Economic Sciences,",
+   "research": "Environmental Economics, Public Economics, Political Economics, Labour Economics, Applied Microeconomics, Development Economics",
+   "qualification": "PhD (University of California, Santa Barbara)"
+  },
+  {
+   "name": "Smriti Verma",
+   "title": "Assistant Professor, Department of Economic Sciences",
+   "dept": "Economic Sciences",
+   "url": "https://www.iitk.ac.in/smriti-verma",
+   "depts": [
+    "Economic Sciences"
+   ],
+   "email": "smritiv@iitk.ac.in"
+  },
+  {
+   "name": "Sohini Sahu",
+   "title": "Professor, Economics Group, Department of Economic Sciences",
+   "dept": "Economic Sciences",
+   "url": "https://www.iitk.ac.in/sohini-sahu",
+   "depts": [
+    "Economic Sciences"
+   ],
+   "email": "ssahu@iitk.ac.in",
+   "phone": "0512-259-6701",
+   "web": "https://sites.google.com/view/sohini-sahu/home",
+   "office": "Faculty Building 603",
+   "research": "Macroeconomics",
+   "qualification": "PhD (State University of New York, Albany, New York)"
+  },
+  {
+   "name": "Somesh Kumar Mathur",
+   "title": "Professor, Department of Economic Sciences",
+   "dept": "Economic Sciences",
+   "url": "https://www.iitk.ac.in/somesh-k-mathur",
+   "depts": [
+    "Economic Sciences"
+   ],
+   "email": "skmathur@iitk.ac.in",
+   "phone": "0512-259-7155",
+   "web": "https://www.youtube.com/playlist?list=PLbMVogVj5nJSX5371tiQd1zK5Q3ahqieg",
+   "office": "Office: Room Number- 651, 6th Floor",
+   "research": "New New Trade Theories, Spatial Regression, Gravity Modelling, Trade Growth Accounting, Frontier areas in trade, econometrics and growth, Evaluating Regional Trade Agreements.",
+   "qualification": "PhD (JNU)"
+  },
+  {
+   "name": "Sounak Thakur",
+   "title": "Assistant Professor, Department of Economic Sciences",
+   "dept": "Economic Sciences",
+   "url": "https://www.iitk.ac.in/sounak-thakur",
+   "depts": [
+    "Economic Sciences"
+   ],
+   "email": "sounakt@iitk.ac.in",
+   "research": "Family Economics and Labour Economics.",
+   "qualification": "PhD (Washington University in St. Louis)"
+  },
+  {
+   "name": "Srinivas Kumar Arigapudi",
+   "title": "Assistant Professor, Department of Economic Sciences",
+   "dept": "Economic Sciences",
+   "url": "https://www.iitk.ac.in/srinivas-arigapudi",
+   "depts": [
+    "Economic Sciences"
+   ],
+   "email": "arigapudi@iitk.ac.in",
+   "research": "Evolutionary Game Theory, Agent-Based Simulations",
+   "qualification": "PhD (University of Wisconsin - Madison)"
+  },
+  {
+   "name": "Subhankar Mukherjee",
+   "title": "Associate Professor, Department of Management Sciences + Economic Sciences Adjunct Faculty",
+   "dept": "Economic Sciences",
+   "url": "https://www.iitk.ac.in/subhankar-mukherjee",
+   "depts": [
+    "Economic Sciences",
+    "Management Sciences"
+   ],
+   "email": "subhankar@iitk.ac.in",
+   "phone": "0512-259-2048",
+   "office": "Office Department of Management Sciences",
+   "research": "Development Economics, Applied Microeconomics.",
+   "qualification": "PhD (IIM Calcutta)"
+  },
+  {
+   "name": "Sujaya Sircar",
+   "title": "Assistant Professor, Department of Economic Sciences",
+   "dept": "Economic Sciences",
+   "url": "https://www.iitk.ac.in/sujaya-sircar",
+   "depts": [
+    "Economic Sciences"
+   ],
+   "email": "ssircar@iitk.ac.in",
+   "research": "Environmental Economics, Labour Economics and Development Economics",
+   "qualification": "PhD (Indian Statistical Institute, Delhi)"
+  },
+  {
+   "name": "Sukumar Vellakkal",
+   "title": "Associate Professor, Department of Economic Sciences",
+   "dept": "Economic Sciences",
+   "url": "https://www.iitk.ac.in/sukumar-vellakkal",
+   "depts": [
+    "Economic Sciences"
+   ],
+   "email": "vellakkal@iitk.ac.in",
+   "research": "Public policy and the impact evaluation techniques; Large data analysis and the applied econometrics; Macroeconomics and health.",
+   "qualification": "PhD (Institute for Social and Economic Change, Bangalore)"
+  },
+  {
+   "name": "Thirumulanathan Dhayaparan",
+   "title": "Assistant Professor, Department of Economic Sciences",
+   "dept": "Economic Sciences",
+   "url": "https://www.iitk.ac.in/thirumulanathan-d",
+   "depts": [
+    "Economic Sciences"
+   ],
+   "email": "nathan@iitk.ac.in",
+   "phone": "0512-259-2169",
+   "web": "https://sites.google.com/view/dtnathan/home",
+   "office": "Room 414-B6, ESB-2 Building",
+   "research": "Game Theory, Mechanism Design, Optimization, Mathematical Economics, Machine Learning",
+   "qualification": "PhD (IISc, Bengaluru)"
+  },
+  {
+   "name": "Vasudha Jain",
+   "title": "Assistant Professor, Department of Economic Sciences",
+   "dept": "Economic Sciences",
+   "url": "https://www.iitk.ac.in/vasudha-jain",
+   "depts": [
+    "Economic Sciences"
+   ],
+   "email": "vasudhaj@iitk.ac.in",
+   "phone": "0512-259-2293",
+   "web": "https://sites.google.com/site/vasudhajainecon/home",
+   "office": "IIT Kanpur-208016, Uttar Pradesh, India",
+   "research": "Game Theory, Economics of Information",
+   "qualification": "Ph.D in Economics, University of Texas at Austin, 2021"
+  },
+  {
+   "name": "Wasim Ahmad",
+   "title": "Associate Professor, Department of Economic Sciences",
+   "dept": "Economic Sciences",
+   "url": "https://www.iitk.ac.in/wasim-ahmad",
+   "depts": [
+    "Economic Sciences"
+   ],
+   "email": "wasimad@iitk.ac.in",
+   "phone": "0512-259-6838",
+   "web": "https://sites.google.com/site/wasimatiitk/",
+   "office": "Room No. 223",
+   "research": "Macroeconomics, Financial Economics and Applied Econometrics",
+   "qualification": "PhD (Delhi University)"
+  },
+  {
+   "name": "Dipak Kumar Giri",
+   "title": "Associate Professor, Department of Aerospace Engineering",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/dipak-kumar-giri",
+   "depts": [
+    "Aerospace Engineering"
+   ],
+   "email": "dkgiri@iitk.ac.in",
+   "phone": "0512-259-7107",
+   "web": "https://sites.google.com/view/dipakgiri",
+   "office": "Office Room No 203, Second Floor, Helicopter Building,",
+   "research": "Linear and nonlinear controls for aerospace systems (flight vehicle), Satellite Attitude Dynamics and Control.",
+   "qualification": "PhD (IIT Kharagpur)"
+  },
+  {
+   "name": "G. M. Kamath",
+   "title": "Professor, Department of Aerospace Engineering",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/g-m-kamath",
+   "depts": [
+    "Aerospace Engineering"
+   ],
+   "email": "gmkamath@iitk.ac.in",
+   "phone": "+91-512-259-6614",
+   "web": "https://www.gmkamath.in/",
+   "office": "210B, National Wind Tunnel Facility Building",
+   "research": "Structural Health Monitoring, Composite Materials and Structures, Structural Dynamics, Condition Monitoring, Machine Learning, Aeroelasticity",
+   "qualification": "PhD (University of Maryland, College Park)"
+  },
+  {
+   "name": "K R Guruprasad",
+   "title": "Associate Professor, Department of Mechanical Engineering + AE Adjunct Faculty",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/k-r-guruprasad",
+   "depts": [
+    "Aerospace Engineering",
+    "Mechanical Engineering"
+   ],
+   "email": "krgprao@iitk.ac.in",
+   "phone": "0512-259-2328",
+   "office": "Office Diamond Jubilee Academic Complex 503H-H,",
+   "qualification": "(PhD, IISc Bangalore)"
+  },
+  {
+   "name": "Kamal Poddar",
+   "title": "Emeritus Fellow, Department of Aerospace Engineering",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/kamal-poddar",
+   "depts": [
+    "Aerospace Engineering"
+   ],
+   "email": "kamal@iitk.ac.in",
+   "phone": "0512-259-7293",
+   "research": "Low and High Speed Aerodynamics, Turbulence",
+   "qualification": "PhD (UC, Sandiego)"
+  },
+  {
+   "name": "Navrose",
+   "title": "Associate Professor, Department of Aerospace Engineering",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/navrose",
+   "depts": [
+    "Aerospace Engineering"
+   ],
+   "email": "navrose@iitk.ac.in",
+   "phone": "+91-512-259-2022",
+   "office": "Office location: Helicopter Building",
+   "research": "Fluid Mechanics, Aerodynamics, Fluid-Structure Interaction, Optimization, Computational Fluid Dynamics.",
+   "qualification": "PhD (IIT Kanpur)"
+  },
+  {
+   "name": "Pradeep Moise",
+   "title": "Assistant Professor, Department of Aerospace Engineering",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/pradeep-moise",
+   "depts": [
+    "Aerospace Engineering"
+   ],
+   "email": "pmoise@iitk.ac.in",
+   "phone": "0512-259-2347",
+   "web": "https://www.pradeepmoise.com/",
+   "office": "Office Office Phone : 0512-259-2347 Email: pmoise[AT]iitk.ac.in",
+   "research": "CFD, Vortex breakdown in swirling flows, Swirl in cardiac flows, tornadoes and wind turbines, Transonic buffet, Resolvent analysis",
+   "qualification": "PhD (Indian Institute of Science, Bengaluru)"
+  },
+  {
+   "name": "Preetamkumar Marutrao Mohite",
+   "title": "Professor, Department of Aerospace Engineering",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/dr-p-m-mohite",
+   "depts": [
+    "Aerospace Engineering"
+   ],
+   "email": "mohite@iitk.ac.in",
+   "phone": "0512-259-6024",
+   "web": "https://home.iitk.ac.in/~mohite/",
+   "office": "Lab Addresses : Structural Analysis Lab",
+   "research": "Damage and micromechanics of fibrous composites, Load bearing RADAR absorbing structures, Inflatable Structures, Laminate modeling, adaptive finite element analysis, fibres and composite characterization",
+   "qualification": "PhD (IIT Kanpur)"
+  },
+  {
+   "name": "Rachana Agrawal",
+   "title": "Assistant Professor, Department of Aerospace Engineering",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/rachana-agrawal",
+   "depts": [
+    "Aerospace Engineering"
+   ],
+   "email": "rachana@iitk.ac.in",
+   "phone": "0512-259-2091",
+   "web": "https://www.spacesystemslab.com/",
+   "office": "Office HB-206",
+   "research": "Space mission design; Planetary mission architectures; Astrodynamics; Space systems design and development; Systems engineering; Entry, descent, and landing (EDL); Small spacecraft technology",
+   "qualification": "PhD (Purdue University, USA)"
+  },
+  {
+   "name": "Raghavendra P Kukillaya",
+   "title": "Assistant Professor, Department of Aerospace Engineering",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/raghavendra-p-kukillaya",
+   "depts": [
+    "Aerospace Engineering"
+   ],
+   "email": "raghavpk@iitk.ac.in",
+   "phone": "0512-259-6706",
+   "office": "Office HSAL-02",
+   "research": "Aircraft and Airship dynamics and control, Systems modeling, simulation and design, Optimal control, Biomechanics",
+   "qualification": "PhD (Princeton University, New Jersey, USA)"
+  },
+  {
+   "name": "Rajesh Kitey",
+   "title": "Professor, Department of Aerospace Engineering",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/dr-rajesh-kitey",
+   "depts": [
+    "Aerospace Engineering"
+   ],
+   "email": "kitey@iitk.ac.in",
+   "phone": "0512-259-7060",
+   "research": "Solid Mechanics, Fracture Mechanics, Experimental Stress Analysis, Optical Metrology, Mechanics of Thin Films, Composite Materials, Finite Element and Boundary Element Methods",
+   "qualification": "PhD (Auburn University, Auburn AL, USA)"
+  },
+  {
+   "name": "Rajesh Ranjan",
+   "title": "Associate Professor, Department of Aerospace Engineering",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/rajesh-ranjan",
+   "depts": [
+    "Aerospace Engineering"
+   ],
+   "email": "rajeshr@iitk.ac.in",
+   "phone": "0512-679-2203",
+   "web": "https://home.iitk.ac.in/~rajeshr/",
+   "research": "Turbomachinery Flows, Applied Aerodynamics, Stability & Flow Control, Transition and Relaminarization, High Performance Computing, Scientific Machine Learning",
+   "qualification": "PhD (JNCASR, Bengaluru)"
+  },
+  {
+   "name": "Rakesh Kumar",
+   "title": "Professor, Department of Aerospace Engineering",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/rakesh-kumar",
+   "depts": [
+    "Aerospace Engineering"
+   ],
+   "email": "rkm@iitk.ac.in",
+   "phone": "0512-259-6301",
+   "research": "Hypersonics, Rarefied Gas Dynamics, Microfluidics, Heat Transfer & Thermal Design",
+   "qualification": "PhD (Penn State)"
+  },
+  {
+   "name": "Salil Goel",
+   "title": "Associate Professor, Department of Civil Engineering + AE Adjunct Faculty",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/salil-goel",
+   "depts": [
+    "Aerospace Engineering",
+    "Civil Engineering"
+   ],
+   "email": "sgoel@iitk.ac.in",
+   "phone": "0512 679 6179",
+   "web": "https://sgoel-web.github.io/",
+   "office": "Office Geoinformatics Laboratory, Department of Civil Engineering, IIT Kanpur",
+   "qualification": "PhD: The University of Melbourne and IIT Kanpur (Jointly awarded)"
+  },
+  {
+   "name": "Sanjay Kumar",
+   "title": "Professor, Department of Aerospace Engineering",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/s-kumar",
+   "depts": [
+    "Aerospace Engineering"
+   ],
+   "email": "skmr@iitk.ac.in",
+   "phone": "+91-512-259-6768",
+   "office": "Office A01 (Low Speed Aerodynamics Laboratory)",
+   "research": "Bluff body wakes and flow control, Granular Flows, Shock Waves, Multiphase Flows, Shock – accelerated flows, Fluid instabilities and turbulence",
+   "qualification": "PhD (GALCIT, Caltech)"
+  },
+  {
+   "name": "Sanjay Mittal",
+   "title": "Professor, Department of Aerospace Engineering",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/sanjay-mittal",
+   "depts": [
+    "Aerospace Engineering"
+   ],
+   "email": "smittal@iitk.ac.in",
+   "phone": "0512-259-7906",
+   "web": "https://home.iitk.ac.in/~smittal/",
+   "research": "Aerodynamics, CFD, Aerodynamic Shape Optimization, Bluff Body Flows, Vortex Induced Vibrations, Fluid-Structure Interactions, Transition and Turbulence, Air Intakes, Wind Tunnel Testing, Modeling of Traffic",
+   "qualification": "PhD (Minnesota)"
+  },
+  {
+   "name": "Sathesh Mariappan",
+   "title": "Professor, Department of Aerospace Engineering",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/dr-sathesh-mariappan",
+   "depts": [
+    "Aerospace Engineering"
+   ],
+   "email": "sathesh@iitk.ac.in",
+   "phone": "0512-259-6331",
+   "web": "https://sites.google.com/view/profsatheshmariappan/bio",
+   "office": "Room 210/A. First floor",
+   "qualification": "PhD (IIT Madras)"
+  },
+  {
+   "name": "Subrahmanyam Saderla",
+   "title": "Associate Professor, Department of Aerospace Engineering",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/subrahmanyam-saderla",
+   "depts": [
+    "Aerospace Engineering"
+   ],
+   "email": "saderlas@iitk.ac.in",
+   "phone": "0512-259-2009",
+   "web": "https://home.iitk.ac.in/~saderlas/",
+   "office": "Office HSAL-05",
+   "research": "Real Time Aircraft Parameter Estimation Aerodynamic Characteristics of UAVs using flight testing methods Aircraft Instrumentation and Control Aircraft/UAV Simulations and Simulator development Unmanned Aerial Vehicle Design Experimental Flight Dynamics Drone Design and Development AI based controller design for UAVs Controller reconfiguration of UAVs using online system identification",
+   "qualification": "PhD (IIT Kanpur)"
+  },
+  {
+   "name": "Tanmay Dutt Mathur",
+   "title": "Assistant Professor, Department of Aerospace Engineering",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/tanmay-mathur",
+   "depts": [
+    "Aerospace Engineering"
+   ],
+   "email": "mathur@iitk.ac.in",
+   "phone": "+91-512-259-2398",
+   "research": "Rotorcraft and aeroengine gearboxes, rotordynamics of turbomachinery, design of rotating mechanical systems, tribology and lubrication.",
+   "qualification": "PhD (The Pennsylvania State University, 2019)"
+  },
+  {
+   "name": "Tufan Kumar Guha",
+   "title": "Assistant Professor, Department of Aerospace Engineering",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/tufan-guha",
+   "depts": [
+    "Aerospace Engineering"
+   ],
+   "email": "tkguha@iitk.ac.in",
+   "phone": "0512-259-2352",
+   "web": "https://sites.google.com/view/eag-iitk-ae/home",
+   "office": "Office : Department of Aerospace Engineering",
+   "research": "Experimental Aerodynamics and Fluid Mechanics, Active and Passive Flow Control",
+   "qualification": "PhD (Florida State University, USA)"
+  },
+  {
+   "name": "Vaibhav Kumar Arghode",
+   "title": "Professor, Department of Aerospace Engineering + Department of Sustainable Energy Engineering (joint appointment)",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/vaibhav-arghode",
+   "depts": [
+    "Aerospace Engineering",
+    "Sustainable Energy Engineering"
+   ],
+   "email": "varghode@iitk.ac.in",
+   "phone": "0512-259-6294",
+   "web": "https://sites.google.com/view/varghode",
+   "office": "Office Room No. 101-C, Bldg. ESB-2",
+   "research": "Combustion, Heat Transfer, Fluid Mechanics, Experimental Methods, Computational Fluid Dynamics",
+   "qualification": "PhD (University of Maryland, College Park)"
+  },
+  {
+   "name": "Vice Admiral Puneet Kumar Bahl",
+   "title": "Visiting Professor, Department of Aerospace Engineering",
+   "dept": "Aerospace Engineering",
+   "url": "https://www.iitk.ac.in/vice-admiral-puneet-kumar-bahl",
+   "depts": [
+    "Aerospace Engineering"
+   ],
+   "email": "pkbahl@iitk.ac.in"
+  },
+  {
+   "name": "Hamim Zafar",
+   "title": "Associate Professor, Department of Computer Science & Engineering + Department of Biological Sciences & Bioengineering (joint appointment)",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/hamim-zafar",
+   "depts": [
+    "Biological Sciences & Bioengineering",
+    "Computer Science & Engineering"
+   ],
+   "email": "hamim@iitk.ac.in",
+   "phone": "0512-259-2054",
+   "research": "Computational biology; probabilistic modeling; single-cell biology; evolution and cancer"
+  },
+  {
+   "name": "Jayandharan Giridhara Rao",
+   "title": "Professor, Department of Biological Sciences & Bioengineering",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/jayandharan-giridhara-rao",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
+   "email": "jayrao@iitk.ac.in",
+   "phone": "0512-259-4086",
+   "web": "http://gjlab.in/",
+   "office": "Office Department of Biological Sciences and Bioengineering",
+   "qualification": "PhD (Christian Medical College, Vellore)"
+  },
+  {
+   "name": "Jonaki Sen",
+   "title": "Professor, Department of Biological Sciences & Bioengineering",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/jonaki-sen",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
+   "email": "jonaki@iitk.ac.in",
+   "phone": "0512-259-4054",
+   "research": "Vertebrate neuronal development Our goal is to understand the molecular mechanism of how neurons are generated, undergo migration, differentiate and make connections with their appropriate targets. We aim to identify the molecules that regulate these processes in the visual system, the cortex and the hippocampus, using the developing chick and mouse as model systems.",
+   "qualification": "PhD (A.E. College of Medicine, New York)"
+  },
+  {
+   "name": "Nikunj Arunkumar Bhagat",
+   "title": "Assistant Professor, Department of Electrical Engineering + Department of Biological Sciences and Bioengineering (joint appointment)",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/nikunj-arunkumar-bhagat",
+   "depts": [
+    "Biological Sciences & Bioengineering",
+    "Electrical Engineering"
+   ],
+   "email": "nbhagat@iitk.ac.in",
+   "phone": "0512-259-2479",
+   "web": "https://home.iitk.ac.in/~nbhagat/",
+   "office": "Office: 306, ACES Building",
+   "research": "Neural & Bio-signal processing, Medical Instrumentation, Brain-machine interfaces, Functional Electrical Stimulation, and Rehabilitation Engineering"
+  },
+  {
+   "name": "Nitin Gupta",
+   "title": "Professor, Department of Biological Sciences and Bioengineering",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/nitin-gupta",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
+   "email": "guptan@iitk.ac.in",
+   "phone": "0512-259-4384",
+   "web": "https://sites.google.com/site/labofneuralsystems/",
+   "office": "Department of BSBE, IIT Kanpur",
+   "qualification": "PhD (University of California San Diego)"
+  },
+  {
+   "name": "Nitin Mohan",
+   "title": "Associate Professor, Department of Biological Sciences & Bioengineering",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/nitin-mohan",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
+   "email": "nitinm@iitk.ac.in",
+   "research": "Optical engineering; super-resolution microscopy; applications in neurodegenerative disorders, lysosomal storage disease & cancer"
+  },
+  {
+   "name": "Pradip Sinha",
+   "title": "Emeritus Fellow, Department of Biological Sciences & Bioengineering",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/dr-pradip-sinha",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
+   "email": "pradips@iitk.ac.in",
+   "phone": "0512-259-4027",
+   "research": "Goals of my researches are to identify fundamental genetic mechanisms of carcinogenesis in the fruit fly, Drosophila. Our eventual aims are also to extend these insights to explain developmental genetic basis of carcinogenesis in higher organisms including human and exploit the sophisticated genetics of Drosophila to screen for anti-cancer drug.",
+   "qualification": "PhD (Banaras Hindu University)"
+  },
+  {
+   "name": "Rakesh Kumar Majhi",
+   "title": "Assistant Professor, Department of Biological Sciences & Bioengineering",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/rakesh-majhi",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
+   "email": "rakesh@iitk.ac.in",
+   "phone": "0512-259-2354",
+   "research": "Ion channels, Immune cell engineering, Tissue restoration"
+  },
+  {
+   "name": "Robert Sonowal",
+   "title": "Assistant Professor, Department of Biological Sciences & Bioengineering",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/robert-sonowa",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
+   "email": "rsonowal@iitk.ac.in",
+   "phone": "0512-259-2351",
+   "research": "Microbiota, aging, metabolites, antimicrobial resistance"
+  },
+  {
+   "name": "Sai Chaitanya Chiliveri",
+   "title": "Assistant Professor, Department of Biological Sciences & Bioengineering",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/sai-chaitanya-chiliveri",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
+   "email": "saichay@iitk.ac.in"
+  },
+  {
+   "name": "Sai Prasad Pydi",
+   "title": "Assistant Professor, Department of Biological Sciences & Bioengineering",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/sai-prasad-pydi",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
+   "email": "pydi@iitk.ac.in",
+   "phone": "0512-259-2212",
+   "research": "Diabetes, Obesity, Immunometabolism, GPCRs, Cell Signaling",
+   "qualification": "PhD (University of Manitoba – Canada)"
+  },
+  {
+   "name": "Sankararamakrishnan Ramasubbu",
+   "title": "Professor, Department of Biological Sciences & Bioengineering",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/dr-r-sankararamakrishnan",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
+   "email": "rsankar@iitk.ac.in",
+   "phone": "0512-259-4014",
+   "web": "https://home.iitk.ac.in/~rsankar/",
+   "qualification": "PhD (IISc Bangalore)"
+  },
+  {
+   "name": "Santosh Kumar Misra",
+   "title": "Associate Professor, Department of Biological Sciences & Bioengineering",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/santosh-k-misra",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
+   "email": "skmisra@iitk.ac.in",
+   "phone": "0512-259-4013",
+   "research": "Biosensors, personalized medicine, bubble therapy, 3D-printed biomedical devices, carbon composites, drug delivery systems, nanocomposites."
+  },
+  {
+   "name": "Saravanan Matheshwaran",
+   "title": "Associate Professor, Department of Biological Sciences & Bioengineering",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/dr-saravanan-matheshwaran",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
+   "email": "saran@iitk.ac.in",
+   "phone": "0512-259-4066",
+   "web": "https://saranlab.weebly.com/",
+   "office": "Office Lab 1",
+   "qualification": "PhD (IISc Bangalore)"
+  },
+  {
+   "name": "Saroj Chooramani Gopal",
+   "title": "Distinguished Visiting Professor, Department of Biological Sciences & Bioengineering",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/saroj-chooramani-gopal",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ]
+  },
+  {
+   "name": "Shanu Jain",
+   "title": "Assistant Professor, Department of Biological Sciences & Bioengineering",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/shanu-jain",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
+   "email": "shanuj@iitk.ac.in",
+   "research": "Liver Metabolic Disorders, G Protein-Coupled Receptors, Cellular Signaling, Genetic Mutations, Small Molecule Drug Discovery"
+  },
+  {
+   "name": "Sharmila Mande",
+   "title": "Visiting Professor of Practice, Department of Biological Sciences and Bioengineering",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/sharmila-mande",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ]
+  },
+  {
+   "name": "Shekhar C. Mande",
+   "title": "Distinguished Visiting Professor, Department of Biological Sciences and Bioengineering",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/shekhar-c-mande",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ]
+  },
+  {
+   "name": "Sivaprakash Kullampalayam Ramalingam",
+   "title": "Associate Professor, Department of Biological Sciences & Bioengineering",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/sivaprakash-kullampalayam-ramalingam",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
+   "email": "sivaprakash@iitk.ac.in"
+  },
+  {
+   "name": "Srikant Sastri",
+   "title": "Distinguished Visiting Professor, Department of Biological Sciences and Bioengineering",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/srikant-sastri",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ]
+  },
+  {
+   "name": "Subramaniam Ganesh",
+   "title": "Professor, Department of Biological Sciences & Bioengineering",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/s-ganesh",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
+   "email": "sganesh@iitk.ac.in",
+   "phone": "0512-259-4040",
+   "web": "https://home.iitk.ac.in/~sganesh/index.html",
+   "office": "Indian Institute of Technology Kanpur",
+   "qualification": "PhD (Banaras Hindu University)"
+  },
+  {
+   "name": "Suresh Kumar",
+   "title": "Assistant Professor, Department of Biological Sciences & Bioengineering",
+   "dept": "Biological Sciences & Bioengineering",
+   "url": "https://www.iitk.ac.in/suresh-kumar",
+   "depts": [
+    "Biological Sciences & Bioengineering"
+   ],
+   "email": "sureshkr@iitk.ac.in",
+   "phone": "0512-259-2247",
+   "research": "Autophagy, colorectal and breast cancer"
+  },
+  {
+   "name": "Jayant Kumar Singh",
+   "title": "Professor, Department of Chemical Engineering",
+   "dept": "Chemical Engineering",
+   "url": "https://www.iitk.ac.in/jayant-k-singh",
+   "depts": [
+    "Chemical Engineering"
+   ],
+   "email": "jayantks@iitk.ac.in",
+   "phone": "0512-259-6141",
+   "web": "https://cnislab.com/",
+   "office": "Office FA-B201",
+   "research": "Energy storage Heavy metal removal Wetting transition Anti-Ice surface design Adsorption and segregation of nanoparticles Multi-scale modeling of micro/nano devices Selective adsorption and separation CO2 adsorption and separation Phase segregation of granular materials Coarse-grain model development",
+   "qualification": "PhD (SUNY Buffalo)"
+  },
+  {
+   "name": "K. P. Krishnaraj",
+   "title": "Assistant Professor, Department of Chemical Engineering",
+   "dept": "Chemical Engineering",
+   "url": "https://www.iitk.ac.in/k-p-krishnaraj",
+   "depts": [
+    "Chemical Engineering"
+   ],
+   "email": "krishnaraj@iitk.ac.in",
+   "phone": "0512-679-2297",
+   "research": "Flow, structure and stress transmission in granular media, structure and transport in spatial networks.",
+   "qualification": "PhD (Indian Institute of Science, Bangalore)"
+  },
+  {
+   "name": "Naveen Tiwari",
+   "title": "Professor, Department of Chemical Engineering",
+   "dept": "Chemical Engineering",
+   "url": "https://www.iitk.ac.in/naveen-tiwari",
+   "depts": [
+    "Chemical Engineering"
+   ],
+   "email": "naveent@iitk.ac.in",
+   "phone": "0512-259-6751",
+   "web": "https://iitk.ac.in/che/old/nt.htm",
+   "office": "Office FB-459,",
+   "research": "Transport Phenomena, Instabilities in micro‐scale free surface flows, Flow through porous media, Numerical modeling and simulation",
+   "qualification": "PhD (University of Massachusetts Amherst)"
+  },
+  {
+   "name": "Nishith Kumar Verma",
+   "title": "Professor, Department of Chemical Engineering",
+   "dept": "Chemical Engineering",
+   "url": "https://www.iitk.ac.in/nish-ver",
+   "depts": [
+    "Chemical Engineering"
+   ],
+   "email": "nishith@iitk.ac.in",
+   "phone": "0512-259-7704",
+   "web": "https://iitk.ac.in/che/old/nv.htm",
+   "office": "Office FB-452,",
+   "research": "Adsorption Environmental Pollution Control Synthesis and Application of Carbon Nanofibres and Nanoparticles Lattice Boltzmann Modelling and Simulation",
+   "qualification": "PhD (University of Arizona, USA)"
+  },
+  {
+   "name": "Nitin Kaistha",
+   "title": "Head and Professor, Department of Chemical Engineering",
+   "dept": "Chemical Engineering",
+   "url": "https://www.iitk.ac.in/nitin-kaistha",
+   "depts": [
+    "Chemical Engineering"
+   ],
+   "email": "nkaistha@iitk.ac.in",
+   "phone": "0512-259-7513",
+   "web": "https://iitk.ac.in/che/nk.htm",
+   "office": "Office FB- 457,",
+   "research": "Economic plant wide control of complex chemical processes; Reactive Distillation modelling; Simulation and control; Process intensification technologies.",
+   "qualification": "PhD (University of Tennessee, Knoxville)"
+  },
+  {
+   "name": "Pankaj Arvind Apte",
+   "title": "Associate Professor, Department of Chemical Engineering",
+   "dept": "Chemical Engineering",
+   "url": "https://www.iitk.ac.in/pankaj-arvind-apte",
+   "depts": [
+    "Chemical Engineering"
+   ],
+   "email": "papte@iitk.ac.in",
+   "phone": "0512-259-7457",
+   "web": "https://iitk.ac.in/che/old/pa.htm",
+   "office": "Office",
+   "qualification": "PhD (Ohio State University)"
+  },
+  {
+   "name": "Raghavendra Ragipani",
+   "title": "Assistant Professor, Department of Chemical Engineering",
+   "dept": "Chemical Engineering",
+   "url": "https://www.iitk.ac.in/raghavendra-ragipani",
+   "depts": [
+    "Chemical Engineering"
+   ],
+   "email": "ragipani@iitk.ac.in",
+   "phone": "0512-679-2241",
+   "research": "Carbon dioxide capture and mineralization, Resource recovery and solid waste utilization, Sustainable process engineering",
+   "qualification": "PhD (Joint from IIT Bombay and Monash University)"
+  },
+  {
+   "name": "Raghvendra Singh",
+   "title": "Associate Professor, Department of Chemical Engineering",
+   "dept": "Chemical Engineering",
+   "url": "https://www.iitk.ac.in/raghvendra-singh",
+   "depts": [
+    "Chemical Engineering"
+   ],
+   "email": "raghvend@iitk.ac.in",
+   "phone": "0512-259-7605",
+   "office": "Office Room No.",
+   "research": "Molecular dynamics of biological molecules",
+   "qualification": "PhD (State University of New York at Buffalo)"
+  },
+  {
+   "name": "Rahul Mangal",
+   "title": "Associate Professor, Department of Chemical Engineering",
+   "dept": "Chemical Engineering",
+   "url": "https://www.iitk.ac.in/rahul-mangal",
+   "depts": [
+    "Chemical Engineering"
+   ],
+   "email": "mangalr@iitk.ac.in",
+   "research": "Polymer physics, colloids, complex fluids, nanocomposites, active matter, liquid crystals",
+   "qualification": "PhD (Cornell University)"
+  },
+  {
+   "name": "Raj Deo Tewari",
+   "title": "Visiting Professor of Practice, Department of Chemical Engineering",
+   "dept": "Chemical Engineering",
+   "url": "https://www.iitk.ac.in/raj-deo-tewari",
+   "depts": [
+    "Chemical Engineering"
+   ],
+   "email": "dtewari@iitk.ac.in"
+  },
+  {
+   "name": "Raju Kumar Gupta",
+   "title": "Professor, Department of Chemical Engineering",
+   "dept": "Chemical Engineering",
+   "url": "https://www.iitk.ac.in/raju-kumar-gupta",
+   "depts": [
+    "Chemical Engineering"
+   ],
+   "email": "guptark@iitk.ac.in",
+   "phone": "0512-259-6972",
+   "web": "https://iitk.ac.in/che/rkg.htm",
+   "office": "Office FB-486",
+   "research": "Nanomaterials: Synthesis and exploitation of organic molecules, polymers and surface-functionalized nanoparticles and their assembly for electronics and energy applications. Layer by Layer (LbL) assembly Design and engineering of nanostructures for energy applications Self-assembly based: Nanosphere lithography & Block copolymer lithography",
+   "qualification": "PhD (National University of Singapore)"
+  },
+  {
+   "name": "Salman Ahmad Khan",
+   "title": "Assistant Professor, Department of Chemical Engineering",
+   "dept": "Chemical Engineering",
+   "url": "https://www.iitk.ac.in/salman-ahmad-khan",
+   "depts": [
+    "Chemical Engineering"
+   ],
+   "email": "salman@iitk.ac.in"
+  },
+  {
+   "name": "Sana Khanum",
+   "title": "Assistant Professor, Department of Chemical Engineering",
+   "dept": "Chemical Engineering",
+   "url": "https://www.iitk.ac.in/sana-khanum",
+   "depts": [
+    "Chemical Engineering"
+   ],
+   "email": "skhanum@iitk.ac.in"
+  },
+  {
+   "name": "Sanjeev Garg",
+   "title": "Professor, Department of Chemical Engineering",
+   "dept": "Chemical Engineering",
+   "url": "https://www.iitk.ac.in/sanjeev-garg",
+   "depts": [
+    "Chemical Engineering"
+   ],
+   "email": "sgarg@iitk.ac.in",
+   "phone": "0512-259-7736",
+   "web": "https://iitk.ac.in/che/sg.htm",
+   "office": "Office FB-453",
+   "qualification": "PhD (University of Connecticut, Storrs)"
+  },
+  {
+   "name": "Shobha Shukla",
+   "title": "Visiting Professor, Department of Chemical Engineering",
+   "dept": "Chemical Engineering",
+   "url": "https://www.iitk.ac.in/shobha-shukla",
+   "depts": [
+    "Chemical Engineering"
+   ]
+  },
+  {
+   "name": "Soumik Das",
+   "title": "Assistant Professor, Department of Chemical Engineering",
+   "dept": "Chemical Engineering",
+   "url": "https://www.iitk.ac.in/soumik-das",
+   "depts": [
+    "Chemical Engineering"
+   ],
+   "email": "dsoumik@iitk.ac.in",
+   "phone": "0512-679-2385",
+   "research": "Wettability alteration, Surfactants, Composites, Molecular assembly and synthesis in structured solvents, Liquid crystals, Solitons in liquid crystals, Soliton-based chemical soft matter.",
+   "qualification": "PhD (University of Texas at Austin)"
+  },
+  {
+   "name": "Vishal Agarwal",
+   "title": "Associate Professor, Department of Chemical Engineering",
+   "dept": "Chemical Engineering",
+   "url": "https://www.iitk.ac.in/vishal-agarwal",
+   "depts": [
+    "Chemical Engineering"
+   ],
+   "email": "vagarwal@iitk.ac.in",
+   "phone": "0512-259-6895",
+   "research": "Catalysis, Biofuels, Nucleation, Gas-Surface and Liquid-Surface Interactions, Molecular Simulation, Abintio Molecular Dynamics, Density Functional Theory, Rare-Event Simulations, Reaction Rate Theory",
+   "qualification": "PhD (University of Massachusetts Amherst)"
+  },
+  {
+   "name": "Viswanathan Shankar",
+   "title": "Professor, Department of Chemical Engineering",
+   "dept": "Chemical Engineering",
+   "url": "https://www.iitk.ac.in/viswanathan-shankar",
+   "depts": [
+    "Chemical Engineering"
+   ],
+   "email": "vshankar@iitk.ac.in",
+   "phone": "0512-259-7827",
+   "web": "https://home.iitk.ac.in/~vshankar/",
+   "office": "Office NL2-205",
+   "qualification": "PhD (Indian Institute of Science, Bangalore)"
+  },
+  {
+   "name": "Dr. Chunendra K Sahu",
+   "title": "Assistant Professor, CE (HWRE)",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/chunendra-k-sahu",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "cksahu@iitk.ac.in",
+   "phone": "0512-259-2198",
+   "web": "https://sites.google.com/view/cksahu",
+   "office": "Office WLE 112",
+   "research": "Fluid Mechanics. Flow and mixing in porous media. Buoyancy and density-driven flows. Carbon sequestration. Groundwater contamination. Geothermal energy recovery."
+  },
+  {
+   "name": "Dr. Hossam Aboel Naga",
+   "title": "Adjunct Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/dr-hossam-aboel-naga",
+   "depts": [
+    "Civil Engineering"
+   ]
+  },
+  {
+   "name": "Durgesh Chandra Rai",
+   "title": "Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/durgesh-c-rai",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "dcrai@iitk.ac.in",
+   "phone": "0512-259-7717",
+   "web": "https://home.iitk.ac.in/~dcrai/",
+   "office": "Office Structural Engineering Laboratory, Workshop II",
+   "research": "Structural Engineering",
+   "qualification": "PhD (University of Michigan Ann Arbor, USA)"
+  },
+  {
+   "name": "Gaurav Tiwari",
+   "title": "Associate Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/gaurav-tiwari",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "gauravt@iitk.ac.in",
+   "phone": "0512-259-2062",
+   "web": "https://gauravtiwariiitk.github.io/Website/index.html",
+   "office": "Office Western Laboratory Extension, Room-302A",
+   "research": "Rock Mechanics and Rock Engineering. Experimental Rock Mechanics. Probabilistic Rock Engineering.",
+   "qualification": "PhD, Geotechnical Engineering (Rock Mechanics), IISc Bangalore"
+  },
+  {
+   "name": "Gourabananda Pahar",
+   "title": "Associate Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/gourabananda-pahar",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "gpahar@iitk.ac.in",
+   "phone": "0512-259-2011",
+   "web": "https://home.iitk.ac.in/~gpahar/",
+   "office": "Office 308 Faculty Building",
+   "research": "Computational and Experimental Hydraulics Lagrangian Particle Methods",
+   "qualification": "PhD (IIT Kharagpur)"
+  },
+  {
+   "name": "Harish K. V.",
+   "title": "Associate Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/harish-k-venkatanarayanan",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "kvharish@iitk.ac.in",
+   "phone": "0512-259-6427",
+   "web": "https://home.iitk.ac.in/~kvharish/",
+   "office": "Office Room No. 334, Faculty Building",
+   "research": "Structural Engineering",
+   "qualification": "PhD (Civil Engineering, Clemson University)"
+  },
+  {
+   "name": "Hemant Gehlot",
+   "title": "Assistant Professor, Departement of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/hemant-gehlot",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "hemantg@iitk.ac.in",
+   "phone": "+91-5126792238",
+   "web": "https://sites.google.com/view/hemantgehlot/home",
+   "office": "Office Room: 302 Western Laboratory Extension,",
+   "research": "Transportation network modeling Combinatorial optimization Intelligent transportation systems Disaster management",
+   "qualification": "PhD, Purdue University, 2021"
+  },
+  {
+   "name": "Jagdish Prasad Sahoo",
+   "title": "Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/jagdish-prasad-sahoo",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "jpsahoo@iitk.ac.in",
+   "phone": "0512-259-2147",
+   "web": "https://sites.google.com/view/jagdish-prasad-sahoo",
+   "office": "Office Room no. 331, Faculty Building",
+   "research": "Foundation Engineering, Reinforced Earth Structures, Stability of Slopes and Underground Excavations, Pavement Geotechnics, Strength Behavior of Rock",
+   "qualification": "Ph.D. in Engineering (Specialization in Geotechnical Engg.)"
+  },
+  {
+   "name": "Kaushik Bhattacharjee",
+   "title": "Assistant Professor, Departement of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/kaushik-bhattacharjee",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "bkaushik@iitk.ac.in",
+   "phone": "+91-512-259-2668",
+   "office": "Room No. 704,",
+   "research": "Construction and Work Zone Safety Human Factors and Driver and Worker Behavior Construction Contracts Building Information Modeling (BIM) Workforce Training and Capacity Building Technology-Enabled Safety Management",
+   "qualification": "PhD (IIT Madras)"
+  },
+  {
+   "name": "Mukesh Sharma",
+   "title": "Emeritus Fellow, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/mukesh-sharma",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "mukesh@iitk.ac.in",
+   "phone": "0512-259-7759",
+   "web": "https://home.iitk.ac.in/~mukesh/",
+   "office": "Office 302 Western Laboratory Extension,",
+   "research": "Air Quality Modelling and Management, Fate Processes of Organic Pollutants and Parameter Estimation.",
+   "qualification": "PhD (University of Waterloo, Canada)"
+  },
+  {
+   "name": "Nihar Ranjan Patra",
+   "title": "Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/nihar-ranjan-patra",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "nrpatra@iitk.ac.in",
+   "phone": "0512-259-7623",
+   "web": "https://home.iitk.ac.in/~nrpatra/",
+   "office": "Office Room: FB-316,",
+   "research": "Pile Foundations, Soil Structure Interactions and Ground Engineering, Soil Arching, Liquefaction Potential Evaluation",
+   "qualification": "PhD (IIT Kharagpur)"
+  },
+  {
+   "name": "Onkar Dikshit",
+   "title": "Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/onkar-dikshit",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "onkar@iitk.ac.in",
+   "phone": "0512-259-793",
+   "office": "Office Room: 303A",
+   "research": "Remote Sensing Applications, SAR, Photogrammetry, GIS, GPS and DIP for Engineering and Natural Resource Management Problems.",
+   "qualification": "PhD (Cambridge University)"
+  },
+  {
+   "name": "Partha Chakroborty",
+   "title": "Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/partha-chakroborty",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "partha@iitk.ac.in",
+   "phone": "0512-259-7037",
+   "web": "https://home.iitk.ac.in/~partha/",
+   "research": "(i) Traffic flow theory (especially for streams where there is no lane-discipline and large geometry variations) (ii) Optimal resource allocation (in areas as diverse as railway operations and pavement management among others) (iii) Urban transit network routing and scheduling (iv) Mathematical modeling of traveler and driver choice processes",
+   "qualification": "PhD (University of Delaware, USA)"
+  },
+  {
+   "name": "Prabin Kumar Ashish",
+   "title": "Assistant Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/prabin-kumar-ashish",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "pkashish@iitk.ac.in",
+   "phone": "0512-259-2336",
+   "web": "https://sites.google.com/view/prabinashish/home",
+   "office": "Office Room: WLE 303B,",
+   "research": "Performance based mechanistic characterization of asphalt binder and mixes, Semi Flexible Pavement (SFP) based composite materials, Non-destructive methods for understanding pavement materials behavior, Bonding/debonding between aggregate and asphalt binder, Development of sustainable pavement materials.",
+   "qualification": "Ph.D"
+  },
+  {
+   "name": "Prishati Raychowdhury",
+   "title": "Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/prishati-raychowdhury",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "prishati@iitk.ac.in",
+   "phone": "0512-259-6692",
+   "web": "https://home.iitk.ac.in/~prishati/",
+   "office": "Office Faculty Building - #330,",
+   "research": "Soil Dynamics, Geotechnical Earthquake Engineering, Seismic Soil-Structure Interaction",
+   "qualification": "PhD (University of California, San Diego)"
+  },
+  {
+   "name": "Priyanka Ghosh",
+   "title": "Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/priyanka-ghosh",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "priyog@iitk.ac.in",
+   "phone": "0512-259-7022",
+   "web": "https://home.iitk.ac.in/~priyog/",
+   "office": "Office FB-335,",
+   "research": "Bearing Capacity of Foundations, Numerical Analysis, Retaining walls and Earth Pressure Theory, Pullout Resistance of Anchors, Stability of Slopes, Vibration Screening, Geopolymers",
+   "qualification": "PhD (IISc Bangalore)"
+  },
+  {
+   "name": "Purnendu Bose",
+   "title": "Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/purnendu-bose",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "pbose@iitk.ac.in",
+   "phone": "0512-259-7403",
+   "office": "Office 304 Western Laboratory Extension",
+   "research": "Physico-chemical processes for water and waste water treatment, Abiotic remediation of groundwater resources, Advanced oxidation processes for water and wastewater treatment.",
+   "qualification": "PhD (University of Massachusetts, Amherst, USA)"
+  },
+  {
+   "name": "Rajesh Sathiyamoorthy",
+   "title": "Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/rajesh-sathiyamoorthy",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "hsrajesh@iitk.ac.in",
+   "phone": "0512-259-6054",
+   "web": "https://home.iitk.ac.in/~hsrajesh/",
+   "office": "Office FB-309,",
+   "research": "Numerical and Physical Modelling Technique, Environmental Geotechnology, Ground Improvement Techniques, Unsaturated and Fundamental Soil Mechanics, Remote Sensing and GIS Applications in Geotechnical Engineering",
+   "qualification": "PhD (IIT Bombay)"
+  },
+  {
+   "name": "Richa Ojha",
+   "title": "Associate Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/richa-ojha",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "richao@iitk.ac.in",
+   "phone": "0512-259-6564",
+   "office": "Office Room: # 5 Hydraulics Lab",
+   "research": "Flow and transport in porous media, Scaling of hydrological processes, Hydrologic extremes",
+   "qualification": "PhD (Purdue University)"
+  },
+  {
+   "name": "Sachchida Nand Tripathi",
+   "title": "Professor, Department of Civil Engineering + Dean, Kotak School of Sustainability",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/sachchida-nand-tripathi",
+   "depts": [
+    "Civil Engineering",
+    "Kotak School of Sustainability"
+   ],
+   "email": "snt@iitk.ac.in",
+   "phone": "0512-259-7845",
+   "web": "https://home.iitk.ac.in/~snt/#/home",
+   "office": "Office Room No. 101, National Aerosol Facility, IIT Kanpur",
+   "research": "Climate Issues, Climate Modelling, Environment, Air Pollution",
+   "qualification": "PhD (Reading University, UK)"
+  },
+  {
+   "name": "Samit Ray Chaudhuri",
+   "title": "Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/samit-ray-chaudhuri",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "samitrc@iitk.ac.in",
+   "phone": "0512-259-7267",
+   "web": "https://home.iitk.ac.in/~samitrc/",
+   "office": "Office WLE 303G",
+   "research": "Structural Dynamics and Earthquake Engineering, Performance Evaluation of Structural and Nonstructural Components and Systems, Performance-Based Design and Structural Rehabilitation, Seismic Soil-Structure Interaction, Structural Health Monitoring, Structural Testing",
+   "qualification": "PhD (University of California, Irvine)"
+  },
+  {
+   "name": "Saumyen Guha",
+   "title": "Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/saumyen-guha",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "sguha@iitk.ac.in",
+   "phone": "0512-259-7917",
+   "web": "https://home.iitk.ac.in/~sguha/",
+   "office": "Office 303 F Western Laboratory Extension",
+   "research": "Subsurface Flow and Transport, Bioremediation of Toxic Organics in Natural Systems, Fate and Transport of Pesticides and Heavy Metals in the Natural Systems, Metal uptake in plants, Natural Isotopes",
+   "qualification": "PhD (Princeton University)"
+  },
+  {
+   "name": "Shivam Tripathi",
+   "title": "Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/shivam-tripathi",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "shiva@iitk.ac.in",
+   "phone": "0512-259-6709",
+   "web": "https://home.iitk.ac.in/~shiva/",
+   "office": "Office Room 6 Hydraulics Lab",
+   "research": "Statistical Hydrology, Sediment Transport, Eco-Hydrology",
+   "qualification": "PhD (Purdue University, USAM)"
+  },
+  {
+   "name": "Subhadip Das",
+   "title": "Assistant Professor, Departement of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/subhadip-das",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "subhadipd@iitk.ac.in",
+   "phone": "0512-259-2589",
+   "web": "https://sites.google.com/view/subhadipdas/home",
+   "office": "Office Room No. 604, National Aerosol Facility (NAF)",
+   "research": "Computational and experimental fluid dynamics Open channel flow Bluff body hydraulics Multiphase flow River mechanics and sediment transport",
+   "qualification": "PhD, University of Windsor, 2021"
+  },
+  {
+   "name": "Sudhir Mishra",
+   "title": "Emeritus Fellow, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/sudhir-mishra",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "sud@iitk.ac.in",
+   "phone": "0512-259-7346",
+   "web": "https://iitk.ac.in/ce/CIVIL/faculty/sud/index.php?option=com_content&amp;view=article&amp;id=2",
+   "office": "Office Room: 303C Western Laboratory Extension",
+   "research": "Durability and Deterioration of Concrete Structures, Non-Destructive Testing, Concrete Materials",
+   "qualification": "PhD (University of Tokyo)"
+  },
+  {
+   "name": "Sudib Kumar Mishra",
+   "title": "Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/sudib-kumar-mishra",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "smishra@iitk.ac.in",
+   "phone": "0512-2596731",
+   "web": "https://home.iitk.ac.in/~smishra/",
+   "office": "Office FB-305,",
+   "research": "Structural Dynamics and Vibration Structural Health Monitoring Probabilistic Safety Assessment Instability in Structures Multi-scale Modeling",
+   "qualification": "Ph.D (University of Arizona, Tucson, USA)"
+  },
+  {
+   "name": "Suparno Mukhopadhyay",
+   "title": "Associate Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/suparno-mukhopadhyay",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "suparno@iitk.ac.in",
+   "phone": "0512-259-6886",
+   "office": "Office Room No. 303 Faculty Building",
+   "research": "Structural Identification and Health Monitoring Structural Dynamics Earthquake Engineering",
+   "qualification": "PhD (Columbia University)"
+  },
+  {
+   "name": "Syam Nair",
+   "title": "Associate Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/syam-nair",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "syamnair@iitk.ac.in",
+   "phone": "0512-259-6421",
+   "office": "Office FB-489,",
+   "research": "Pavements and Materials Engineering",
+   "qualification": "PhD (Texas A&M University, College Station, Texas, USA)"
+  },
+  {
+   "name": "Tarun Gupta",
+   "title": "Professor, Departement of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/tarun-gupta",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "tarun@iitk.ac.in",
+   "phone": "0512-259-7128",
+   "web": "https://iitk.irins.org/profile/52991",
+   "office": "Office FB-310,",
+   "research": "Development of instruments for aerosol measurement, Engineering control of particles in ambient and indoor settings, Physico-chemical characterization of atmospheric pollutants formation of secondary organic aerosol, Personal exposure assessment and health effects of inhaled particles, Source apportionment of air pollution formation and control of engine exhaust emissions, and risk assessment.",
+   "qualification": "PhD (Harvard University)"
+  },
+  {
+   "name": "Tushar Apurv",
+   "title": "Assistant Professor, Departement of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/tushar-apurv",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "tusharap@iitk.ac.in",
+   "phone": "+91-512-259-2176",
+   "web": "https://sites.google.com/view/tusharap/home",
+   "office": "Office :",
+   "research": "Drought risk management, hydro-climatology, water resources systems analysis, hydrologic modelling",
+   "qualification": "PhD - University of Illinois"
+  },
+  {
+   "name": "Venkatesan Kanagaraj",
+   "title": "Associate Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/venkatesan-kanagaraj",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "venkatk@iitk.ac.in",
+   "phone": "0512-259-2096",
+   "office": "Office 604,",
+   "research": "Traffic Flow Theory Crowd Dynamics Connected and Autonomous Vehicles",
+   "qualification": "PhD (IIT Madras)"
+  },
+  {
+   "name": "Vinay Kumar Gupta",
+   "title": "Professor, Department of Civil Engineering",
+   "dept": "Civil Engineering",
+   "url": "https://www.iitk.ac.in/vinay-kumar-gupta",
+   "depts": [
+    "Civil Engineering"
+   ],
+   "email": "vinaykg@iitk.ac.in",
+   "phone": "0512-259-7118",
+   "web": "https://home.iitk.ac.in/~vinaykg/",
+   "office": "Office Workshop Building II",
+   "research": "Random Vibrations, Earthquake Engineering",
+   "qualification": "PhD (University of Southern California, USA)"
+  },
+  {
+   "name": "Dr. Pravesh K.Kothari",
+   "title": "Adjunct Assistant Professor, Department of Computer Science & Engineering",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/dr-pravesh-k-kothari",
+   "depts": [
+    "Computer Science & Engineering"
+   ]
+  },
+  {
+   "name": "Gunjan Kumar",
+   "title": "Assistant Professor, Department of Computer Science & Engineering",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/gunjan-kumar",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
+   "email": "gunjan@iitk.ac.in"
+  },
+  {
+   "name": "M A K P Singh",
+   "title": "Visiting Professor of Practice, Department of Computer Science and Engineering",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/m-a-k-p-singh",
+   "depts": [
+    "Computer Science & Engineering"
+   ]
+  },
+  {
+   "name": "Mainak Chaudhuri",
+   "title": "Professor, Department of Computer Science and Engineering",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/dr-mainak-chaudhuri",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
+   "email": "mainakc@iitk.ac.in",
+   "phone": "0512-259-7890",
+   "web": "https://www.cse.iitk.ac.in/users/mainakc/",
+   "office": "Office CS-211,",
+   "research": "Computer Architecture.",
+   "qualification": "PhD (Cornell University)"
+  },
+  {
+   "name": "Preeti Malakar",
+   "title": "Assistant Professor, Department of Computer Science & Engineering",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/preeti-malakar",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
+   "email": "pmalakar@iitk.ac.in",
+   "phone": "0512-259-2024",
+   "research": "High Performance Computing, Scalable Parallel Communication and Workflow Optimization",
+   "qualification": "PhD (Indian Institute of Science Bangalore)"
+  },
+  {
+   "name": "Pritam Choudhury",
+   "title": "Assistant Professor, Department of Computer Science & Engineering",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/pritam-choudhury",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
+   "email": "pritam@iitk.ac.in",
+   "phone": "0512-259-2152",
+   "web": "https://www.cse.iitk.ac.in/users/pritam/",
+   "office": "KD-318, Department of Computer Science and Engineering",
+   "research": "Programming Languages, Type Theory, Static Analyses, Language-Based Security, Formal Verification, Logic and Formal Methods in Indian Knowledge Traditions",
+   "qualification": "PhD. University of Pennsylvania, US"
+  },
+  {
+   "name": "Priyanka Vijay Bagade",
+   "title": "Assistant Professor, Department of Computer Science & Engineering",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/priyanka-bagade",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
+   "email": "pbagade@iitk.ac.in",
+   "phone": "0512-259-2206",
+   "research": "Internet of things, Sensors, Mobile Computing and Deep Learning",
+   "qualification": "PhD (Arizona State University)"
+  },
+  {
+   "name": "Purushottam Kar",
+   "title": "",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/purushottam-kar",
+   "depts": [
+    "Computer Science & Engineering"
+   ]
+  },
+  {
+   "name": "Raghunath Tewari",
+   "title": "Professor, Department of Computer Science and Engineering",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/dr-raghunath-tewari",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
+   "email": "rtewari@iitk.ac.in",
+   "phone": "0512-259-7174",
+   "web": "https://www.cse.iitk.ac.in/users/rtewari/",
+   "office": "Office RM 514,",
+   "research": "Computational Complexity Theory, Graph Theory.",
+   "qualification": "PhD (University of Nebraska - Lincoln)"
+  },
+  {
+   "name": "Rajat Mittal",
+   "title": "Associate Professor, Department of Computer Science and Engineering",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/dr-rajat-mittal",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
+   "email": "rmittal@iitk.ac.in",
+   "phone": "0512-259-6210",
+   "web": "https://www.cse.iitk.ac.in/users/rmittal/",
+   "office": "Office RM 202,",
+   "research": "Computational Complexity, Quantum Computing and Semidefinite Programming.",
+   "qualification": "PhD (Rutgers University)"
+  },
+  {
+   "name": "Rajat Moona",
+   "title": "Professor (Computer Science and Engineering) is present Director of IIT Gandhinagar.",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/dr-rajat-moona",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
+   "email": "moona@iitk.ac.in",
+   "phone": "0512-259-7652",
+   "web": "https://www.cse.iitk.ac.in/users/moona/",
+   "office": "Office CS 221,",
+   "research": "Computer Hardware and Architecture, VLSI Design.",
+   "qualification": "PhD (IISc Bangalore)"
+  },
+  {
+   "name": "Sanjeev Saxena",
+   "title": "Professor, Department of Computer Science and Engineering",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/dr-sanjeev-saxena",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
+   "email": "ssax@iitk.ac.in",
+   "phone": "0512-259-7611",
+   "web": "https://www.cse.iitk.ac.in/users/ssax/",
+   "office": "Office CS 226,",
+   "research": "Parallel Processing, VLSI, Data Structures, Algorithms, Heuristics.",
+   "qualification": "PhD (IIT Delhi)"
+  },
+  {
+   "name": "Satyadev Nandakumar",
+   "title": "Professor, Department of Computer Science and Engineering",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/dr-satyadev-nandakumar",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
+   "email": "satyadev@iitk.ac.in",
+   "phone": "0512-259-7619",
+   "web": "https://www.cse.iitk.ac.in/users/satyadev/",
+   "office": "Office 312 H. R. Kadim Diwan Building,",
+   "research": "Theoretical Computer Science, Algorithmic Information Theory, Computible Analysis.",
+   "qualification": "PhD (Iowa State University)"
+  },
+  {
+   "name": "Sayak Ray Chowdhury",
+   "title": "Assistant Professor, Department of Computer Science & Engineering",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/sayak-ray-chowdhury",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
+   "email": "sayakrc@iitk.ac.in",
+   "phone": "5122592575",
+   "web": "https://sites.google.com/view/sayakraychowdhury/home",
+   "office": "KD 223, H.R. Kadim Diwan Building",
+   "research": "Sequential Decision making, Language Model Optimization, Privacy, Safety, and Fairness",
+   "qualification": "PhD (Indian Institute of Science, Bangalore)"
+  },
+  {
+   "name": "Soumya Dutta",
+   "title": "Assistant Professor, Department of Computer Science & Engineering",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/soumya-dutta",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
+   "email": "soumyad@iitk.ac.in",
+   "phone": "0512-259-2348",
+   "web": "https://soumyadutta-cse.github.io/",
+   "office": "KD-224,",
+   "research": "Machine Learning, Visual Computing and Image Analysis, Big Data Visualization and Analytics, Data Science, HPC, Uncertainty Quantification, Explainability and Interpretability of AI Models.",
+   "qualification": "PhD (Ohio State University)"
+  },
+  {
+   "name": "Sruti Srinivasa Ragavan",
+   "title": "Assistant Professor, Department of Computer Science & Engineering +",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/sruti-srinivasa-ragavan",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
+   "email": "srutis@iitk.ac.in",
+   "phone": "0512-259-2231",
+   "research": "Human Factors in Computing, Software Engineering and End-user Computing",
+   "qualification": "PhD"
+  },
+  {
+   "name": "Subhajit Roy",
+   "title": "Professor, Department of Computer Science and Engineering",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/dr-subhajit-roy",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
+   "email": "subhajit@iitk.ac.in",
+   "phone": "0512-259-7585",
+   "office": "Office CS 303,",
+   "research": "Compilers, Program Analysis & Code Optimization",
+   "qualification": "PhD (IISc)"
+  },
+  {
+   "name": "Sumit Ganguly",
+   "title": "Professor, Department of Computer Science and Engineering",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/dr-sumit-ganguly",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
+   "email": "sganguly@iitk.ac.in",
+   "phone": "0512-259-7597",
+   "web": "https://www.cse.iitk.ac.in/users/sganguly/",
+   "office": "Office CS 303,",
+   "research": "Databases.",
+   "qualification": "PhD (University of Texas, Austin)"
+  },
+  {
+   "name": "Sunil Easaw Simon",
+   "title": "Associate Professor, Department of Computer Science and Engineering",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/dr-sunil-easaw-simon",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
+   "email": "simon@iitk.ac.in",
+   "phone": "0512-259-7975",
+   "web": "https://www.cse.iitk.ac.in/users/simon/",
+   "office": "Office CS 206,",
+   "research": "Game Theory, Distributed Systems, Temporal Logics and Verification",
+   "qualification": "PhD (Institute of Mathematical Sciences)"
+  },
+  {
+   "name": "Surender Baswana",
+   "title": "Professor, Department of Computer Science and Engineering",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/dr-surender-baswana",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
+   "email": "sbaswana@iitk.ac.in",
+   "phone": "0512-259-6074",
+   "web": "https://www.cse.iitk.ac.in/users/sbaswana/",
+   "office": "Office CS 307,",
+   "research": "Graph algorithms, randomized algorithms, and dynamic algorithms.",
+   "qualification": "PhD (IIT Delhi)"
+  },
+  {
+   "name": "Sutanu Gayen",
+   "title": "Assistant Professor, Department of Computer Science & Engineering",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/sutanu-gayen",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
+   "email": "sutanu@iitk.ac.in",
+   "phone": "0512-259-2276",
+   "web": "https://www.cse.iitk.ac.in/users/sutanu/",
+   "office": "Department of Computer Science and Engineering",
+   "research": "Foundations of Machine Learning and Probabilistic Algorithms",
+   "qualification": "PhD"
+  },
+  {
+   "name": "Swarnendu Biswas",
+   "title": "Assistant Professor, Department of Computer Science and Engineering",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/swarnendu-biswas",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
+   "email": "swarnendu@cse.iitk.ac.in",
+   "phone": "0512-259-2055",
+   "web": "https://www.cse.iitk.ac.in/users/swarnendu/",
+   "office": "KD 302, Department of CSE,",
+   "research": "Programming Languages, Compilers and Runtime Systems, Parallel Software systems",
+   "qualification": "PhD"
+  },
+  {
+   "name": "Urbi Chatterjee",
+   "title": "Assistant Professor, Department of Computer Science & Engineering",
+   "dept": "Computer Science & Engineering",
+   "url": "https://www.iitk.ac.in/urbi-chatterjee",
+   "depts": [
+    "Computer Science & Engineering"
+   ],
+   "email": "urbic@iitk.ac.in",
+   "phone": "0512-259-2211",
+   "research": "Hardware Security, Physically Unclonable Functions, Secure Authentication Protocols Design and Internet of Things Security",
+   "qualification": "PhD (Indian Institute of Technology Kharagpur )"
+  },
+  {
+   "name": "Satyaki Roy",
+   "title": "Professor, Department of Design",
+   "dept": "Design",
+   "url": "https://www.iitk.ac.in/satyaki-roy",
+   "depts": [
+    "Design"
+   ],
+   "email": "satyaki@iitk.ac.in",
+   "phone": "0512-259-4060",
+   "web": "https://home.iitk.ac.in/~satyaki/",
+   "office": "Dept of Humanities & Social Sciences/",
+   "research": "Visual Communication, Folk Art and Crafts, Creativity, Film Making , Design Thinking , User Experience Design",
+   "qualification": "PhD (Kala Bhavana, Visva Bharati, Santiniketan.)"
+  },
+  {
+   "name": "Shatarupa Thakurta Roy",
+   "title": "Associate Professor, Department of Design",
+   "dept": "Design",
+   "url": "https://www.iitk.ac.in/shatarupa-thakurta-roy",
+   "depts": [
+    "Design"
+   ],
+   "email": "stroy@iitk.ac.in",
+   "phone": "0512-259-7145",
+   "web": "https://home.iitk.ac.in/~stroy/",
+   "office": "Office Office address: 671, Faculty Building",
+   "research": "History of Art, Art Appreciation, Design Theory, Visual Culture, Visual Communication",
+   "qualification": "PhD (IIT Guwahati, 2014)"
+  },
+  {
+   "name": "Shoubhik Dutta Roy",
+   "title": "Assistant Professor, Department of Design",
+   "dept": "Design",
+   "url": "https://www.iitk.ac.in/shoubhik-dutta-roy",
+   "depts": [
+    "Design"
+   ]
+  },
+  {
+   "name": "Subhajit Chandra",
+   "title": "Assistant Professor, Department of Design",
+   "dept": "Design",
+   "url": "https://www.iitk.ac.in/subhajit-chandra",
+   "depts": [
+    "Design"
+   ]
+  },
+  {
+   "name": "Vivek Kant",
+   "title": "Associate Professor, Department of Design",
+   "dept": "Design",
+   "url": "https://www.iitk.ac.in/vivek-kant",
+   "depts": [
+    "Design"
+   ],
+   "email": "vkant@iitk.ac.in"
+  },
+  {
+   "name": "Arnab Bose",
+   "title": "Assistant Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/arnab-bose",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "abose@iitk.ac.in",
+   "phone": "+91-512-259-2411",
+   "web": "https://sites.google.com/view/bose-spinlab/",
+   "office": "Office",
+   "research": "Spin-based electronics, Fabrication and characterization of nanoscale devices, 2D material heterostructure, topological quantum materials, generation of unconventional spin current, altermagnets, MTJs, spin-caloritronics, spin-orbitronics, spin-mechatronics, chiral spin textures among others.",
+   "qualification": "PhD (IIT Bombay)"
+  },
+  {
+   "name": "Ashwin Kumar Ramakrishnan Sivakumar",
+   "title": "Assistant Professor, Department of Electrical Engineering.",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/r-s-ashwin-kumar",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "ashwinrs@iitk.ac.in",
+   "phone": "+91-512-259-2165",
+   "web": "https://home.iitk.ac.in/~ashwinrs",
+   "office": "Office",
+   "research": "Analog-to-digital converters, biomedical circuits, and signal processing.",
+   "qualification": "PhD (IIT Madras)"
+  },
+  {
+   "name": "Avinash Lahgere",
+   "title": "Assistant Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/avinash-lahgere",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "alahgere@iitk.ac.in",
+   "phone": "+91-512-679-2302",
+   "web": "https://home.iitk.ac.in/~alahgere/avinash.html",
+   "office": "Office ACES 401B,",
+   "research": "Semiconductor Devices, Compact Modeling, Emerging CMOS Devices, Emerging Volatile-Nonvolatile Memory, Variation, PPA Benchmarking, Analog/RF, and Neuromorphic computing",
+   "qualification": "Ph.D. in Electrical Engineering, Indian Institute of Technology Delhi"
+  },
+  {
+   "name": "Baquer Mazhari",
+   "title": "Professor, Departement of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/baquer-mazhari",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "baquer@iitk.ac.in",
+   "phone": "0512-259-7924",
+   "web": "https://home.iitk.ac.in/~baquer/",
+   "office": "Office WL-123,",
+   "research": "Organic Electronics",
+   "qualification": "PhD ( University of Illinois at Urbana Champaign)"
+  },
+  {
+   "name": "Chithra",
+   "title": "Assistant Professor, Department of Electrical Engineering.",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/chithra",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "chithra@iitk.ac.in",
+   "phone": "+91-512-259-2199",
+   "web": "https://home.iitk.ac.in/~chithra/",
+   "office": "WL-211,",
+   "research": "Analog and mixed-signal VLSI design, digital VLSI design, frequency and phase synthesis, time-to-digital converters",
+   "qualification": "PhD (IIT Madras)"
+  },
+  {
+   "name": "Debdatta Ray",
+   "title": "Assistant Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/debdatta-ray",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "dray@iitk.ac.in",
+   "phone": "+91-512-679-2487",
+   "office": "Office 411",
+   "research": "Nanophotonics, Optical Metasurfaces, Nanofabrication, Optical Spin orbit coupling"
+  },
+  {
+   "name": "Dr. Tushar Balasaheb Sandhan",
+   "title": "Associate Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/tushar-sandhan",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "sandhan@iitk.ac.in",
+   "phone": "+91-512-2592240",
+   "web": "https://home.iitk.ac.in/~sandhan/",
+   "office": "408-B,",
+   "research": "Computer vision, Machine learning, AI in healthcare and AI in robotics",
+   "qualification": "PhD (Seoul National University, South Korea)"
+  },
+  {
+   "name": "Dr. Udaya Parampalli",
+   "title": "Distinguished Visiting Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/dr-udaya-parampalli",
+   "depts": [
+    "Electrical Engineering"
+   ]
+  },
+  {
+   "name": "Dr. Vijay Vittal",
+   "title": "Distinguished Visiting Professor, Departement of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/dr-vijay-vittal",
+   "depts": [
+    "Electrical Engineering"
+   ]
+  },
+  {
+   "name": "Ebin Cherian Mathew",
+   "title": "Assistant Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/ebin-cherian-mathew",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "ebincm@iitk.ac.in",
+   "phone": "+91-512-679-2498",
+   "web": "https://home.iitk.ac.in/~ebincm/",
+   "office": "Office ACES 105A",
+   "research": "HVDC and MVDC transmission systems, Fault tolerant modular converters for high-power applications, Medium and high-power DC-DC converters, Application of Power Electronics in Power Systems, Planning and operation of bulk power systems, Power Electronics dominated Grid."
+  },
+  {
+   "name": "Gururaj Mirle Vishwanath",
+   "title": "Assistant Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/gururaj-mirle-vishwanath",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "gururajmv@iitk.ac.in",
+   "phone": "0512-259-7131",
+   "web": "https://home.iitk.ac.in/~gururajmv/",
+   "office": "Office ACES 103A,",
+   "research": "Renewable penetration challenges to the grid, Machine learning applications to power systems, Power Converters for EV and its interfacing challenges, Power Electronics Applications to Power Systems, Microgrid Control (Black out, Islanded Operation, EMS), Stability.",
+   "qualification": "PhD (IIT Roorkee)"
+  },
+  {
+   "name": "Imon Mondal",
+   "title": "Associate Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/imon-mondal",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "imon@iitk.ac.in",
+   "phone": "+91-512-259-7732",
+   "research": "Analog and mixed signal circuit design.",
+   "qualification": "PhD (IIT Madras)"
+  },
+  {
+   "name": "Kasturi Vasudevan",
+   "title": "Professor, Departement of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/k-vasudevan",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "vasu@iitk.ac.in",
+   "phone": "0512-259-7109",
+   "web": "https://home.iitk.ac.in/~vasu/",
+   "office": "Office Room No ACES 303B",
+   "research": "Digital communications, Coherent & noncoherent receivers, Synchronization, Channel estimation Diversity techniques",
+   "qualification": "PhD (IIT Madras)"
+  },
+  {
+   "name": "Koteswar Rao Jerripothula",
+   "title": "Associate Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/koteswar-rao-jerripothula",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "kotesrj@iitk.ac.in",
+   "phone": "+91-512-259-2483",
+   "web": "https://sites.google.com/site/koteswarraojerripothula/",
+   "office": "#302, ACES Building,",
+   "research": "Computer Vision & Image Processing Multimedia Computing & Systems A rtificial Intelligence & Machine Learning Medical Imaging & Informatics",
+   "qualification": "PhD (NTU Singapore)"
+  },
+  {
+   "name": "Kumar Vaibhav Srivastava",
+   "title": "Professor, Departement of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/k-v-srivastava",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "kvs@iitk.ac.in",
+   "phone": "0512-259-7105",
+   "web": "https://home.iitk.ac.in/~kvs/",
+   "office": "Office ACES-328,",
+   "research": "Meta-Materials, Microwave Antennas, Microwave Absorbers, Microwave Cloaking, Finite-Difference Time-Domain (FD-TD) Technique, Electromagnetics",
+   "qualification": "PhD (IIT Kanpur)"
+  },
+  {
+   "name": "Laxmidhar Behera",
+   "title": "Professor (Electrical Engineering), Currently on Deputation as Director, IIT Mandi",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/laxmidhar-behera",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "lbehera@iitk.ac.in",
+   "phone": "0512-259-7198",
+   "web": "https://home.iitk.ac.in/~lbehera/",
+   "office": "Office Department of Electrical Engineering (ACES building).",
+   "research": "Intelligent Systems and Control, Cognitive Robotics, Nano-robotics, Vision based Control, Soft Computing, Information Retrieval in music and language, Semantic Information Processing, Physics of Complex Systems, Cyber Physical Systems, Formation Control of UAVs, Brain-Computer Interface (BCI), Sanskrit Computational Linguistics.",
+   "qualification": "PhD (IIT Delhi)"
+  },
+  {
+   "name": "Mohit D. Ganeriwala",
+   "title": "Assistant Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/mohit-d-ganeriwala",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "mohitdg@iitk.ac.in",
+   "phone": "0512-259-2622",
+   "web": "https://home.iitk.ac.in/~mohitdg",
+   "office": "Office: 202, ACES Building",
+   "research": "Multiscale-Atomistic, Numerical and Compact Modeling, TCAD, Electrical characterization, Neuromorphic Computing, Two-dimensional Materials and Advanced nanoscale FETs",
+   "qualification": "PhD. Electrical Engineering (IIT Gandhinagar)"
+  },
+  {
+   "name": "Nagaditya Poluri",
+   "title": "Assistant Professor, Departement of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/nagaditya-poluri",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "npoluri@iitk.ac.in",
+   "phone": "+91-512-679-2450",
+   "web": "https://home.iitk.ac.in/~npoluri/",
+   "office": "ACES 225A,"
+  },
+  {
+   "name": "Nagarjuna Nallam",
+   "title": "Associate Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/nagarjuna-nallam",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "nallam@iitk.ac.in",
+   "web": "https://home.iitk.ac.in/~nallam/",
+   "office": "226, ACES Building",
+   "research": "Analog, RF, and mm-Wave Integrated Circuits"
+  },
+  {
+   "name": "Nandini Gupta",
+   "title": "Professor, Departement of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/nandini-gupta",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "ngupta@iitk.ac.in",
+   "phone": "0512-259-7511",
+   "web": "https://nandinigupta.netlify.app/",
+   "office": "Office",
+   "research": "High Voltage Engineering, dielectric and Insulation, Plasma and gas discharges,Field estimation.",
+   "qualification": "PhD (IISc Bangalore)"
+  },
+  {
+   "name": "Nishchal Kumar Verma",
+   "title": "Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/nishchal-verma",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "nishchal@iitk.ac.in",
+   "phone": "0512-259-6524",
+   "web": "https://www.iitk.ac.in/idea/",
+   "office": "Office 107-ACES Building,",
+   "research": "Intelligent Data mining Algorithms and applications, Health Monitoring and Intelligent Fault Diagnosis Systems, Soft-Computing in Modelling and Control, Machine Learning Algorithms, Computer Vision, Bioinformatics, Smart Grid, Intelligent Agents and their Applications, Intelligent Informatics, Fuzzy Controllers, Image frame generation, Brain Computer/ Machine Interface, Unmanned Aerial Vehicles",
+   "qualification": "PhD (IIT Delhi)"
+  },
+  {
+   "name": "Parthasarathi Sensarma",
+   "title": "Professor, Departement of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/parthasarathi-sensarma",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "sensarma@iitk.ac.in",
+   "phone": "0512-259-7076",
+   "web": "https://home.iitk.ac.in/~sensarma/",
+   "office": "Office",
+   "research": "Power Electronic Applications to Power Systems,Power Quality,FACTS devices,Power Supplies, Utility Interfaces for Renewable Generation",
+   "qualification": "PhD (IISc Bangalore)"
+  },
+  {
+   "name": "Piyush Kant",
+   "title": "Assistant Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/piyush-kant",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "piyushkant@iitk.ac.in",
+   "phone": "+91-512-259-2308",
+   "web": "https://home.iitk.ac.in/~piyushkant/",
+   "office": "Office ACES-205B",
+   "research": "Multi-winding transformers for multi-pulse AC-DC converters, Multi-level inverters, Modulation techniques, Medium voltage drives, Electrical machines and drives, Motor control algorithms for electric vehicles",
+   "qualification": "PhD (IIT Delhi)"
+  },
+  {
+   "name": "Raghvendra Kumar Chaudhary",
+   "title": "Associate Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/raghvendra-kumar-chaudhary",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "raghvendra@iitk.ac.in",
+   "phone": "0512-679-2306",
+   "web": "https://home.iitk.ac.in/~raghvendra/",
+   "office": "Office ACES-325A,",
+   "research": "Reconfigurable Active Antenna, Multifunctional/Smart Metamaterial Antenna, Compact MIMO Antenna, Frequency Selective Surface, and Circularly Polarized Antenna, Dielectric Resonator Antenna, mm-wave & THz passive components.",
+   "qualification": "PhD (IIT Kanpur)"
+  },
+  {
+   "name": "Rajesh Mahanand Hegde",
+   "title": "Professor, Departement of Electrical Engineering + Adjunct Faculty in Kotak School of Sustainable (KSS)",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/rajesh-m-hegde",
+   "depts": [
+    "Electrical Engineering",
+    "Kotak School of Sustainability"
+   ],
+   "email": "rhegde@iitk.ac.in",
+   "phone": "0512-259-6248",
+   "web": "https://home.iitk.ac.in/~rhegde/",
+   "office": "Office ACES 203-B,",
+   "qualification": "PhD (IIT Madras)"
+  },
+  {
+   "name": "Ramprasad Potluri",
+   "title": "Associate Professor, Departement of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/ramprasad-potluri",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "potluri@iitk.ac.in",
+   "phone": "0512-259-6093",
+   "web": "https://home.iitk.ac.in/~potluri/",
+   "office": "Western Labs 217A,",
+   "research": "Practical applications of Control Systems theory",
+   "qualification": "PhD (University of Kentucky, USA)"
+  },
+  {
+   "name": "Rik Dey",
+   "title": "Assistant Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/rik-dey",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "rikdey@iitk.ac.in",
+   "phone": "+91-512-259-0063",
+   "research": "Topological Insulators, Transition Metal Chalcogenides and Di-Chalcogenides, Fabrication, Characterization and Analysis of micro and nano devices.",
+   "qualification": "PhD (University of Texas at Austin, UT Austin)"
+  },
+  {
+   "name": "Rituraj",
+   "title": "Assistant Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/rituraj",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "rituraj@iitk.ac.in",
+   "phone": "+91-512-259-2068",
+   "web": "https://home.iitk.ac.in/~rituraj/",
+   "office": "Office ACES 410",
+   "research": "Nanophotonics, Optoelectronic devices, Quantum optics, Waveguide quantum electrodynamics",
+   "qualification": "Ph.D. in EE"
+  },
+  {
+   "name": "Saikat Chakrabarti",
+   "title": "Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/saikat-chakrabarti",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "saikatc@iitk.ac.in",
+   "phone": "0512-259-6598",
+   "web": "https://saikatchakrabarti.github.io/",
+   "office": "Details can be found in the link: https://saikatchakrabarti.github.io/",
+   "research": "State estimation of transmission and distribution systems Stability and control of power systems with penetration of renewable energy Operation and control of microgrids Modelling of generators and loads, planning and operation of distribution systems Planning and operation of distribution systems",
+   "qualification": "PhD (Memorial University of Newfoundland, Canada)"
+  },
+  {
+   "name": "Shilpi Gupta",
+   "title": "Associate Professor, Department of Electrical Engineering + Photonics Science and Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/shilpi-gupta",
+   "depts": [
+    "Electrical Engineering",
+    "Photonics Science and Engineering Programme"
+   ],
+   "email": "shilpig@iitk.ac.in",
+   "phone": "0512-679-6231",
+   "web": "https://sites.google.com/site/labquantumphotonics/",
+   "office": "Office",
+   "research": "Photonics, Plasmonics, Quantum optics",
+   "qualification": "PhD (University of Maryland College Park)"
+  },
+  {
+   "name": "Shubham Sahay",
+   "title": "Associate Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/shubham-sahay",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "ssahay@iitk.ac.in",
+   "phone": "0512-259-2148",
+   "web": "https://home.iitk.ac.in/~ssahay/",
+   "office": "Office WL 121-A",
+   "research": "Hardware Platforms for Neuromorphic Computing, Hardware Security Primitives, Novel Device Architectures for Scaling CMOS Technology, Analytical and Compact Modeling of Semiconductor Devices, Non-volatile Memories, and Spintronics.",
+   "qualification": "PhD (IIT Delhi)"
+  },
+  {
+   "name": "Shyama Prasad Das",
+   "title": "Professor, Departement of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/shyama-prasad-das",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "spdas@iitk.ac.in",
+   "phone": "0512-259-7106",
+   "office": "Office WL 111B ,",
+   "research": "Power electronics, Electric Drives, Electrical machines, Microprocessor Systems & instrumentation",
+   "qualification": "PhD (IIT Kharagpur)"
+  },
+  {
+   "name": "Sri Niwas Singh",
+   "title": "Professor (Electrical Engineering), Currently on Deputation as Director, ABV-IIITM",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/sri-niwas-singh",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "snsingh@iitk.ac.in",
+   "phone": "0512-259-7009",
+   "web": "https://home.iitk.ac.in/~snsingh/",
+   "office": "Office Department of Electrical Engineering,",
+   "research": "Power System Restructuring, FACTS Technology, Optimal Power Dispatch and Security Analysis, Power System Dynamics, Operation and Control, Distribution System Planning and Demand Side Management, Application of Genetic Algorithms and Artificial Neural Networks in Power Systems",
+   "qualification": "PhD (IIT Kanpur)"
+  },
+  {
+   "name": "Subrahmanya Swamy Peruru",
+   "title": "Assistant Professor, Departement of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/subrahmanya-swamy-peruru",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "swamyp@iitk.ac.in",
+   "phone": "+91-512-259-2189",
+   "web": "https://swamypiitk.wixsite.com/subrahmanya-swamy-pe",
+   "office": "Office ACES-404,",
+   "research": "Wireless Networks, Artificial Intelligence and Probabilistic Graphical Models.",
+   "qualification": "PhD (Indian Institute of Technology Madras)"
+  },
+  {
+   "name": "Subramaniam Sundar Kumar Iyer",
+   "title": "Professor, Departement of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/sundar-kumar-iyer",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "sskiyer@iitk.ac.in",
+   "web": "https://home.iitk.ac.in/~sskiyer/",
+   "office": "Office WL 122",
+   "research": "Organic solar cells , Photovoltaic systems ,Printable electronics,VLSI technology, devices and circuits",
+   "qualification": "PhD (University of California, USA)"
+  },
+  {
+   "name": "Suvendu Samanta",
+   "title": "Associate Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/suvendu-samanta",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "suvendus@iitk.ac.in",
+   "phone": "0512-679-2130",
+   "web": "https://home.iitk.ac.in/~suvendus/",
+   "office": "Office ACES 401A,",
+   "research": "Power Electronics Electric Vehicles Wireless Power Transfer Resonant Converters with WBG Devices",
+   "qualification": "Ph.D. (Concordia University, Montreal, Canada)"
+  },
+  {
+   "name": "Swathi Battula",
+   "title": "Assistant Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/swathi-battula",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "swathi@iitk.ac.in",
+   "phone": "+91-512-259-2282",
+   "web": "https://home.iitk.ac.in/~swathi/",
+   "office": "Office ACES 103B",
+   "research": "Electricity Markets, Modelling and Design of Electrical Energy Systems, Transactive Energy System Design, Integrated Transmission and Distribution Systems, Energy Policy and Management",
+   "qualification": "PhD in Electrical Engineering, Iowa State University in 202"
+  },
+  {
+   "name": "Twinkle Tripathy",
+   "title": "Assistant Professor, Departement of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/twinkle-tripathy",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "ttripathy@iitk.ac.in",
+   "phone": "+91-512-679-2201",
+   "web": "https://sites.google.com/view/twinkletripathy/home",
+   "office": "Office ACES 412A,",
+   "research": "Guidance of autonomous vehicles, Formation control problems in multi-agent systems Study of nonholonomic systems Missile guidance"
+  },
+  {
+   "name": "Utsab Kundu",
+   "title": "Assistant Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/utsab-kundu",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "ukundu@iitk.ac.in",
+   "phone": "+91-512-259-2572",
+   "web": "https://home.iitk.ac.in/~ukundu/",
+   "office": "WLE 211,",
+   "research": "Applications of resonant converters, Power management ICs, Wireless power transfer technology",
+   "qualification": "PhD (IIT Kanpur)"
+  },
+  {
+   "name": "Vipul Arora",
+   "title": "Associate Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/vipul-arora",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "vipular@iitk.ac.in",
+   "phone": "+91-512-259-2056",
+   "research": "Audio scene analysis, generative machine learning, automatic speech recognition, music information retrieval, machine learning for Physics (quantum chromodynamics and statistical Physics)",
+   "qualification": "PhD (IIT Kanpur)"
+  },
+  {
+   "name": "Washim Uddin Mondal",
+   "title": "Assistant Professor, Department of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/washim-uddin-mondal",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "wmondal@iitk.ac.in",
+   "phone": "+91-512-679-2488",
+   "web": "https://home.iitk.ac.in/~wmondal/",
+   "office": "Office Office: ACES 307B",
+   "research": "Reinforcement Learning, Wireless Communications",
+   "qualification": "PhD (IIT Kharagpur)"
+  },
+  {
+   "name": "Yatindra Nath Singh",
+   "title": "Professor, Departement of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/y-n-singh",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "ynsingh@iitk.ac.in",
+   "phone": "0512-679-7944",
+   "web": "https://home.iitk.ac.in/~ynsingh/",
+   "office": "EE/ACES,",
+   "qualification": "PhD (IIT Delhi)"
+  },
+  {
+   "name": "Yogesh Singh Chauhan",
+   "title": "Professor & Head, Departement of Electrical Engineering",
+   "dept": "Electrical Engineering",
+   "url": "https://www.iitk.ac.in/yogesh-singh-chauhan",
+   "depts": [
+    "Electrical Engineering"
+   ],
+   "email": "chauhan@iitk.ac.in",
+   "phone": "0512-259-7244",
+   "web": "https://home.iitk.ac.in/~chauhan/",
+   "office": "Office WL125",
+   "research": "Nanoelectronics Compact SPICE Modeling of semiconductor devices (Bulk/SOI MOSFET, Multigate FET, Nanowire, FDSOI, GaN HEMT, LDMOS, SiC MOSFET) BSIM model development and support (with BSIM Group at UCB) Atommistic Simulation of Nanoscale Devices DC, CV and RF Characterization",
+   "qualification": "PhD (Ecole Polytechnique Federale de Lausanne (EPFL), Switzerland)"
+  },
+  {
+   "name": "Nilesh Umesh Badwe",
+   "title": "Associate Professor, Department of Materials Science and Engineering",
+   "dept": "Materials Science & Engineering",
+   "url": "https://www.iitk.ac.in/nilesh-badwe",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
+   "email": "nbadwe@iitk.ac.in",
+   "phone": "0512-259-2205",
+   "research": "Nanoporous metals, Electrodeposition of nanocrystalline alloys, Interconnect materials",
+   "qualification": "PhD, Arizona State University, USA"
+  },
+  {
+   "name": "Niraj Mohan Chawake",
+   "title": "Associate Professor, Department of Materials Science and Engineering",
+   "dept": "Materials Science & Engineering",
+   "url": "https://www.iitk.ac.in/niraj-mohan-chawake",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
+   "email": "nchawake@iitk.ac.in",
+   "phone": "0512-259-2181",
+   "web": "https://home.iitk.ac.in/~nchawake/index.html",
+   "office": "Room No. 417, Faculty Building",
+   "research": "Creep and High-Temperature Deformation of Materials, High-temperature Alloys, Superalloys, Severe Plastic Deformation, Solid-State Sintering, Alloy Design, in-situ deformation, Electron Microscopy, Structure-Property Correlation",
+   "qualification": "PhD, IIT Madras"
+  },
+  {
+   "name": "Raghupathy Yuvaraj",
+   "title": "Assistant Professor, Department of Materials Science and Engineering",
+   "dept": "Materials Science & Engineering",
+   "url": "https://www.iitk.ac.in/raghupathy-yuvaraj",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
+   "email": "raghu@iitk.ac.in",
+   "phone": "0512-259-2316",
+   "research": "Structure-electrochemical property relationships in metastable and nanocrystalline materials, development of materials for extreme corrosive environments, coatings for corrosion control, material-microbe interactions leading to bio-fouling and microbially induced corrosion, and biohydrometallurgy for recycling industrial wastes",
+   "qualification": "PhD, IISc Bengaluru, India"
+  },
+  {
+   "name": "Rahul Sarkar",
+   "title": "Associate Professor, Department of Materials Science and Engineering",
+   "dept": "Materials Science & Engineering",
+   "url": "https://www.iitk.ac.in/rahul-sarkar",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
+   "email": "rsarkar@iitk.ac.in",
+   "phone": "0512-259-2242",
+   "research": "Process Metallurgy, Transport phenomena in Materials Engineering, Process modelling, Diffusion in solids",
+   "qualification": "PhD, Metallurgical Engineering, The University of Utah, USA"
+  },
+  {
+   "name": "Rajdip Mukherjee",
+   "title": "Professor, Department of Materials Science and Engineering",
+   "dept": "Materials Science & Engineering",
+   "url": "https://www.iitk.ac.in/rajdip-mukherjee",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
+   "email": "rajdipm@iitk.ac.in",
+   "phone": "0512-259-6449",
+   "office": "Office FB-407",
+   "qualification": "PhD"
+  },
+  {
+   "name": "Sarang Ingole",
+   "title": "Associate Professor, Department of Materials Science and Engineering",
+   "dept": "Materials Science & Engineering",
+   "url": "https://www.iitk.ac.in/sarang-lngole",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
+   "email": "sarang@iitk.ac.in",
+   "phone": "0512-259-7089",
+   "web": "https://home.iitk.ac.in/~sarang/index.html",
+   "office": "Office Department of MSE",
+   "research": "Materials for photovoltaic applications and energy storage.",
+   "qualification": "PhD (Arizona State University)"
+  },
+  {
+   "name": "Shashank Shekhar",
+   "title": "Professor, Department of Materials Science and Engineering",
+   "dept": "Materials Science & Engineering",
+   "url": "https://www.iitk.ac.in/shashank-shekhar",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
+   "email": "shashank@iitk.ac.in",
+   "phone": "0512-259-6528",
+   "web": "https://home.iitk.ac.in/~shashank/",
+   "office": "Office FB-411,",
+   "research": "Thermomechanical Processing, Grain boundary engineering, Machining, Surface engineering",
+   "qualification": "PhD (Purdue University)"
+  },
+  {
+   "name": "Shikhar Krishn Jha",
+   "title": "Assistant Professor, Department of Materials Science and Engineering",
+   "dept": "Materials Science & Engineering",
+   "url": "https://www.iitk.ac.in/shikhar-krishn-jha",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
+   "email": "skjha@iitk.ac.in",
+   "phone": "0512-259-2094",
+   "research": "Thermodynamics of phase transformations, Structure of material, Interfaces, and Solid state physics",
+   "qualification": "Ph.D, University of Colorado, Boulder, USA"
+  },
+  {
+   "name": "Shikhar Misra",
+   "title": "Assistant Professor, Department of Materials Science and Engineering",
+   "dept": "Materials Science & Engineering",
+   "url": "https://www.iitk.ac.in/shikhar-misra",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
+   "email": "shikharm@iitk.ac.in",
+   "phone": "0512-259-2257",
+   "research": "Ceramic Nanocomposite Designs, Processing and Characterizations for Microelectronics, Optics, and Energy applications, Machine learning for Materials Database Mining and Structural Refinin",
+   "qualification": "PhD, Purdue University, West Lafayette, USA"
+  },
+  {
+   "name": "Shivam Tripathi",
+   "title": "Assistant Professor, Department of Materials Science and Engineering",
+   "dept": "Materials Science & Engineering",
+   "url": "https://www.iitk.ac.in/shivam-tripathi-msme",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
+   "email": "shivamt@iitk.ac.in"
+  },
+  {
+   "name": "Shobit Omar",
+   "title": "Professor, Department of Materials Science and Engineering",
+   "dept": "Materials Science & Engineering",
+   "url": "https://www.iitk.ac.in/shobit-omar",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
+   "email": "somar@iitk.ac.in",
+   "phone": "0512-259-7427",
+   "office": "Office 203(E),",
+   "qualification": "PhD (University of Florida)"
+  },
+  {
+   "name": "Somnath Bhowmick",
+   "title": "Professor, Department of Materials Science and Engineering",
+   "dept": "Materials Science & Engineering",
+   "url": "https://www.iitk.ac.in/somnath-bhowmick",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
+   "email": "bsomnath@iitk.ac.in",
+   "phone": "0512-259-7161",
+   "web": "https://sites.google.com/view/cmsmseiitk/home",
+   "office": "Office FB-410,",
+   "research": "Data science, AI-M L, Ab initio and atomistic calculations, Multi-scale modeling, Integrated computational materials engineering (ICME)",
+   "qualification": "PhD (IISc Bangalore)"
+  },
+  {
+   "name": "Srinu Gangolu",
+   "title": "Associate Professor, Department of Materials Science and Engineering",
+   "dept": "Materials Science & Engineering",
+   "url": "https://www.iitk.ac.in/srinu-gangolu",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
+   "email": "srinu@iitk.ac.in",
+   "phone": "0512-259-2317",
+   "web": "https://home.iitk.ac.in/~srinu",
+   "office": "Office: WL306A",
+   "research": "Grain refinement, Severe plastic deformation, Thermo-Mechanical Processing, Mechanical behaviour of Materials i.e. Creep and Superplasticity",
+   "qualification": "PhD, IIT Bombay, India"
+  },
+  {
+   "name": "Sudhanshu Shekhar Singh",
+   "title": "Associate Professor, Department of Materials Science and Engineering",
+   "dept": "Materials Science & Engineering",
+   "url": "https://www.iitk.ac.in/sudhanshu-shekhar-singh",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
+   "email": "sudhanss@iitk.ac.in",
+   "phone": "0512-259-6908",
+   "web": "https://home.iitk.ac.in/~sudhanss/",
+   "office": "Office:",
+   "research": "Nanoindentation, Micro-mechanical testing, Lightweight alloys, Deformation behavior of alloys, powder metallurgy",
+   "qualification": "PhD (Arizona State University, Tempe, Arizona, USA)"
+  },
+  {
+   "name": "Tanmoy Maiti",
+   "title": "Professor, Department of Materials Science and Engineering",
+   "dept": "Materials Science & Engineering",
+   "url": "https://www.iitk.ac.in/tanmoy-maiti",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
+   "email": "tmaiti@iitk.ac.in",
+   "phone": "0512-259-6599",
+   "web": "https://home.iitk.ac.in/~tmaiti/",
+   "office": "Office WL302B, IIT Kanpur, Kanpur 208016",
+   "research": "Clean Energy: Thermoelectrics, Waste-Heat Harvesting, Electroceramics, Oxide electronics: Pyroelectrics, Ferroelectrics; Semiconductor Devices, Perovskite Solar Cell. Next Generation Chip-scale Technology: RRAM, Optical Memory based on Plasmonic Lens.",
+   "qualification": "PhD (Pennsylvania State University)"
+  },
+  {
+   "name": "Vivek Verma",
+   "title": "Professor, Department of Materials Science and Engineering",
+   "dept": "Materials Science & Engineering",
+   "url": "https://www.iitk.ac.in/vivek-verma",
+   "depts": [
+    "Materials Science & Engineering"
+   ],
+   "email": "vverma@iitk.ac.in",
+   "phone": "0512-259-6527",
+   "web": "https://home.iitk.ac.in/~vverma/",
+   "office": "Office Department of MSE",
+   "research": "Protein patterning, cellulose, biodegradable composites, drug delivery",
+   "qualification": "PhD (Pennsylvania State University)"
+  },
+  {
+   "name": "Jothsna Rajan",
+   "title": "Assistant Professor, Department of Management Sciences",
+   "dept": "Management Sciences",
+   "url": "https://www.iitk.ac.in/jothsna-rajan",
+   "depts": [
+    "Management Sciences"
+   ],
+   "email": "jothsna@iitk.ac.in",
+   "office": "Office Department of Management Sciences",
+   "research": "Partnerships, Public Administration, Policy Evaluation",
+   "qualification": "PhD in Public Policy (IIM Bangalore)"
+  },
+  {
+   "name": "Mousami Prasad",
+   "title": "Assistant Professor, Department of Management Sciences",
+   "dept": "Management Sciences",
+   "url": "https://www.iitk.ac.in/mousami-prasad",
+   "depts": [
+    "Management Sciences"
+   ],
+   "email": "mousami@iitk.ac.in",
+   "phone": "0512-259-2266",
+   "web": "https://home.iitk.ac.in/~mousami/",
+   "office": "Office Room No. DoMS-217,",
+   "research": "Energy and Climate Change Economics; Energy Transition; Energy Policy; Industrial decarbonisation (Green Steel; Green Hydrogen)",
+   "qualification": "Ph.D (IIT Bombay)"
+  },
+  {
+   "name": "Nivedita Bhaktha",
+   "title": "Assistant Professor, Department of Management Sciences",
+   "dept": "Management Sciences",
+   "url": "https://www.iitk.ac.in/nivedita-bhaktha",
+   "depts": [
+    "Management Sciences"
+   ],
+   "email": "nbhaktha@iitk.ac.in",
+   "phone": "0512-259-2459",
+   "web": "https://sites.google.com/view/niveditabhaktha/home",
+   "office": "200, DoMS",
+   "research": "Psychometrics, Categorical Data Analysis, Survey Research, Multivariate Analysis, Latent Variable Modeling, Causal Inference, Data Quality Assessment, Simulation Studies, Data Visualization",
+   "qualification": "Ph.D (The Ohio State University)"
+  },
+  {
+   "name": "Prerna Gautam",
+   "title": "Assistant Professor, Department of Management Sciences",
+   "dept": "Management Sciences",
+   "url": "https://www.iitk.ac.in/prerna-gautam",
+   "depts": [
+    "Management Sciences"
+   ],
+   "email": "gprerna@iitk.ac.in",
+   "phone": "0512-259-2265",
+   "office": "Office Room No. 216",
+   "research": "Operational Research, Optimization, Sustainability, Waste Management, Service Operations Management",
+   "qualification": "PhD (University of Delhi, Delhi)"
+  },
+  {
+   "name": "Raghu Nandan Sengupta",
+   "title": "Professor, Department of Management Sciences",
+   "dept": "Management Sciences",
+   "url": "https://www.iitk.ac.in/raghu-nandan-sengupta",
+   "depts": [
+    "Management Sciences"
+   ],
+   "email": "raghus@iitk.ac.in",
+   "phone": "+91-512-679-6607",
+   "web": "https://web.iitk.ac.in/raghu-nandan-sengupta",
+   "office": "Office",
+   "research": "Sequential Estimation Statistical and Mathematical Reliability Theory Risk Analysis Optimization Techniques in Finance Meta Heuristic Techniques Reliability based Optimization Robust Optimization",
+   "qualification": "Fellow in Management (IIM Calcutta, INDIA)"
+  },
+  {
+   "name": "Rahul Varman",
+   "title": "Professor, Department of Management Sciences",
+   "dept": "Management Sciences",
+   "url": "https://www.iitk.ac.in/rahul-varman",
+   "depts": [
+    "Management Sciences"
+   ],
+   "email": "rahulv@iitk.ac.in",
+   "phone": "0512-259-7970",
+   "web": "https://iitk.ac.in/ime/rahulv/",
+   "office": "Office Department of Management Sciences",
+   "research": "The Political Economy of Corporations Globalisation and Working Classes Governance of Global Value Chains",
+   "qualification": "Fellow in Management (IIM Ahmedabad)"
+  },
+  {
+   "name": "Shankar Prawesh",
+   "title": "Associate Professor, Department of Management Sciences",
+   "dept": "Management Sciences",
+   "url": "https://www.iitk.ac.in/shankar-prawesh",
+   "depts": [
+    "Management Sciences"
+   ],
+   "email": "sprawesh@iitk.ac.in",
+   "phone": "0512-259-6182",
+   "web": "https://sites.google.com/view/sprawesh/home",
+   "office": "Office Department of Management Sciences,",
+   "research": "Social Media, Agent Based Simulation, Fairness in Big Data.",
+   "qualification": "PhD (University of South Florida, College of Business)"
+  },
+  {
+   "name": "Sourav Majumdar",
+   "title": "Assistant Professor, Department of Management Sciences",
+   "dept": "Management Sciences",
+   "url": "https://www.iitk.ac.in/sourav-majumdar",
+   "depts": [
+    "Management Sciences"
+   ],
+   "email": "souravm@iitk.ac.in",
+   "phone": "+91-512-259-2460",
+   "web": "https://home.iitk.ac.in/~souravm/",
+   "office": "301, Department of Management Sciences",
+   "research": "Quantitative Finance, High-Frequency Econometrics, Stochastic Processes, Circular Statistics, Topological Data Analysis",
+   "qualification": "PhD (IIM Ahmedabad)"
+  },
+  {
+   "name": "Sourya Joyee De",
+   "title": "Assistant Professor, Department of Management Sciences",
+   "dept": "Management Sciences",
+   "url": "https://www.iitk.ac.in/sourya-joyee-de",
+   "depts": [
+    "Management Sciences"
+   ],
+   "email": "sourya@iitk.ac.in",
+   "phone": "+91-512-259-2586",
+   "office": "Department of Management Sciences"
+  },
+  {
+   "name": "Sri Vanamalla Venkataraman",
+   "title": "Professor, Department of Management Sciences",
+   "dept": "Management Sciences",
+   "url": "https://www.iitk.ac.in/sri-vanamalla-v",
+   "depts": [
+    "Management Sciences"
+   ],
+   "email": "vanamala@iitk.ac.in",
+   "phone": "0512-259-6608",
+   "office": "Office Department of Management Sciences",
+   "research": "Applied Operations Research, Optimization and Game Theory.",
+   "qualification": "PhD (IISc Bangalore)"
+  },
+  {
+   "name": "Subhas Chandra Misra",
+   "title": "Professor, Department of Management Sciences",
+   "dept": "Management Sciences",
+   "url": "https://www.iitk.ac.in/subhas-chandra-misra",
+   "depts": [
+    "Management Sciences"
+   ],
+   "email": "subhasm@iitk.ac.in",
+   "phone": "0512-259-7430",
+   "web": "https://home.iitk.ac.in/~subhasm/",
+   "research": "Business Process Management, Project Management, Managing Supply Chain Services, Business Analytics/Data Analysis, Enterprise Resource Planning (ERP), Change and Risk Management, E-Governance, and Information Systems.",
+   "qualification": "PhD (Carleton University)"
+  },
+  {
+   "name": "Suman Saurabh",
+   "title": "Assistant Professor, Department of Management Sciences",
+   "dept": "Management Sciences",
+   "url": "https://www.iitk.ac.in/suman-saurabh",
+   "depts": [
+    "Management Sciences"
+   ],
+   "email": "sumans@iitk.ac.in",
+   "phone": "+91-512-259-2015",
+   "web": "https://sumansaurabh.net/",
+   "office": "Office : R. No. - 312, Department of Management Sciences IIT Kanpur, Kalyanpur, Uttar Pradesh - 208016",
+   "research": "Corporate Finance, Asset Pricing, Behavioral Finance, Mergers and Acquisitions, Financial Derivatives",
+   "qualification": "PhD (IIM Ahmedabad)"
+  },
+  {
+   "name": "Suvendu Naskar",
+   "title": "Assistant Professor, Department of Management Sciences",
+   "dept": "Management Sciences",
+   "url": "https://www.iitk.ac.in/suvendu-naskar",
+   "depts": [
+    "Management Sciences"
+   ],
+   "email": "snaskar@iitk.ac.in",
+   "phone": "512-259-2370",
+   "office": "Office 305, Department of Management Sciences",
+   "research": "Information Technology, Emerging Technologies, Supply Chain Management, SC Finance, Social and Organisational impact of IT",
+   "qualification": "Ph.D, IIM Calcutta (2022)"
+  },
+  {
+   "name": "Veena Bansal",
+   "title": "Professor, Department of Management Sciences",
+   "dept": "Management Sciences",
+   "url": "https://www.iitk.ac.in/veena-bansal",
+   "depts": [
+    "Management Sciences"
+   ],
+   "email": "veena@iitk.ac.in",
+   "phone": "0512-259-7743",
+   "web": "https://home.iitk.ac.in/~veena/",
+   "office": "Office Department of Management Sciences",
+   "research": "Data Science, Software Project Management, ERP",
+   "qualification": "PhD (IIT Kanpur)"
+  },
+  {
+   "name": "Vinay Ramani",
+   "title": "Associate Professor, Department of Management Sciences",
+   "dept": "Management Sciences",
+   "url": "https://www.iitk.ac.in/v-ramani",
+   "depts": [
+    "Management Sciences"
+   ],
+   "email": "vramani@iitk.ac.in",
+   "phone": "+91-512-259-2289",
+   "office": "Office R. No: 316,",
+   "research": "Economics-Operations Management Interface; Industrial Organization; Pricing Strategy",
+   "qualification": "PhD (University at Buffalo)"
+  },
+  {
+   "name": "Basant Lal Sharma",
+   "title": "Associate Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/basant-lal-sharma",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "bls@iitk.ac.in",
+   "phone": "0512-259-6173",
+   "web": "https://home.iitk.ac.in/~bls/Homepage/Home.html",
+   "office": "Office FB-356,",
+   "research": "Continuum Mechanics and Thermodynamics, Lattice Dynamics, Dislocations, Brittle Fracture, Solid-Solid Phase transformation, Wave Scattering, Nonlinear Elasticity. Geometric Algorithms, Symplectic Algorithms, Structure of Hamiltonian Systems, Calculus of variations, Toeplitz Operator Theory, Difference equations, Fourier Analysis, Special Functions.",
+   "qualification": "PhD (Cornell University)"
+  },
+  {
+   "name": "Bishakh Bhattacharya",
+   "title": "Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/bishakh-bhattacharya",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "bishakh@iitk.ac.in",
+   "phone": "0512-259-7824",
+   "web": "https://home.iitk.ac.in/~bishakh/",
+   "office": "Office NL-103, Applied Dynamics and Vibration Laboratory",
+   "research": "Active & Passive Vibration Control, Active Shape Control and Adaptive Structures, Intelligent Gripper Design, Smart Structures, Structural Health Monitoring, Child-Robot Interaction Design, Neural Oscillation and Multi-scale Brain-modelling .",
+   "qualification": "PhD (IISc Bangalore)"
+  },
+  {
+   "name": "Chandraprakash Chindam",
+   "title": "Associate Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/chandraprakash-chindam",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "chindamc@iitk.ac.in",
+   "phone": "0512-259-6743",
+   "web": "http://chandraprakashster.wixsite.com/chan",
+   "office": "Office 211, Northern Laboratories I Office Phone: 0512-259-6743 Email: chindamc@iitk.ac.in",
+   "research": "Acoustic metamaterials, thermal nondestructive evaluation, soft robotics, multifunctional materials, instrumentation, computer vision.",
+   "qualification": "PhD (Pennsylvania State University)"
+  },
+  {
+   "name": "David Chelidze",
+   "title": "Visiting Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/david-chelidze",
+   "depts": [
+    "Mechanical Engineering"
+   ]
+  },
+  {
+   "name": "Dipayan Mukherjee",
+   "title": "Assistant Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/dipayan-mukherjee",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "dipayanm@iitk.ac.in",
+   "phone": "0512-259-2353",
+   "qualification": "(PhD, Ecole Polytechnique)"
+  },
+  {
+   "name": "Jishnu Bhattacharya",
+   "title": "Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/jishnu-bhattacharya",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "jishnu@iitk.ac.in",
+   "phone": "0512-259-7684",
+   "web": "https://home.iitk.ac.in/~jishnu/",
+   "office": "Office NL-1, 302 Dept. of Mech. Engg. IIT, Kanpur, UP 208016",
+   "research": "Renewable energy storage, thermal management of portable energy sources, energy storage materials, computational material science, thermodynamic analysis of energy harvesting and storage, heat transfer, low cost energy options.",
+   "qualification": "PhD (University of Michigan, Ann Arbor)"
+  },
+  {
+   "name": "Malay Kumar Das",
+   "title": "Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/malay-kumar-das",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "mkdas@iitk.ac.in",
+   "phone": "0512-259-7359",
+   "web": "https://home.iitk.ac.in/~mkdas/",
+   "office": "Office Southern Lab 210 ,",
+   "research": "Energy Conversion and Storage Hydrodynamic Instability",
+   "qualification": "PhD (Pennsylvania State University)"
+  },
+  {
+   "name": "Manjesh Kumar Singh",
+   "title": "Associate Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/manjesh-kumar-singh",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "manjesh@iitk.ac.in",
+   "phone": "0512-259-2108",
+   "web": "https://home.iitk.ac.in/~manjesh/",
+   "office": "Office NLX-101,",
+   "research": "Tribology, Soft Matter and Rheology.",
+   "qualification": "PhD (ETH Zurich, Switzerland)"
+  },
+  {
+   "name": "Mohit Subhas Law",
+   "title": "Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/mohit-law",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "mlaw@iitk.ac.in",
+   "phone": "0512-259-6897",
+   "web": "https://home.iitk.ac.in/~mlaw/",
+   "office": "Office Room No.",
+   "research": "Machining dynamics; Machine tool design and analysis; Dynamic substructuring; Vibration damping, isolation and control; Analytical and experimental modal analysis; Machining with robots; Environmentally responsible design and manufacturing; High performance machining strategies; Finite element methods; Process-machine interactions; Model order reduction",
+   "qualification": "PhD (University of British Columbia, Canada)"
+  },
+  {
+   "name": "Nachiketa Tiwari",
+   "title": "Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/nachiketa-tiwari",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "ntiwari@iitk.ac.in",
+   "phone": "0512-259-6526",
+   "web": "https://home.iitk.ac.in/~ntiwari/",
+   "office": "Office NL -201A,",
+   "research": "Acoustics and Noise Control, Solid Mechanics, Composite Structures, Vibrations, Product Design, Automotive Systems, MEMS.",
+   "qualification": "PhD (Viriginia Tech)"
+  },
+  {
+   "name": "Nalinaksh SharadchandraVyas",
+   "title": "Emeritus Fellow, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/nalinaksh-s-vyas",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "vyas@iitk.ac.in",
+   "phone": "0512-259-7040",
+   "web": "https://home.iitk.ac.in/~vyas/",
+   "office": "Office NL-103,",
+   "research": "Rotor Dynamics, Rail Wheel Dynamics, Automotive Dynamics, System Identification and Parameter Estimation, MEMS, Instrumentation and Sensor Technologies, Neural Networks.",
+   "qualification": "PhD (IIT Delhi)"
+  },
+  {
+   "name": "Niraj Sinha",
+   "title": "Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/niraj-sinha",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "nsinha@iitk.ac.in",
+   "phone": "0512-259-7196",
+   "web": "https://home.iitk.ac.in/~nsinha/",
+   "office": "Office FB-333,",
+   "research": "Additive Manufacturing, Biomaterials, Biomedical Engineering, Prosthetic Devices, Nanotechnology",
+   "qualification": "PhD (University of Waterloo)"
+  },
+  {
+   "name": "Pranav Ramkrishna Joshi",
+   "title": "Associate Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/pranav-joshi",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "jpranavr@iitk.ac.in",
+   "phone": "0512-259-2023",
+   "web": "https://sites.google.com/view/pranavjoshi-iitk/home",
+   "office": "Office NL301,",
+   "research": "Laminar, transitional and turbulent boundary layers, natural convection, flows in rotating systems, turbulent flows, aerodynamics.",
+   "qualification": "PhD (Johns Hopkins University, Baltimore, USA)"
+  },
+  {
+   "name": "Sachin Y. Shinde",
+   "title": "Associate Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/sachin-y-shinde",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "sachin@iitk.ac.in",
+   "phone": "0512-259-6939",
+   "web": "https://home.iitk.ac.in/~sachin/",
+   "office": "Office Room No. FB-439, Faculty Building,",
+   "research": "Experimental Fluid Mechanics, Biofluiddynamics, Swimming and Flying, Fluid–Structure (Flexible) Interaction, Propulsion by Flapping Foils, Cloud Fluid Dynamics.",
+   "qualification": "PhD (IISc Bangalore )"
+  },
+  {
+   "name": "Santanu De",
+   "title": "Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/santanu-de",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "sde@iitk.ac.in",
+   "phone": "0512-259-6478",
+   "web": "https://home.iitk.ac.in/~sde/index.htm",
+   "office": "Office NL 302 (Northern Laboratory),",
+   "research": "Turbulent Combustion, Spray Combustion, Flame Dynamics, Ignition, Coal and Biomass Combustion, Modeling of Turbulent Combustion, Conditional Moment Closure Method, Stochastic Methods, Computational Fluid Dynamics and Heat Transfer",
+   "qualification": "PhD (IISc Bangalore)"
+  },
+  {
+   "name": "Sarvesh Mishra",
+   "title": "Assistant Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/sarvesh-mishra",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "msarvesh@iitk.ac.in",
+   "phone": "0512-259-2337",
+   "web": "https://sites.google.com/view/m8s/home",
+   "office": "Office",
+   "research": "Metal Additive Manufacturing, Machining Science, Hybrid Manufacturing, Surface Engineering",
+   "qualification": "PhD (IIT Delhi)"
+  },
+  {
+   "name": "Shantanu Bhattacharya",
+   "title": "Professor (Mechanical Engineering), Currently on Deputation as Director, CSIR-CSIO",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/shantanu-bhattacharya",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "bhattacs@iitk.ac.in",
+   "phone": "0512-259-6056",
+   "web": "https://home.iitk.ac.in/~bhattacs/",
+   "office": "Office NL-115,",
+   "research": "Bio MEMS, Lab on Chip, Nano Technology, Microsystems Fabrication and MicroFluids",
+   "qualification": "PhD (University of Missouri)"
+  },
+  {
+   "name": "Shyam Sunder Gopalakrishnan",
+   "title": "Assistant Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/shyam-sunder-gopalakrishnan",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "shyamsg@iitk.ac.in",
+   "web": "https://sites.google.com/view/lfdi"
+  },
+  {
+   "name": "Siddhartha Mukherjee",
+   "title": "Assistant Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/siddhartha-mukherjee",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "smukherjee@iitk.ac.in"
+  },
+  {
+   "name": "Subrata Sarkar",
+   "title": "Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/subrata-sarkar",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "subra@iitk.ac.in",
+   "phone": "0512-259-7942",
+   "web": "https://home.iitk.ac.in/~subra/",
+   "office": "Office FB-353,",
+   "research": "Turbomachinery, Turbulence, Computational Fluid Dynamics, LES, Experimental Fluid Mechanics, Heat Transfer.",
+   "qualification": "PhD (IIT Madras)"
+  },
+  {
+   "name": "Sumit Basu",
+   "title": "Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/sumit-basu",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "sbasu@iitk.ac.in",
+   "phone": "0512-259-7506",
+   "web": "https://www.cmg-iitkanpur.in/",
+   "office": "Office NL-211,",
+   "research": "Multi scale modelling of solids, Finite deformations, Non-linear Finite Element techniques, Surfaces and interfaces, Mechanics of Fracture, Mechanical behaviour of polymers.",
+   "qualification": "PhD (IISc Bangalore)"
+  },
+  {
+   "name": "Supratik Mukhopadhyay",
+   "title": "Associate Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/supratik-mukhopadhyay",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "smukh@iitk.ac.in",
+   "phone": "0512-259-7094",
+   "web": "https://sites.google.com/view/supratikmukhopadhyay/",
+   "office": "Office Office address: FB-360, IIT Kanpur",
+   "research": "Mechanics of composites, Theory of Damage and failure, Numerical simulation of strain localization and fracture, Finite element method, Meshindependent and mesh-free methods, Numerical simulation of manufacturing processes.",
+   "qualification": "PhD (University of Bristol)"
+  },
+  {
+   "name": "Tushar Sikroria",
+   "title": "Assistant Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/tushar-sikroria",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "tsikroria@iitk.ac.in",
+   "phone": "0512-679-2481",
+   "web": "https://tsikroria0.wixsite.com/trisep",
+   "office": "Faculty Building 358",
+   "research": "Aero-acoustics in phase-locked compressible flows and flow distortion generation in compressor intake ducts.",
+   "qualification": "(PhD, The University of Melbourne, Australia)"
+  },
+  {
+   "name": "Umesh Madanan",
+   "title": "Assistant Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/umesh-madanan",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "umadanan@iitk.ac.in",
+   "phone": "0512-259-2162",
+   "web": "https://home.iitk.ac.in/~umadanan/",
+   "office": "Office Faculty Building # 302,",
+   "research": "Buoyancy-driven convection with/without porous media at high Rayleigh numbers; single- and two-phase flows in micro- and mini-tubes; heat transfer enhancement in nucleate pool boiling, thermofluidics of supercritical fluids, passive thermal management techniques for electronic devices",
+   "qualification": "PhD (University of Minnesota)"
+  },
+  {
+   "name": "Ushasi Roy",
+   "title": "Assistant Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/ushasi-roy",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "ushasiroy@iitk.ac.in",
+   "phone": "0512-259-2245",
+   "office": "Office 115K Northern Lab - I,",
+   "qualification": "PhD, Georgia Institute of Technology"
+  },
+  {
+   "name": "Vasudevan Rajagopal Iyer",
+   "title": "Assistant Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/vasudevan-rajagopal-iyer",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "vasuiyer@iitk.ac.in"
+  },
+  {
+   "name": "Venkitanarayanan Parameswaran",
+   "title": "Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/p-venkitanarayanan2",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "venkit@iitk.ac.in",
+   "phone": "0512-259-7528",
+   "web": "https://home.iitk.ac.in/~venkit/",
+   "office": "Office Northern Laboratory",
+   "research": "Fracture Mechanics, High Strain Rate Phenomena, Experimental Mechanics",
+   "qualification": "PhD (University of Rhode Island)"
+  },
+  {
+   "name": "Virkeshwar Kumar",
+   "title": "Assistant Professor, Department of Mechanical Engineering",
+   "dept": "Mechanical Engineering",
+   "url": "https://www.iitk.ac.in/virkeshwar-kumar",
+   "depts": [
+    "Mechanical Engineering"
+   ],
+   "email": "virkeshwar@iitk.ac.in",
+   "phone": "0512-259-2334",
+   "web": "https://sites.google.com/view/virkeshwarkumar",
+   "office": "Office",
+   "research": "Solidification, Melting, Casting, Welding, Interfacial interactions phenomena, Evaporation, Crystallization during evaporation, Boiling, Flow visualization, Transport Phenomena, Natural convection, Experimental Fluid Dynamics and Heat Transfer, Phase change process, Phase change materials.",
+   "qualification": "PhD (IIT, Bombay)"
+  },
+  {
+   "name": "Renu Malhotra",
+   "title": "Distinguished Visiting Professor, Space, Planetary & Astronomical Sciences & Engineering",
+   "dept": "Space, Planetary and Astronomical Sciences and Engineering",
+   "url": "https://www.iitk.ac.in/renu-malhotra",
+   "depts": [
+    "Space, Planetary and Astronomical Sciences and Engineering"
+   ],
+   "research": "Planetary Science, Orbital Dynamics",
+   "qualification": "PhD, University of Arizona, U.S.A"
+  },
+  {
+   "name": "Rohit Sharma",
+   "title": "Assistant Professor, Department of Space, Planetary & Astronomical Sciences & Engineering",
+   "dept": "Space, Planetary and Astronomical Sciences and Engineering",
+   "url": "https://www.iitk.ac.in/rohit-sharma",
+   "depts": [
+    "Space, Planetary and Astronomical Sciences and Engineering"
+   ],
+   "email": "rsharma@iitk.ac.in",
+   "web": "https://rohitcbscient.netlify.app/work.html",
+   "qualification": "PhD"
+  },
+  {
+   "name": "Sharvari Nadkarni Ghosh",
+   "title": "Assistant Professor, Department of Space, Planetary & Astronomical Sciences & Engineering",
+   "dept": "Space, Planetary and Astronomical Sciences and Engineering",
+   "url": "https://www.iitk.ac.in/sharvari-nadkarni-ghosh",
+   "depts": [
+    "Space, Planetary and Astronomical Sciences and Engineering"
+   ],
+   "email": "sharvari@iitk.ac.in"
+  },
+  {
+   "name": "Soumyabrata Chakrabarty",
+   "title": "Professor of Practice, Department of Space, Planetary & Astronomical Sciences & Engineering(SPASE)",
+   "dept": "Space, Planetary and Astronomical Sciences and Engineering",
+   "url": "https://www.iitk.ac.in/soumyabrata-chakrabarty",
+   "depts": [
+    "Space, Planetary and Astronomical Sciences and Engineering"
+   ],
+   "email": "soumyac@iitk.ac.in",
+   "office": "ESB-II, Room No. 726",
+   "research": "Space Weather interaction of Spacecrafts Spacecraft Charging Analysis Computational Electromagnetics Design and development of Antennas for Radio Telescopes and Microwave Sensors",
+   "qualification": "Ph. D (IIT Kharagpur)"
+  },
+  {
+   "name": "Sumitesh Sarkar",
+   "title": "Professor of Practice, Department of Space, Planetary & Astronomical Sciences & Engineering(SPASE)",
+   "dept": "Space, Planetary and Astronomical Sciences and Engineering",
+   "url": "https://www.iitk.ac.in/sumitesh-sarkar",
+   "depts": [
+    "Space, Planetary and Astronomical Sciences and Engineering"
+   ],
+   "email": "sumitesh@iitk.ac.in"
+  },
+  {
+   "name": "Yamini Jangir",
+   "title": "Visiting Assistant Professor, Department of Space, Planetary & Astronomical Sciences & Engineering",
+   "dept": "Space, Planetary and Astronomical Sciences and Engineering",
+   "url": "https://www.iitk.ac.in/yamini-jangir",
+   "depts": [
+    "Space, Planetary and Astronomical Sciences and Engineering"
+   ],
+   "email": "jangir@iitk.ac.in"
+  },
+  {
+   "name": "Lalit Mohan Pant",
+   "title": "Assistant Professor, Department of Sustainable Energy Engineering",
+   "dept": "Sustainable Energy Engineering",
+   "url": "https://www.iitk.ac.in/lalit-mohan-pant",
+   "depts": [
+    "Sustainable Energy Engineering"
+   ],
+   "email": "lalit@iitk.ac.in",
+   "phone": "5126792261",
+   "web": "https://home.iitk.ac.in/~lalit/",
+   "office": "Room A-112, Sustainable Energy Engineering",
+   "research": "Hydrogen energy systems Electrochemical Energy Conversion and Storage Electrolyzers, fuel cells, electrochemical synthesis Numerical Modelling, Porous Media Transport",
+   "qualification": "Ph.D."
+  },
+  {
+   "name": "Laltu Chandra",
+   "title": "Professor, Department of Sustainable Energy Engineering",
+   "dept": "Sustainable Energy Engineering",
+   "url": "https://www.iitk.ac.in/laltu-chandra",
+   "depts": [
+    "Sustainable Energy Engineering"
+   ],
+   "email": "lchandra@iitk.ac.in",
+   "phone": "0512-679-2284",
+   "research": "Heat Transfer and Fluid Flow, Computation and Experiment, Turbulent Flow Simulation and Modelling, Solar Thermal Sub-system Design, Nuclear Reactor Thermal Hydarulics",
+   "qualification": "PhD (KIT Germany)"
+  },
+  {
+   "name": "Mr. Sanjay Khare",
+   "title": "Visiting Professor of Practice, Department of Sustainable Energy Engineering",
+   "dept": "Sustainable Energy Engineering",
+   "url": "https://www.iitk.ac.in/mr-sanjay-khare",
+   "depts": [
+    "Sustainable Energy Engineering"
+   ]
+  },
+  {
+   "name": "Prabodh Bajpai",
+   "title": "Professor, Department of Sustainable Energy Engineering",
+   "dept": "Sustainable Energy Engineering",
+   "url": "https://www.iitk.ac.in/prabodh-bajpai",
+   "depts": [
+    "Sustainable Energy Engineering"
+   ],
+   "email": "pbajpai@iitk.ac.in",
+   "phone": "0512-679-2327",
+   "web": "https://home.iitk.ac.in/~pbajpai/",
+   "office": "102, Block C, Department of Sustainable Energy Engineering",
+   "research": "Hybrid AC-DC Microgrids, Smart Grid and Renewable Integration, Solar Photovoltaics, Electricity Markets, Power System Analysis & Control",
+   "qualification": "PhD (Indian Institute of Technology Kanpur)"
+  },
+  {
+   "name": "Pulickel M. Ajayan",
+   "title": "Distinguished Visiting Professor, Department of Sustainable Energy Engineering",
+   "dept": "Sustainable Energy Engineering",
+   "url": "https://www.iitk.ac.in/pulickel-m-ajayan",
+   "depts": [
+    "Sustainable Energy Engineering"
+   ]
+  },
+  {
+   "name": "Sayan Kar",
+   "title": "Assistant Professor, Department of Sustainable Energy Engineering",
+   "dept": "Sustainable Energy Engineering",
+   "url": "https://www.iitk.ac.in/sayan-kar",
+   "depts": [
+    "Sustainable Energy Engineering"
+   ],
+   "email": "sayank@iitk.ac.in"
+  },
+  {
+   "name": "Sheo Shankar Rai",
+   "title": "Professor of Practice, Department of Sustainable Energy Engineering",
+   "dept": "Sustainable Energy Engineering",
+   "url": "https://www.iitk.ac.in/sheo-shankar-rai",
+   "depts": [
+    "Sustainable Energy Engineering"
+   ],
+   "email": "sheo@iitk.ac.in"
+  },
+  {
+   "name": "Soumyabrata Roy",
+   "title": "Assistant Professor, Department of Sustainable Energy Engineering",
+   "dept": "Sustainable Energy Engineering",
+   "url": "https://www.iitk.ac.in/soumyabrata-roy",
+   "depts": [
+    "Sustainable Energy Engineering"
+   ],
+   "email": "soumyar@iitk.ac.in"
+  },
+  {
+   "name": "Srinivas Karthik Yadavalli",
+   "title": "Assistant Professor, Department of Sustainable Energy Engineering",
+   "dept": "Sustainable Energy Engineering",
+   "url": "https://www.iitk.ac.in/srinivas-karthik-yadavalli",
+   "depts": [
+    "Sustainable Energy Engineering"
+   ],
+   "email": "srinivask@iitk.ac.in"
+  },
+  {
+   "name": "Sudarshan Narayanan",
+   "title": "Assistant Professor, Department of Sustainable Energy Engineering",
+   "dept": "Sustainable Energy Engineering",
+   "url": "https://www.iitk.ac.in/sudarshan-narayanan",
+   "depts": [
+    "Sustainable Energy Engineering"
+   ],
+   "email": "sudarshan@iitk.ac.in",
+   "phone": "0512-679-2356",
+   "research": "Solid state batteries (solid electrolytes, anode materials), thin films for energy conversion (transparent conductors, low-emissivity coatings), advanced characterization"
+  },
+  {
+   "name": "Vivek Verma",
+   "title": "Assistant Professor, Department of Sustainable Energy Engineering",
+   "dept": "Sustainable Energy Engineering",
+   "url": "https://www.iitk.ac.in/vivek_verma",
+   "depts": [
+    "Sustainable Energy Engineering"
+   ],
+   "email": "vermav@iitk.ac.in"
+  },
+  {
+   "name": "Munmun Jha",
+   "title": "Professor, Department of Humanities and Social Sciences",
+   "dept": "Humanities and Social Sciences",
+   "url": "https://www.iitk.ac.in/munmun-jha",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
+   "email": "mjha@iitk.ac.in",
+   "phone": "0512-259-7615",
+   "web": "https://home.iitk.ac.in/~mjha/",
+   "office": "FB-655,",
+   "research": "Human rights issues, NGOs, Social movements, Caste and race.",
+   "qualification": "PhD (Glasgow University)"
+  },
+  {
+   "name": "Muthukumar M",
+   "title": "Assistant Professor, Department of Humanities and Social Sciences",
+   "dept": "Humanities and Social Sciences",
+   "url": "https://www.iitk.ac.in/muthukumar-m",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
+   "email": "mkmuthu@iitk.ac.in",
+   "phone": "0512-259-2291",
+   "office": "Office Office address:",
+   "research": "Nation with a Special Reference to Subnationalism, North-East Indian Literature in English and Translation, Cultural Studies, Critical Theory, Tamil Literature",
+   "qualification": "PhD (NIT Tiruchirappalli)"
+  },
+  {
+   "name": "Prashant Bhalchandra Bagad",
+   "title": "Professor, Department of Humanities and Social Sciences",
+   "dept": "Humanities and Social Sciences",
+   "url": "https://www.iitk.ac.in/prashant-bagad",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
+   "email": "pbagad@iitk.ac.in",
+   "phone": "0512-259-6691",
+   "web": "https://sites.google.com/site/prabagad/",
+   "office": "Office FB-611",
+   "research": "Aesthetics, Philosophy of Literature, Existentialism, Gandhian Studies",
+   "qualification": "PhD (University of Southampton)"
+  },
+  {
+   "name": "Rajarshi Sengupta",
+   "title": "Assistant Professor, Department of Humanities and Social Sciences",
+   "dept": "Humanities and Social Sciences",
+   "url": "https://www.iitk.ac.in/rajarshi-sengupta",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
+   "email": "rsengupta@iitk.ac.in",
+   "phone": "0512-259-2036",
+   "office": "Office Office address: #602,",
+   "research": "Printmaking, Art history, Artisanal Histories, Textiles, Theory-practice interface",
+   "qualification": "PhD (University of British Columbia, Vancouver, Canada )"
+  },
+  {
+   "name": "Ravishankar Sarma Ayyadevara",
+   "title": "Professor, Department of Humanities and Social Sciences",
+   "dept": "Humanities and Social Sciences",
+   "url": "https://www.iitk.ac.in/a-v-ravishankar-sarma",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
+   "email": "avrs@iitk.ac.in",
+   "phone": "0512-259-6137",
+   "web": "https://home.iitk.ac.in/~avrs/",
+   "office": "Office Faculty Building: FB- 659,",
+   "research": "Belief Revision, Causality, Scientific Theory Change",
+   "qualification": "PhD (IIT Mumbai)"
+  },
+  {
+   "name": "Ritwij Bhowmik",
+   "title": "Associate Professor, Department of Humanities and Social Sciences & Design Programme",
+   "dept": "Humanities and Social Sciences",
+   "url": "https://www.iitk.ac.in/ritwij-bhowmik",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
+   "email": "ritwij@iitk.ac.in",
+   "phone": "0512-259-6975",
+   "web": "https://home.iitk.ac.in/~ritwij/",
+   "office": "FB624,",
+   "research": "Creative Drawing & Painting, Mural, Calligraphy, Art Appreciation, and Visual Art.",
+   "qualification": "PhD (National Chiao Tung University, Taiwan)"
+  },
+  {
+   "name": "Sayan Chattopadhyay",
+   "title": "Professor, Department of Humanities and Social Sciences",
+   "dept": "Humanities and Social Sciences",
+   "url": "https://www.iitk.ac.in/sayan-chattopadhyay",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
+   "email": "sayanc@iitk.ac.in",
+   "phone": "0512-259-6105",
+   "web": "https://sites.google.com/site/sayandhrupad/home",
+   "office": "Office Faculty Building (Room 673)",
+   "research": "Indian Writing in English, Postcolonial Studies, Life Writings, Literature of Colonial Bengal",
+   "qualification": "PhD (University of Cambridge)"
+  },
+  {
+   "name": "Sh. Francis Monsang",
+   "title": "Assistant Professor, Department of Humanities and Social Sciences",
+   "dept": "Humanities and Social Sciences",
+   "url": "https://www.iitk.ac.in/sh-francis-monsang",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
+   "email": "sfmonsang@iitk.ac.in",
+   "phone": "0512-259-2484",
+   "office": "Office Office address: FB672, Faculty Building",
+   "research": "Phonetics, Phonology, Morphology, Syntax, Applied Linguistics, Language Structure, Language Variations, Tibeto-Burman Languages, Language Typology, South Asian Languages, Language and Culture Documentation, Indigenous Knowledge Systems",
+   "qualification": "PhD (Indian Institute of Technology Madras, 2022)"
+  },
+  {
+   "name": "Shikha Dixit",
+   "title": "Professor, Department of Humanities and Social Sciences",
+   "dept": "Humanities and Social Sciences",
+   "url": "https://www.iitk.ac.in/shikha-dixit",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
+   "email": "shikha@iitk.ac.in",
+   "phone": "+915122597157",
+   "web": "https://home.iitk.ac.in/~shikha/",
+   "office": "Indian Institute of Technology Kanpur"
+  },
+  {
+   "name": "Suchitra Mathur",
+   "title": "Professor, Department of Humanities and Social Sciences",
+   "dept": "Humanities and Social Sciences",
+   "url": "https://www.iitk.ac.in/suchitra-mathur",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
+   "email": "suchitra@iitk.ac.in",
+   "phone": "0512-259-7836",
+   "web": "https://home.iitk.ac.in/~suchitra/",
+   "research": "Feminist Theory and Literature; Indian literature in English; Indian writing in English including Science Fiction and Detective Fiction; Dalit Studies",
+   "qualification": "PhD (Wayne State University, USA)"
+  },
+  {
+   "name": "Sudharshana N. P.",
+   "title": "Professor, Department of Humanities and Social Sciences",
+   "dept": "Humanities and Social Sciences",
+   "url": "https://www.iitk.ac.in/n-p-sudharshana",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
+   "email": "sudh@iitk.ac.in",
+   "phone": "0512-259-6188",
+   "web": "https://sites.google.com/site/drsudharshana/",
+   "office": "Office FB 607",
+   "research": "I am interested in acquisition of English as an L2 by Indian learners. In particular, I focus on the interface between the general cognition and language-specific patterns in acquisition. I am also interested in applying insights from acquisition research and language theories to teaching English at various levels.",
+   "qualification": "PhD (EFL University, Hyderabad)"
+  },
+  {
+   "name": "Sushruth Ravish",
+   "title": "Assistant Professor, Department of Humanities and Social Sciences",
+   "dept": "Humanities and Social Sciences",
+   "url": "https://www.iitk.ac.in/sushruth-ravish",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
+   "email": "sravish@iitk.ac.in",
+   "phone": "0512-259-2275",
+   "web": "https://sites.google.com/view/sushruthravish/",
+   "office": "Office Room No. 654, Faculty Building",
+   "research": "Moral epistemology, Metaethics, Normative ethics, Social epistemology, Political philosophy, Ethics of AI",
+   "qualification": "PhD (IIT Bombay)"
+  },
+  {
+   "name": "Syed Feroz Hassan",
+   "title": "Assistant Professor, Department of Humanities and Social Sciences",
+   "dept": "Humanities and Social Sciences",
+   "url": "https://www.iitk.ac.in/feroz-hassan",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
+   "email": "feroz@iitk.ac.in",
+   "phone": "+91-512-679-2065",
+   "office": "Office FB626",
+   "qualification": "PhD (University of Michigan)"
+  },
+  {
+   "name": "Thangamani Ravichandran",
+   "title": "Professor, Department of Humanities and Social Sciences",
+   "dept": "Humanities and Social Sciences",
+   "url": "https://www.iitk.ac.in/t-ravichandran",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
+   "email": "trc@iitk.ac.in",
+   "phone": "0512-392-7871",
+   "web": "https://home.iitk.ac.in/~trc/",
+   "research": "Postmodern American Literature, Critical Theory, Communication Skills",
+   "qualification": "PhD (Pondicherry University)"
+  },
+  {
+   "name": "Thounaojam Somokanta",
+   "title": "Assistant Professor, Department of Humanities and Social Sciences",
+   "dept": "Humanities and Social Sciences",
+   "url": "https://www.iitk.ac.in/thounaojam-somokanta",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
+   "email": "somo@iitk.ac.in",
+   "phone": "0512-259-2324",
+   "office": "Office Department of Humanities and Social Sciences",
+   "research": "Urban sustainability, energy transition, climate governance, coalition studies, transboundary water studies, resource politics, environmental movement, environmental conflict, gender and society, science and technology studies",
+   "qualification": "PhD (Central University of Gujarat, India, 2016 )"
+  },
+  {
+   "name": "Usha Udaar",
+   "title": "Assistant Professor , Department of Humanities and Social Sciences",
+   "dept": "Humanities and Social Sciences",
+   "url": "https://www.iitk.ac.in/usha-udaar",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
+   "email": "ushaudaar@iitk.ac.in",
+   "phone": "0512-259-6915",
+   "office": "Office CESE 106,",
+   "research": "General Linguistics, Linguistic Variation, Generative Theory of Language",
+   "qualification": "PhD, (Indian Institute of technology Delhi, 2017)"
+  },
+  {
+   "name": "Vineet Sahu",
+   "title": "Professor, Department of Humanities and Social Sciences",
+   "dept": "Humanities and Social Sciences",
+   "url": "https://www.iitk.ac.in/vineet-sahu",
+   "depts": [
+    "Humanities and Social Sciences"
+   ],
+   "email": "vineet@iitk.ac.in",
+   "phone": "0512-259-7633",
+   "web": "https://sites.google.com/site/vineetsahu/",
+   "office": "Office FB-661,",
+   "research": "Ethics, Philosophy of Religion, Philosophical Anthropology",
+   "qualification": "PhD (University of Hyderabad)"
+  },
+  {
+   "name": "Raghu Murtugudde",
+   "title": "Visiting Professor, Kotak School of Sustainability",
+   "dept": "Kotak School of Sustainability",
+   "url": "https://www.iitk.ac.in/raghu-murtugudde",
+   "depts": [
+    "Kotak School of Sustainability"
+   ],
+   "email": "mahatma@umd.edu"
+  },
+  {
+   "name": "Sai Czander Ravela",
+   "title": "Visiting Professor, Kotak School of Sustainability",
+   "dept": "Kotak School of Sustainability",
+   "url": "https://www.iitk.ac.in/dr-sai-czander-ravela",
+   "depts": [
+    "Kotak School of Sustainability"
+   ]
+  },
+  {
+   "name": "Sarosh Alam Ghausi",
+   "title": "Assistant Professor, Kotak School of Sustainability",
+   "dept": "Kotak School of Sustainability",
+   "url": "https://www.iitk.ac.in/sarosh-alam-ghausi",
+   "depts": [
+    "Kotak School of Sustainability"
+   ],
+   "email": "saroshag@iitk.ac.in",
+   "phone": "0512-679-2114",
+   "web": "https://sites.google.com/view/sarosh-alam-ghausi",
+   "office": "CESE Building, Room 103,",
+   "research": "Land-atmosphere Interactions Extreme Weather events Earth system Modelling Hybrid AI-Physics Frameworks for Climate Modelling Thermodynamics",
+   "qualification": "PhD (MPI-BGC) and (KIT), Germany"
+  },
+  {
+   "name": "Venkatachalam \"Ram\" Ramaswamy",
+   "title": "Distinguished Visiting Faculty, Kotak School of Sustainability",
+   "dept": "Kotak School of Sustainability",
+   "url": "https://www.iitk.ac.in/venkatachalam-ram-ramaswamy",
+   "depts": [
+    "Kotak School of Sustainability"
+   ],
+   "email": "v.ramaswamy@noaa.gov",
+   "phone": "+91-512-679-7274"
+  },
+  {
+   "name": "Somitra Kumar Sanadhya",
+   "title": "Professor, Wadhwani School of AI & Intelligent Systems (WSAIS)",
+   "dept": "Wadhwani School of AI & Intelligent Systems (WSAIS)",
+   "url": "https://www.iitk.ac.in/somitra-kumar-sanadhya",
+   "depts": [
+    "Wadhwani School of AI & Intelligent Systems (WSAIS)"
+   ],
+   "email": "somitra@iitk.ac.in"
+  },
+  {
+   "name": "Sudhir Saxena",
+   "title": "Visiting Professor of Practice, Wadhwani School of AI & Intelligent Systems (WSAIS)",
+   "dept": "Wadhwani School of AI & Intelligent Systems (WSAIS)",
+   "url": "https://www.iitk.ac.in/dr-sudhir-saxena",
+   "depts": [
+    "Wadhwani School of AI & Intelligent Systems (WSAIS)"
+   ],
+   "email": "sudhirs@iitk.ac.in"
+  },
+  {
+   "name": "Dharmaraja Allimuthu",
+   "title": "Associate Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/dharmaraja-allimuthu",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "atdharma@iitk.ac.in",
+   "phone": "+91512-259-2086",
+   "web": "https://sites.google.com/view/dharmalab",
+   "office": "SL 206, Southern laboratories",
+   "research": "Targeting Ferroptosis in Cancer and Neurodegeneration Covalent Probes for Selective Modification of Amino Acids Small-Molecule Inducers of Lipid Droplets Targeted Protein Degradation: PROTACs & Molecular Glues",
+   "qualification": "PhD (IISER-Pune)"
+  },
+  {
+   "name": "Dr. Hiroyuki Furuta",
+   "title": "Distinguished Visiting Professor (VAJRA), Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/dr-hiroyuki-furuta",
+   "depts": [
+    "Chemistry"
+   ]
+  },
+  {
+   "name": "Dr. Varinder Kumar Aggarwal",
+   "title": "Distinguished Visiting Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/dr-varinder-kumar-aggarwal",
+   "depts": [
+    "Chemistry"
+   ]
+  },
+  {
+   "name": "Gurunath Ramanathan",
+   "title": "Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/gurunath-ramanathan",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "gurunath@iitk.ac.in",
+   "phone": "0512-259-7417",
+   "web": "https://home.iitk.ac.in/~gurunath/",
+   "office": "CL 203E ,",
+   "qualification": "PhD (IISc Bangalore)"
+  },
+  {
+   "name": "Jarugu Narasimha Moorthy",
+   "title": "Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/j-n-moorthy",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "moorthy@iitk.ac.in",
+   "phone": "0512-259-7438",
+   "web": "https://home.iitk.ac.in/~moorthy/",
+   "office": "CL 204A ,",
+   "research": "Organic Photochemistry, Supramolecular Chemistry, Mechanistic Organic Chemistry and Synthesis",
+   "qualification": "PhD (IISc Bangalore)"
+  },
+  {
+   "name": "Jitendra Kumar Bera",
+   "title": "Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/jitendra-k-bera",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "jbera@iitk.ac.in",
+   "phone": "0512-259-7336",
+   "web": "https://home.iitk.ac.in/~jbera/",
+   "office": "CL 107A/B,",
+   "research": "Bimetallic Synergism, Small Molecule Activation, Metal-Ligand Cooperativity, N-Heterocyclic Carbene, Green Chemistry.",
+   "qualification": "PhD (IISc Bangalore)"
+  },
+  {
+   "name": "Maddali Lakshmi Narayana Rao",
+   "title": "Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/m-l-n-rao",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "maddali@iitk.ac.in",
+   "phone": "0512-259-7163",
+   "web": "https://maddali.wixsite.com/mlnrao",
+   "office": "CL 204E/ Core Labs ,",
+   "qualification": "PhD (University of Hyderabad)"
+  },
+  {
+   "name": "Madhav V Ranganathan",
+   "title": "Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/madhav-ranganathan",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "madhavr@iitk.ac.in",
+   "phone": "0512-259-6037",
+   "web": "https://home.iitk.ac.in/~madhavr/",
+   "office": "Old SAC C'-CHM-104,",
+   "research": "Modeling and Simulation of crystal growth of classical semiconductors and 2D materials",
+   "qualification": "PhD (Stanford University)"
+  },
+  {
+   "name": "Mainak Sadhukhan",
+   "title": "Assistant Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/mainak-sadhukhan",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "mainaks@iitk.ac.in",
+   "phone": "0512-259-2062",
+   "web": "https://home.iitk.ac.in/~mainaks/",
+   "office": "FB 424,",
+   "qualification": "PhD (IISER-Kolkata)"
+  },
+  {
+   "name": "Manabendra Chandra",
+   "title": "Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/manabendra-chandra",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "mchandra@iitk.ac.in",
+   "phone": "0512-259-7265",
+   "web": "https://home.iitk.ac.in/~mchandra/",
+   "office": "FB-424,",
+   "qualification": "PhD (IISc Bangalore)"
+  },
+  {
+   "name": "Manas Kumar Ghorai",
+   "title": "Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/manas-k-ghorai",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "mkghorai@iitk.ac.in",
+   "phone": "0512-259-7518",
+   "web": "https://home.iitk.ac.in/~mkghorai/",
+   "office": "Indian Institute of Technology Kanpur",
+   "research": "Aziridine and azetidine chemistry, Dianion chemistry, Memory of chirality, Organocatalysis",
+   "qualification": "PhD (NCL Pune)"
+  },
+  {
+   "name": "Nagma Parveen",
+   "title": "Associate Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/nagma-parveen",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "nagma@iitk.ac.in",
+   "phone": "0512-259-2154",
+   "web": "https://sites.google.com/view/bionanoparticle-lab/research?authuser=0",
+   "office": "Room No. 437 ,",
+   "qualification": "PhD (University of Muenster)"
+  },
+  {
+   "name": "Namrata Singh",
+   "title": "Assistant Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/namrata-singh",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "namrata@iitk.ac.in",
+   "phone": "0512-259-2527",
+   "web": "https://www.namratasingh.co.in/",
+   "office": "Office FB 437, Faculty Building,",
+   "qualification": "PhD (Indian Institute of Science)"
+  },
+  {
+   "name": "Nisanth Narayanan Nair",
+   "title": "Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/nisanth-n-nair",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "nnair@iitk.ac.in",
+   "phone": "0512-259-6311",
+   "web": "https://home.iitk.ac.in/~nnair/",
+   "office": "Southern Labs, 302",
+   "qualification": "PhD (Universität Hannover)"
+  },
+  {
+   "name": "Parthasarathi Subramanian",
+   "title": "Assistant Professor , Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/parthasarathi-subramanian",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "parthas@iitk.ac.in",
+   "phone": "0512-259-2153",
+   "web": "https://sites.google.com/view/parthasarathi-lab/home?authuser=0",
+   "office": "Office Old SAC, Block C, Ground Floor ,",
+   "qualification": "PhD (IIT Bombay)"
+  },
+  {
+   "name": "Prakash Chandra Mondal",
+   "title": "Associate Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/prakash-chandra-mondal",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "pcmondal@iitk.ac.in",
+   "phone": "0512-259-2074",
+   "web": "https://mondalpc.wixsite.com/mondalresearchgroup",
+   "office": "FB 436 ,",
+   "qualification": "PhD (University of Delhi)"
+  },
+  {
+   "name": "Raja Angamuthu",
+   "title": "Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/raja-angamuthu",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "raja@iitk.ac.in",
+   "phone": "0512-259-6786",
+   "web": "http://lisbic.com/",
+   "office": "CL101C,",
+   "qualification": "PhD (Leiden University)"
+  },
+  {
+   "name": "Ramesh Ramapanicker",
+   "title": "Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/ramesh-ramapanicker",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "rameshr@iitk.ac.in",
+   "phone": "0512-259-6684",
+   "web": "http://www.ramapanicker.net/",
+   "office": "SL 207,",
+   "qualification": "PhD (IISc Bangalore)"
+  },
+  {
+   "name": "Ramkrishna Sarkar",
+   "title": "Assistant Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/ramkrishna-sarkar",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "ramkrishna@iitk.ac.in",
+   "phone": "+91512-259-2304",
+   "office": "Office Faculty building 435,",
+   "research": "Polymer synthesis, Dynamic covalent polymeric network, Reusable polymeric (coating) materials, Recycling and upcycling of polymers, Bio-sourced reusable polymers, Light-driven (green) catalysis in water",
+   "qualification": "Ph.D. (IISc Bangalore)"
+  },
+  {
+   "name": "Ritika Gautam Singh",
+   "title": "Associate Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/ritika-gautam",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "rgautam@iitk.ac.in",
+   "phone": "0512-259-2106",
+   "web": "https://www.ritikagautam.co.in/",
+   "office": "Office 202H, Core Lab Extension",
+   "qualification": "PhD (The University of Arizona)"
+  },
+  {
+   "name": "Sabuj Kumar Kundu",
+   "title": "Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/sabuj-kumar-kundu",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "sabuj@iitk.ac.in",
+   "phone": "0512-259-7425",
+   "web": "https://pincersabuj.wixsite.com/skk-lab",
+   "office": "FB 404,",
+   "research": "Organometallic Chemistry, Catalysis and Mechanistic Investigation, C-X (X= H, C, O, etc.) Bond, Activation and Functionalization, Renewable Energy and Green Chemistry",
+   "qualification": "PhD (Rutgers University)"
+  },
+  {
+   "name": "Sandeep Verma",
+   "title": "Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/sandeep-verma",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "sverma@iitk.ac.in",
+   "phone": "0512-259-7643",
+   "web": "https://home.iitk.ac.in/~sverma/",
+   "office": "CL 206E ,",
+   "research": "My lab is interested in using biological building blocks to unravel diseases concerning protein aggregation and indulge in creating bioinspired soft matter. These studies involve synthetic organic chemistry and state-of-the-art spectroscopic and microscopic tools.",
+   "qualification": "PhD (University of Illinois)"
+  },
+  {
+   "name": "Sankar Prasad Rath",
+   "title": "Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/sankar-prasad",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "sprath@iitk.ac.in",
+   "phone": "0512-259-7251",
+   "web": "https://home.iitk.ac.in/~sprath/",
+   "office": "CL-205C ,",
+   "qualification": "PhD (IACS, Kolkata)"
+  },
+  {
+   "name": "Srihari Keshavamurthy",
+   "title": "Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/k-srihari",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "srihari@iitk.ac.in",
+   "phone": "0512-259-7469",
+   "web": "https://home.iitk.ac.in/~srihari/ks/home.html",
+   "office": "FB 435/SL 304 Faculty Bldg. ,",
+   "qualification": "PhD (University of California)"
+  },
+  {
+   "name": "Srinivas Dharavath",
+   "title": "Associate Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/srinivas-dharavath",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "srinivasd@iitk.ac.in",
+   "phone": "0512-259-7826",
+   "web": "https://www.energeticslab.com/",
+   "office": "Room. No: 6, Block-A, OLD SAC,",
+   "qualification": "PhD (University of Hyderabad)"
+  },
+  {
+   "name": "T. G. Gopakumar",
+   "title": "Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/thiruvancheril-g-gopakumar",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "gopan@iitk.ac.in",
+   "phone": "0512-259-6830",
+   "web": "https://home.iitk.ac.in/~gopan/",
+   "office": "SL 213 ,",
+   "qualification": "PhD (University of Chemnitz)"
+  },
+  {
+   "name": "Venkata Suresh Mothika",
+   "title": "Assistant Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/venkata-suresh-mothika",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "smothika@iitk.ac.in",
+   "phone": "+91-512-259-2335",
+   "web": "https://smothika37.wixsite.com/organic-molecules-an/research",
+   "office": "Office Old core extension 101H",
+   "research": "Porous Organic Materials, Photocatalysis, Supramolecular Chemistry",
+   "qualification": "Ph.D. (JNCASR Bangalore)"
+  },
+  {
+   "name": "Vinod Kumar Singh",
+   "title": "Emeritus Fellow, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/vinod-k-singh",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "vinodks@iitk.ac.in",
+   "phone": "0512-259-7291",
+   "web": "https://home.iitk.ac.in/~vinodks/",
+   "office": "CL 205A ,",
+   "qualification": "PhD (M. S. University Baroda)"
+  },
+  {
+   "name": "Vishal Govind Rao",
+   "title": "Associate Professor, Department of Chemistry",
+   "dept": "Chemistry",
+   "url": "https://www.iitk.ac.in/vishal-govind-rao",
+   "depts": [
+    "Chemistry"
+   ],
+   "email": "vgrao@iitk.ac.in",
+   "phone": "0512-259-2077",
+   "web": "https://vgrresearchpage.myfreesites.net/",
+   "office": "FB 422,",
+   "research": "Plasmonic photocatalysis; interfacial charge transfer dynamics; strategies for efficient solar energy utilization, and carbon dioxide reduction into hydrocarbon fuels",
+   "qualification": "PhD (IIT Kharagpur)"
+  },
+  {
+   "name": "Rabiul Haque Biswas",
+   "title": "Assistant Professor, Department of Earth Sciences",
+   "dept": "Earth Sciences",
+   "url": "https://www.iitk.ac.in/rabiul-haque-biswas",
+   "depts": [
+    "Earth Sciences"
+   ],
+   "email": "rabiul@iitk.ac.in"
+  },
+  {
+   "name": "Rajiv Sinha",
+   "title": "Professor, Departement of Earth Sciences",
+   "dept": "Earth Sciences",
+   "url": "https://www.iitk.ac.in/rajiv-sinha",
+   "depts": [
+    "Earth Sciences"
+   ],
+   "email": "rsinha@iitk.ac.in",
+   "phone": "0512-259-7317",
+   "web": "https://home.iitk.ac.in/~rsinha/",
+   "office": "Office 303B, Western Lab Extension Building",
+   "research": "River science-river morphology and dynamics, flood hazards, morphology-ecology linkages Remote Sensing and GIS Applications Climate Change and paleoclimate reconstruction",
+   "qualification": "PhD (University of Cambridge, England)"
+  },
+  {
+   "name": "Santanu Misra",
+   "title": "Professor, Department of Earth Sciences",
+   "dept": "Earth Sciences",
+   "url": "https://www.iitk.ac.in/santanu-misra",
+   "depts": [
+    "Earth Sciences"
+   ],
+   "email": "smisra@iitk.ac.in",
+   "phone": "0512-259-6812",
+   "web": "https://home.iitk.ac.in/~smisra/index.html",
+   "office": "Office Room no. 201, Old SAC Building",
+   "qualification": "PhD (Jadavpur University)"
+  },
+  {
+   "name": "Shyam Nandan",
+   "title": "Assistant Professor, Department of Earth Sciences",
+   "dept": "Earth Sciences",
+   "url": "https://www.iitk.ac.in/shyam-nandan",
+   "depts": [
+    "Earth Sciences"
+   ],
+   "email": "snandan@iitk.ac.in"
+  },
+  {
+   "name": "Tajdarul Hassan Syed",
+   "title": "Professor, Department of Earth Sciences",
+   "dept": "Earth Sciences",
+   "url": "https://www.iitk.ac.in/tajdarul-hassan-syed",
+   "depts": [
+    "Earth Sciences"
+   ],
+   "email": "tsyed@iitk.ac.in"
+  },
+  {
+   "name": "Thupstan Angchuk",
+   "title": "Assistant Professor, Department of Earth Sciences",
+   "dept": "Earth Sciences",
+   "url": "https://www.iitk.ac.in/thupstan-angchuk",
+   "depts": [
+    "Earth Sciences"
+   ],
+   "email": "thupstan@iitk.ac.in"
+  },
+  {
+   "name": "Debasis Sen",
+   "title": "Associate Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/sen-d",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "debasis@iitk.ac.in",
+   "phone": "0512-259-6401",
+   "web": "https://sites.google.com/site/sendeba/",
+   "office": "FB501",
+   "research": "Equivariant Homotopy Theory, Equivariant cohomology with local coefficients, Higher category theory, Model category.",
+   "qualification": "PhD (ISI Kolkata)"
+  },
+  {
+   "name": "Dhirendra Bahuguna",
+   "title": "Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/dhirendra-bahuguna",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "dhiren@iitk.ac.in",
+   "phone": "0512-259-7053",
+   "web": "https://home.iitk.ac.in/~dhiren/",
+   "office": "Prof. D. Bahuguna",
+   "research": "Differential Equations In Abstract Spaces, Functional Differential Equations, Fractional Differential Equations, Intregal Equations",
+   "qualification": "PhD (IIT Kanpur)"
+  },
+  {
+   "name": "Dipak K. Dey",
+   "title": "Distinguished Visiting Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/dipak-k-dey",
+   "depts": [
+    "Mathematics"
+   ]
+  },
+  {
+   "name": "Dr. Ashutosh Kumar",
+   "title": "Assistant Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/ashutosh-kumar",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "krashu@iitk.ac.in",
+   "phone": "0512-259-2104",
+   "web": "https://home.iitk.ac.in/~krashu/",
+   "research": "Mathematical Logic, Set Theory and its applications to Analysis, Measure Theory and Topology.",
+   "qualification": "PhD: University of Wisconsin Madison"
+  },
+  {
+   "name": "Dr. Cherif Amrouche",
+   "title": "Distinguished Visiting Professor, Department of Maths",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/dr-cherif-amrouche",
+   "depts": [
+    "Mathematics"
+   ]
+  },
+  {
+   "name": "Indranil Chowdhury",
+   "title": "Assistant Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/indranil-chowdhury",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "indranil@iitk.ac.in",
+   "phone": "0512-259-2371",
+   "web": "https://sites.google.com/view/indranil-chowdhury-math",
+   "office": "FB579",
+   "research": "Theory and Numerical Analysis of PDEs, Nonlocal/ Fractional order Problems, Fully Nonlinear Equations",
+   "qualification": "Ph.D (TIFR - CAM, Bengaluru, India)"
+  },
+  {
+   "name": "Kaushik Bal",
+   "title": "Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/kaushik-bal",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "kaushik@iitk.ac.in",
+   "phone": "0512-259-6217",
+   "web": "https://sites.google.com/view/kaushikbal/home",
+   "office": "FB - 327",
+   "qualification": "PhD (UPPA, France)"
+  },
+  {
+   "name": "Keshab Chandra Bakshi",
+   "title": "Associate Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/keshab-chandra-bakshi",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "keshab@iitk.ac.in",
+   "web": "https://sites.google.com/view/keshab-bakshi/home",
+   "office": "Department of Mathematics and Statistics",
+   "research": "C*-algebras and von Neumann algebras. In particular, Subfactor theory and Planar algebras.",
+   "qualification": "PhD (IMSc., Chennai)"
+  },
+  {
+   "name": "Malay Banerjee",
+   "title": "Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/malay-banerjee",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "malayb@iitk.ac.in",
+   "phone": "0512-259-6157",
+   "web": "https://sites.google.com/view/malaybanerjee/home",
+   "office": "FB-526,",
+   "research": "Mathematical Ecology and Eco-epidemiology, Nonlinear Dynamics",
+   "qualification": "PhD (University of Calcutta)"
+  },
+  {
+   "name": "Mohua Banerjee",
+   "title": "Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/mohua-banerjee",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "mohua@iitk.ac.in",
+   "phone": "0512-259-7634",
+   "web": "https://home.iitk.ac.in/~mohua/",
+   "office": "Department of Mathematics",
+   "research": "Rough Set Theory and its Applications, Modal Logics",
+   "qualification": "PhD (University of Calcutta)"
+  },
+  {
+   "name": "Mrinmay Biswas",
+   "title": "Assistant Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/mrinmay-biswas",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "mbiswas@iitk.ac.in",
+   "phone": "0512-679-2342",
+   "web": "https://sites.google.com/view/mrinmayhome/home",
+   "office": "Room No- 502, FB",
+   "research": "PDE, Stochastic PDE, Control Theory and Numerics.",
+   "qualification": "Ph.D (IISER, Kolkata)"
+  },
+  {
+   "name": "Muthukumar P",
+   "title": "Assistant Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/p-muthukumar",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "muthu@iitk.ac.in",
+   "web": "https://sites.google.com/view/pmuthukumar/home",
+   "office": "IIT Kanpur, Kanpur 208016.",
+   "research": "Complex Analysis and Operator Theory",
+   "qualification": "PhD, (Indian Statistical Institute, Chennai)"
+  },
+  {
+   "name": "Muthukumar T",
+   "title": "Professor, Department of Mathematics & Statistics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/muthukumar-t",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "tmk@iitk.ac.in",
+   "phone": "0512-259-7911",
+   "web": "https://home.iitk.ac.in/~tmk/",
+   "office": "FB 326,",
+   "research": "Homogenization and Variational Methods for PDE's, Elliptic PDE's, Optimal controls",
+   "qualification": "PhD (Institute of Mathematical Sciences)"
+  },
+  {
+   "name": "Nandini Nilakantan",
+   "title": "Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/nandini-nilakantan",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "nandini@iitk.ac.in",
+   "phone": "0512-259-7066",
+   "office": "FB 508,",
+   "research": "Combinatorial Topology, Computational Geometry",
+   "qualification": "PhD (IISC, Banglore)"
+  },
+  {
+   "name": "Narasimha Chary Bonala",
+   "title": "Assistant Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/narasimha-chary-bonala",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "chary@iitk.ac.in",
+   "web": "https://home.iitk.ac.in/~chary/",
+   "office": "503 H-N (Diamond Jubilee Academic Complex),",
+   "research": "Algebraic Groups, Algebraic geometry and Representation Theory",
+   "qualification": "Ph.D, Chennai Mathematical Institute, Chennai"
+  },
+  {
+   "name": "Palanikumar Shunmugaraj",
+   "title": "Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/shunmugaraj-p",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "psraj@iitk.ac.in",
+   "phone": "0512-259-7297",
+   "web": "https://home.iitk.ac.in/~psraj/",
+   "office": "FB558",
+   "research": "Functional Analysis",
+   "qualification": "PhD (IIT Bombay)"
+  },
+  {
+   "name": "Parasar Mohanty",
+   "title": "Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/parasar-mohanty",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "parasar@iitk.ac.in",
+   "phone": "0512-259-6139",
+   "web": "https://www.iitk.ac.in/math/faculty/parasar/",
+   "office": "FB 502,",
+   "research": "Harmonic Analysis",
+   "qualification": "PhD (IIT Kanpur)"
+  },
+  {
+   "name": "Pooja Singla",
+   "title": "Associate Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/pooja-singla",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "psingla@iitk.ac.in",
+   "phone": "0512 679 4784",
+   "web": "https://sites.google.com/site/poojasingla7/Home",
+   "office": "KD 206 (H R Kadim Diwan Building)",
+   "research": "Representations theory of finite and p-adic groups, Applications of representation theory",
+   "qualification": "PhD: The Institute of Mathematical Sciences, Chennai"
+  },
+  {
+   "name": "Preena Samuel",
+   "title": "Associate Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/preena-samuel",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "preena@iitk.ac.in",
+   "phone": "0512-259-6917",
+   "web": "https://home.iitk.ac.in/~preena/",
+   "qualification": "PhD (IMSc, Chennai)"
+  },
+  {
+   "name": "Prosenjit Roy",
+   "title": "Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/prosenjit-roy",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "prosenjit@iitk.ac.in",
+   "phone": "0512-259-2008",
+   "web": "https://sites.google.com/view/prosenjit/home?authuser=1I",
+   "office": "FB 507",
+   "research": "Nonlinear Functional Inequalities, Asymptotic Aanalysis, Nonlocal Problems",
+   "qualification": "PhD (University of Zurich, Switzerland)"
+  },
+  {
+   "name": "Rama Rawat",
+   "title": "Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/rama-rawat",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "rrawat@iitk.ac.in",
+   "phone": "0512-259-7466",
+   "web": "https://home.iitk.ac.in/~rrawat/",
+   "office": "FB 509, Faculty Building,",
+   "research": "Harmonic analysis on Lie groups.",
+   "qualification": "PhD (ISI Bangalore)"
+  },
+  {
+   "name": "Sachin Subhash Sharma",
+   "title": "Associate Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/sachin-sharma",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "sachinsh@iitk.ac.in",
+   "phone": "0512-679-7206",
+   "office": "FB 575",
+   "research": "Representation theory of Kac-Moody algebra, extended affine Lie algebra",
+   "qualification": "PhD (IMSc, Chennai)"
+  },
+  {
+   "name": "Saktipada Ghorai",
+   "title": "Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/s-ghorai",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "sghorai@iitk.ac.in",
+   "phone": "0512-259-7461",
+   "web": "https://home.iitk.ac.in/~sghorai/",
+   "office": "FB-559 ,",
+   "research": "Mathematical Biology, Bio-fluid Dynamics, Computational Fluid Dynamics",
+   "qualification": "PhD (Leeds, UK)"
+  },
+  {
+   "name": "Sameer Laxman Chavan",
+   "title": "Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/sameer-chavan",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "chavan@iitk.ac.in",
+   "phone": "0512-259-7158",
+   "web": "https://home.iitk.ac.in/~chavan/",
+   "office": "Department of Mathematics",
+   "research": "Operator Theory",
+   "qualification": "PhD (University of Pune)"
+  },
+  {
+   "name": "Santosh V R N Nadimpalli",
+   "title": "Associate Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/santosh-nadimpalli",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "nsantosh@iitk.ac.in",
+   "web": "https://home.iitk.ac.in/~nsantosh/",
+   "office": "Old SAC, Block C, first floor, Room No. 5.,",
+   "research": "Representation theory",
+   "qualification": "PhD (Universitè Paris-XI, Orsay and University of Leiden)"
+  },
+  {
+   "name": "Santosha Kumar Pattanayak",
+   "title": "Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/sk-pattanayak",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "santosha@iitk.ac.in",
+   "phone": "0512-259-6402",
+   "web": "https://home.iitk.ac.in/~santosha/",
+   "office": "FB 502",
+   "research": "Algebraic Groups and Invariant Theory, Lie Algebra and Representation Theory",
+   "qualification": "PhD (CMI Chennai)"
+  },
+  {
+   "name": "Sasmita Patnaik",
+   "title": "Associate Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/sasmita-patnaik",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "sasmita@iitk.ac.in",
+   "phone": "0512-259-7972",
+   "web": "https://home.iitk.ac.in/~sasmita/",
+   "office": "Room number 572",
+   "research": "Operator Theory, Problems in operator theory and applications of operator theory to operator algebras",
+   "qualification": "PhD (University of Cincinnati, USA)"
+  },
+  {
+   "name": "Satyajit Guin",
+   "title": "Associate Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/satyajit-guin",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "sguin@iitk.ac.in",
+   "phone": "0512-259 2053",
+   "web": "https://sites.google.com/view/satyajitguin/home",
+   "office": "FB 573",
+   "research": "Noncommutative Geometry, Operator Algebra",
+   "qualification": "PhD (PhD, IMSc, Chennai)"
+  },
+  {
+   "name": "Saurabh Kumar Singh",
+   "title": "Associate Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/saurabh-kumar-singh",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "saurabs@iitk.ac.in",
+   "phone": "0512-679-2136",
+   "office": "Old SAC A Block Room no 7,",
+   "research": "L-Function, Sub-convexity problems, Sieve Method, Riemann Zeta Function",
+   "qualification": "PhD (TIFR, Mumbai)"
+  },
+  {
+   "name": "Sayani Bera",
+   "title": "Associate Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/sayani-bera",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "sayani@iitk.ac.in",
+   "phone": "0512-259-2664",
+   "web": "https://sites.google.com/view/sayanibera/home",
+   "office": "FB102",
+   "research": "Holomorphic dynamics, Several Complex Variables",
+   "qualification": "PhD (IISc Bangalore)"
+  },
+  {
+   "name": "Somnath Jha",
+   "title": "Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/somnath-jha",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "jhasom@iitk.ac.in",
+   "phone": "0512-259-6916",
+   "web": "https://sites.google.com/view/jhasom",
+   "office": "FB-561, IIT Kanpur, Kanpur -208016, Uttar Pradesh, India",
+   "research": "Number Theory, Arithmetic Geometry",
+   "qualification": "PhD (Tata Institute of Fundamental Research, Mumbai)"
+  },
+  {
+   "name": "Stephanie Cupit-Foutou",
+   "title": "Visiting Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/stephanie-cupit-foutou",
+   "depts": [
+    "Mathematics"
+   ]
+  },
+  {
+   "name": "Sudhanshu Shekhar",
+   "title": "Associate Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/sudhanshu-shekhar",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "sudhansh@iitk.ac.in",
+   "phone": "0512-679-7834",
+   "web": "https://sites.google.com/site/shekharhomepage/home",
+   "office": "FB 329, Department of Mathematics,",
+   "research": "Algebraic Number Theory and Arithmetic Geometry",
+   "qualification": "PhD (TIFR, Mumbai)"
+  },
+  {
+   "name": "Vedansh Arya",
+   "title": "Assistant Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/vedansh-arya",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "vedansh@iitk.ac.in",
+   "phone": "0512-259-2629",
+   "web": "https://sites.google.com/view/vedansharya/home",
+   "office": "OSAC 201B, IIT Kanpur",
+   "research": "Regularity theory for elliptic and parabolic PDEs, Unique continuation problems, Free boundary problems, Curvature driven flows.",
+   "qualification": "PhD, TIFR CAM"
+  },
+  {
+   "name": "Vikramjeet Singh Chandel",
+   "title": "Assistant Professor, Department of Mathematics",
+   "dept": "Mathematics",
+   "url": "https://www.iitk.ac.in/vikramjeet-singh-chandel",
+   "depts": [
+    "Mathematics"
+   ],
+   "email": "vschandel@iitk.ac.in",
+   "phone": "0512-259-2296",
+   "web": "https://sites.google.com/view/vikramjeet-chandel",
+   "office": "FB 508 (Faculty Building)",
+   "research": "Several Complex Variables",
+   "qualification": "PhD (IISc, Bengaluru)"
+  },
+  {
+   "name": "Dipankar Chakrabarti",
+   "title": "Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/dr-dipankar-chakrabarti",
+   "depts": [
+    "Physics"
+   ],
+   "email": "dipankar@iitk.ac.in",
+   "phone": "0512-259-6696",
+   "web": "https://home.iitk.ac.in/~dipankar/",
+   "office": "Office FB-489,",
+   "research": "Quantum Chromodynamics, Light cone field Theories, Lattice Gauge Theories",
+   "qualification": "PhD (Saha Institute of Nuclear Physics)"
+  },
+  {
+   "name": "Diptarka Das",
+   "title": "Associate Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/diptarka-das",
+   "depts": [
+    "Physics"
+   ],
+   "email": "didas@iitk.ac.in",
+   "phone": "+91 512 259 2057",
+   "web": "https://home.iitk.ac.in/~didas/",
+   "office": "Old SAC-206, IIT Kanpur, Kanpur, 208016, U.P., India",
+   "research": "Areas of Interest: Conformal field theories, Non-equilibrium physics, String theory",
+   "qualification": "Ph.D., University of Kentucky, 2014"
+  },
+  {
+   "name": "Dr. Delache Alexandre",
+   "title": "Visiting Associate Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/dr-delache-alexandre",
+   "depts": [
+    "Physics"
+   ]
+  },
+  {
+   "name": "Gopal Hazra",
+   "title": "Assistant Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/gopal-hazra",
+   "depts": [
+    "Physics"
+   ],
+   "email": "hazra@iitk.ac.in",
+   "phone": "+91-512-259-2377",
+   "web": "https://gopalhazra.github.io/",
+   "office": "Room No-604, Engineering Science Building-II Department of Physics",
+   "research": "Astrophysical Magnetic fields, Exoplanets, Exoplanetary Atmospheres, Solar and Planetary winds, Space weather",
+   "qualification": "Ph.D., IISc Bangalore, 2018"
+  },
+  {
+   "name": "Goutam Das",
+   "title": "Assistant Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/goutam-das",
+   "depts": [
+    "Physics"
+   ],
+   "email": "gkdgoutam@iitk.ac.in",
+   "phone": "0512-679-2639",
+   "web": "https://home.iitk.ac.in/~gkdgoutam",
+   "office": "FB-253, Department of Physics, IIT Kanpur, Kanpur, 208016, U.P., India",
+   "research": "Perturbative Quantum Chromodynamics, Soft-Collinear Effective Theory, Precision Collider Physics"
+  },
+  {
+   "name": "Jayita Nayak",
+   "title": "Associate Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/jayita-nayak",
+   "depts": [
+    "Physics"
+   ],
+   "email": "jnayak@iitk.ac.in",
+   "phone": "0512-259-6557",
+   "web": "https://sites.google.com/view/dr-jayita-nayak-iit-kanpur/",
+   "office": "Office – SL 217",
+   "research": "Angle resolved photoemission spectroscopy of topological insulators, high Tc superconductors, and hard X-ray photoelectron spectroscopy of quasicrystals and Heusler alloys.",
+   "qualification": "PhD (Devi Ahilya Viswavidyalaya Indore)"
+  },
+  {
+   "name": "Joydeep Chakrabortty",
+   "title": "Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/joydeep-chakrabortty",
+   "depts": [
+    "Physics"
+   ],
+   "email": "joydeep@iitk.ac.in",
+   "phone": "0512-259-7083",
+   "web": "https://home.iitk.ac.in/~joydeep/",
+   "office": "Room No. FB-372",
+   "research": "Theoretical Physics, Effective Field Theory, Quantum Field Theory, Spectral Functions, Heat kernel",
+   "qualification": "PhD (Harish-Chandra Research Institute)"
+  },
+  {
+   "name": "Kaushik Bhattacharya",
+   "title": "Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/dr-kaushik-bhattacharya",
+   "depts": [
+    "Physics"
+   ],
+   "email": "kaushikb@iitk.ac.in",
+   "phone": "0512-259-7306",
+   "office": "FB-387,",
+   "qualification": "PhD (Saha Institute of Nuclear Physics)"
+  },
+  {
+   "name": "Kocheri Parampan Rajeev",
+   "title": "Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/k-p-rajeev",
+   "depts": [
+    "Physics"
+   ],
+   "email": "kpraj@iitk.ac.in",
+   "phone": "0512-259-7929",
+   "office": "SL-107A,",
+   "qualification": "PhD (IISc Bangalore)"
+  },
+  {
+   "name": "Koushik Pal",
+   "title": "Assistant Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/koushik-pal",
+   "depts": [
+    "Physics"
+   ],
+   "email": "koushik@iitk.ac.in",
+   "web": "https://sites.google.com/view/koushik-pal",
+   "office": "Department of Physics",
+   "research": "Materials theory and simulation, Materials design and discovery, Topology, transport and defect properties, Quantum and energy materials, Materials informatics and machine learning",
+   "qualification": "Ph.D., JNCASR, 2017"
+  },
+  {
+   "name": "Krishnacharya",
+   "title": "Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/dr-krishnacharya",
+   "depts": [
+    "Physics"
+   ],
+   "email": "kcharya@iitk.ac.in",
+   "phone": "0512-259-7968",
+   "web": "https://home.iitk.ac.in/~kcharya/",
+   "office": "SL-202,",
+   "qualification": "PhD (Max-Planck Institute)"
+  },
+  {
+   "name": "Manas Khan",
+   "title": "Assistant Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/manas-khan",
+   "depts": [
+    "Physics"
+   ],
+   "email": "mkhan@iitk.ac.in",
+   "phone": "+91 512 259 6885",
+   "web": "https://home.iitk.ac.in/~mkhan/",
+   "office": "Office - FB 488, NL - 104",
+   "research": "Studying the statistical physics of soft, biological, and active matters employing various experimental tools, principally optical micromanipulations and imaging, supplemented by numerical simulations and analytical calculations.",
+   "qualification": "PhD (Indian Institute of Science)"
+  },
+  {
+   "name": "Manoj Kumar Harbola",
+   "title": "Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/manoj-k-harbola",
+   "depts": [
+    "Physics"
+   ],
+   "email": "mkh@iitk.ac.in",
+   "phone": "0512-259-7823",
+   "office": "Room No.",
+   "qualification": "PhD (City University of New York, USA)"
+  },
+  {
+   "name": "Navaneeth Poonthottathil",
+   "title": "Assistant Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/navaneeth-poonthottathil",
+   "depts": [
+    "Physics"
+   ],
+   "email": "navaneeth@iitk.ac.in",
+   "phone": "0512-679-2350",
+   "web": "https://neutrinos-iitk.com/",
+   "office": "Office Room No: Block C, 105, Old SAC building",
+   "research": "Experimental High Energy Physics, Neutrino Physics, Long-baseline neutrino experiments",
+   "qualification": "PhD (Cochin University of Science and Technology)"
+  },
+  {
+   "name": "Nilay Kundu",
+   "title": "Associate Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/nilay-kundu",
+   "depts": [
+    "Physics"
+   ],
+   "email": "nilayhep@iitk.ac.in",
+   "phone": "0512-259-6801",
+   "web": "https://home.iitk.ac.in/~nilayhep/",
+   "office": "Office Old SAC Building - Block-C, Room 103",
+   "research": "Classical and Quantum Gravity, Quantum Field Theory, String Theory : AdS/CFT Correspondence.",
+   "qualification": "Ph.D., TIFR, 2014"
+  },
+  {
+   "name": "Sabyasachi Chakraborty",
+   "title": "Assistant Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/sabyasachi-chakraborty",
+   "depts": [
+    "Physics"
+   ],
+   "email": "sabyac@iitk.ac.in",
+   "phone": "0512-279-2349",
+   "web": "https://home.iitk.ac.in/~sabyac",
+   "office": "Office 107, Block C, Old Sac building,",
+   "research": "Theoretical Particle Physics.",
+   "qualification": "(Ph.D. IACS, Kolkata, 2016)"
+  },
+  {
+   "name": "Sagar Chakraborty",
+   "title": "Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/sagar-chakraborty",
+   "depts": [
+    "Physics"
+   ],
+   "email": "sagarc@iitk.ac.in",
+   "phone": "0512-259-6584",
+   "web": "https://home.iitk.ac.in/~sagarc/",
+   "office": "Office number: FB-487,",
+   "qualification": "PhD (S. N. Bose National Center for Basic Sciences, Kolkata)"
+  },
+  {
+   "name": "Saikat Ghosh",
+   "title": "Associate Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/dr-saikat-ghosh",
+   "depts": [
+    "Physics"
+   ],
+   "email": "gsaikat@iitk.ac.in",
+   "phone": "0512-259-6971",
+   "web": "https://sites.google.com/site/saikatghoshiitk/home",
+   "office": "FB-475,",
+   "qualification": "PhD (Cornell University)"
+  },
+  {
+   "name": "Sanmay Ganguly",
+   "title": "Assistant Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/sanmay-ganguly",
+   "depts": [
+    "Physics"
+   ],
+   "email": "sanmay@iitk.ac.in",
+   "office": "Office Room No.- 111, Block A, Old Sac building,",
+   "research": "Experimental High Energy Physics, Application of machine learning in HEP and other branches of physics",
+   "qualification": "PhD (TIFR, Mumbai)"
+  },
+  {
+   "name": "Satyajit Banerjee",
+   "title": "Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/satyajit-banerjee",
+   "depts": [
+    "Physics"
+   ],
+   "email": "satyajit@iitk.ac.in",
+   "phone": "0512-259-7559",
+   "web": "https://sites.google.com/view/molabiitk",
+   "office": "SL-110B,",
+   "qualification": "PhD (TIFR, Mumbai)"
+  },
+  {
+   "name": "Sivasurender Chandran",
+   "title": "Assistant Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/sivasurender-chandran",
+   "depts": [
+    "Physics"
+   ],
+   "email": "schandran@iitk.ac.in",
+   "phone": "0512-259-2164",
+   "web": "https://sites.google.com/view/sivasurenderchandran",
+   "office": "(O - PEB-103, next to Media lab)",
+   "qualification": "(Ph.D.: IISc, 2014)"
+  },
+  {
+   "name": "Soumik Mukhopadhyay",
+   "title": "Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/dr-soumik-mukhopadhyay",
+   "depts": [
+    "Physics"
+   ],
+   "email": "soumikm@iitk.ac.in",
+   "phone": "0512-259-6276",
+   "web": "https://sites.google.com/view/melabiitk/home",
+   "office": "SL-217,",
+   "qualification": "PhD (Saha Institute of Nuclear Physics)"
+  },
+  {
+   "name": "Subhomoy Haldar",
+   "title": "Assistant Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/subhomoy-haldar",
+   "depts": [
+    "Physics"
+   ],
+   "email": "shaldar@iitk.ac.in",
+   "phone": "0512-679-2593",
+   "office": "SL-217,"
+  },
+  {
+   "name": "Sudeep Bhattacharjee",
+   "title": "Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/dr-sudeep-bhattacharjee",
+   "depts": [
+    "Physics"
+   ],
+   "email": "sudeepb@iitk.ac.in",
+   "phone": "0512-259-7602",
+   "web": "https://sites.google.com/view/sudeep-bhattacharjee",
+   "office": "N-LAB-T102,",
+   "qualification": "PhD (RIKEN, JAPAN)"
+  },
+  {
+   "name": "Sudeep Kumar Ghosh",
+   "title": "Assistant Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/sudeep-kumar-ghosh",
+   "depts": [
+    "Physics"
+   ],
+   "email": "skghosh@iitk.ac.in",
+   "phone": "0512-259-2318",
+   "web": "https://sites.google.com/view/sudeep-kumar-ghosh/",
+   "office": "Office FB-386,",
+   "research": "Superconductivity and magnetism, Topological order, Ultracold atoms.",
+   "qualification": "PhD (IISc, Bangalore)"
+  },
+  {
+   "name": "Sudipta Dubey",
+   "title": "Assistant Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/sudipta-dubey",
+   "depts": [
+    "Physics"
+   ],
+   "email": "sudiptad@iitk.ac.in",
+   "phone": "0512-679-2174",
+   "office": "Office (O-SL217B),",
+   "research": "Physics of atomically thin materials, Valleytronics, Twistronics",
+   "qualification": "(Ph.D., TIFR, 2015)"
+  },
+  {
+   "name": "Supratik Banerjee",
+   "title": "Associate Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/supratik-banerjee",
+   "depts": [
+    "Physics"
+   ],
+   "email": "sbanerjee@iitk.ac.in",
+   "web": "https://home.iitk.ac.in/~sbanerjee/",
+   "office": "Faculty building 388",
+   "research": "(i) Plasma astrophysics (ii) Turbulence and reconnection in space plasmas (iii) Multiphase turbulence (iv) Turbulence in the presence of spin (ferrofluids etc.)",
+   "qualification": "PhD (Universite Paris-Sud, Orsay, France )"
+  },
+  {
+   "name": "Swagata Mukherjee",
+   "title": "Assistant Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/swagata-mukherjee",
+   "depts": [
+    "Physics"
+   ],
+   "email": "swagata@iitk.ac.in",
+   "office": "Office Room No 103, PEB (near Media lab),",
+   "qualification": "Ph.D., Saha Institute of Nuclear Physics, University of Calcutta, 2016"
+  },
+  {
+   "name": "Tapobrata Sarkar",
+   "title": "Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/dr-tapobrata-sarkar",
+   "depts": [
+    "Physics"
+   ],
+   "email": "tapo@iitk.ac.in",
+   "phone": "0512-259-6103",
+   "web": "https://home.iitk.ac.in/~tapo/",
+   "office": "FB-375,",
+   "research": "High Energy Astrophysical phenomena, Strong Gravity, Tidal Disruption Events, Quantum Information",
+   "qualification": "PhD (IMSc Chennai)"
+  },
+  {
+   "name": "Taraknath Mandal",
+   "title": "Associate Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/taraknath-mandal",
+   "depts": [
+    "Physics"
+   ],
+   "email": "taraknath@iitk.ac.in",
+   "phone": "0512-259-2235",
+   "web": "https://home.iitk.ac.in/~taraknath/",
+   "office": "101, BLOCK - C,",
+   "research": "Computational Soft Matter Physics and Biophysics",
+   "qualification": "PhD, IISc Bangalore"
+  },
+  {
+   "name": "Tarun Kanti Ghosh",
+   "title": "Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/dr-tarun-kanti-ghosh",
+   "depts": [
+    "Physics"
+   ],
+   "email": "tkghosh@iitk.ac.in",
+   "phone": "0512-259-7276",
+   "web": "https://home.iitk.ac.in/~tkghosh/",
+   "office": "FB-352,",
+   "research": "Atomically Thin Materials, low-dimensional fermion systems, ultra-cold atomic superfluid",
+   "qualification": "PhD (Institute of Mathematical Sciences, Chennai)"
+  },
+  {
+   "name": "Venkata Jayasurya Yallapragada",
+   "title": "Assistant Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/venkata-jayasurya-yallapragada",
+   "depts": [
+    "Physics"
+   ],
+   "email": "jayasurya@iitk.ac.in",
+   "phone": "0512-259-2253",
+   "web": "https://home.iitk.ac.in/~jayasurya/",
+   "office": "Department of Physics",
+   "research": "Nanophotonics, nanoscale light emitters and scatterers, biogenic photonic structures, optical imaging.",
+   "qualification": "(Ph.D.: TIFR, 2017)"
+  },
+  {
+   "name": "Zakir Hossain",
+   "title": "Professor, Department of Physics",
+   "dept": "Physics",
+   "url": "https://www.iitk.ac.in/dr-zakir-hossain",
+   "depts": [
+    "Physics"
+   ],
+   "email": "zakir@iitk.ac.in",
+   "phone": "0512-259-7464",
+   "web": "https://www.iitk.ac.in/phy/home/zakir/index.htm",
+   "office": "SL-306,",
+   "qualification": "PhD (TIFR Mumbai)"
   }
  ]
 }

--- a/scripts/fetch-web.mjs
+++ b/scripts/fetch-web.mjs
@@ -56,29 +56,103 @@ async function fetchFaculty(withProfiles) {
   const html = await get('https://www.iitk.ac.in/iitk-faculty')
 
   // Department headings and faculty cards, read in document order so each
-  // card inherits the heading above it.
-  const re = /<div class="ui--acoord-item--heading">\s*<span>([^<]+)<\/span>|<div class="iitk__faculty-card[^"]*">\s*<a href="([^"]+)"><\/a>[\s\S]*?<h4>([^<]*)<\/h4>\s*<p>([^<]*)<\/p>/g
+  // Cards, department headings and "Load More" buttons, read in document order
+  // so each card inherits the heading above it and each button the department
+  // it belongs to. The listing page markup uses double quotes; the AJAX
+  // fragments below use single quotes, hence ['"] throughout.
+  const CARD = `<div class=['"]iitk__faculty-card[^'"]*['"]>\\s*<a href=['"]([^'"]+)['"]>\\s*</a>[\\s\\S]*?<h4>([^<]*)</h4>\\s*<p>([^<]*)</p>`
+  const HEADING = `<div class="ui--acoord-item--heading">\\s*<span>([^<]+)</span>`
+  const MORE = `data-count="(\\d+)"\\s+data-totalcount="(\\d+)"\\s+data-taxon="(\\d+)"`
+
+  const parseCards = (frag, dept) => {
+    const out = []
+    const re = new RegExp(CARD, 'g')
+    let m
+    while ((m = re.exec(frag))) {
+      out.push({
+        name: strip(m[2]),
+        title: strip(m[3]),
+        dept,
+        url: m[1].startsWith('http') ? m[1] : `https://www.iitk.ac.in${m[1]}`,
+      })
+    }
+    return out
+  }
+
   const list = []
-  let m, dept = ''
-  while ((m = re.exec(html))) {
-    if (m[1]) { dept = strip(m[1]); continue }
-    list.push({
-      name: strip(m[3]),
-      title: strip(m[4]),
-      dept,
-      url: m[2].startsWith('http') ? m[2] : `https://www.iitk.ac.in${m[2]}`,
-    })
+  const pending = [] // departments that have more behind a Load More button
+  {
+    const re = new RegExp(`${HEADING}|${CARD}|${MORE}`, 'g')
+    let m, dept = ''
+    while ((m = re.exec(html))) {
+      if (m[1]) { dept = strip(m[1]); continue }
+      if (m[2]) {
+        list.push({
+          name: strip(m[3]),
+          title: strip(m[4]),
+          dept,
+          url: m[2].startsWith('http') ? m[2] : `https://www.iitk.ac.in${m[2]}`,
+        })
+        continue
+      }
+      // A Load More button: data-totalcount is the department's real size.
+      pending.push({ dept, from: +m[5], total: +m[6], taxon: +m[7] })
+    }
   }
   if (!list.length) throw new Error('faculty: parsed 0 cards — the page markup changed')
 
-  // The listing renders at most 12 people per department. Record that so the
-  // app can say so rather than implying it is the whole faculty.
-  const perDept = {}
-  for (const f of list) perDept[f.dept] = (perDept[f.dept] || 0) + 1
-  const capped = Object.entries(perDept).filter(([, n]) => n >= 12).map(([d]) => d)
+  // The listing renders 12 per department and hides the rest behind a button
+  // that POSTs to /loadmore-faculty. Page through it so this is the whole roll.
+  const PAGE = 12
+  const jobs = []
+  for (const d of pending) {
+    for (let page = d.from; page * PAGE < d.total; page++) jobs.push({ ...d, page })
+  }
 
-  console.log(`faculty: ${list.length} cards across ${Object.keys(perDept).length} departments`)
-  if (capped.length) console.log(`  note: ${capped.length} departments hit the 12-per-department listing cap`)
+  if (jobs.length) {
+    const advertised = pending.reduce((s, d) => s + d.total, 0)
+    console.log(`faculty: ${list.length} on the first page; ${pending.length} departments ` +
+                `advertise ${advertised} total — fetching ${jobs.length} more pages`)
+    const pages = await pool(jobs, 6, async (j) => {
+      const url = `https://www.iitk.ac.in/loadmore-faculty?count=${j.page}&taxon=${j.taxon}`
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'User-Agent': UA, 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'action=replace',
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      return parseCards(await res.text(), j.dept)
+    })
+    const missed = pages.filter((p) => p === null).length
+    if (missed) console.warn(`  ! ${missed} of ${jobs.length} load-more pages failed`)
+    for (const p of pages) if (p) list.push(...p)
+  }
+
+  // One record per person. Joint appointments are real — Ashutosh Sharma is
+  // listed under four units — so collect every department rather than dropping
+  // the duplicate listing.
+  const byPerson = new Map()
+  for (const f of list) {
+    const key = f.url.replace(/^https?:\/\/[^/]+/, '').replace(/^\/main\//, '/').toLowerCase()
+    const hit = byPerson.get(key)
+    if (hit) { if (!hit.depts.includes(f.dept)) hit.depts.push(f.dept); continue }
+    byPerson.set(key, { ...f, depts: [f.dept] })
+  }
+  list.length = 0
+  list.push(...byPerson.values())
+
+  // Completeness is per department listing, so count by membership, not by the
+  // primary department — otherwise cross-listed people read as missing.
+  const inDept = (d) => list.filter((f) => f.depts.includes(d)).length
+  const short = pending.filter((d) => inDept(d.dept) < d.total)
+  const departments = new Set(list.flatMap((f) => f.depts))
+
+  console.log(`faculty: ${list.length} people across ${departments.size} departments ` +
+              `(${list.filter((f) => f.depts.length > 1).length} hold joint appointments)`)
+  if (short.length) {
+    console.warn(`  ! ${short.length} departments came back short: ` +
+      short.map((d) => `${d.dept} ${inDept(d.dept)}/${d.total}`).join(', '))
+  }
 
   if (withProfiles) {
     console.log(`  fetching ${list.length} profile pages (concurrency 6)…`)
@@ -128,13 +202,34 @@ async function fetchFaculty(withProfiles) {
     const withEmail = list.filter((f) => f.email).length
     const withOffice = list.filter((f) => f.office).length
     console.log(`  enriched: ${withEmail} emails, ${withOffice} offices`)
+
+    // A few people have two profile pages under different slugs
+    // (vivek-verma and vivek_verma). The URL key cannot see that; the email
+    // can, so collapse on it once profiles are in.
+    const byEmail = new Map()
+    const merged = []
+    for (const f of list) {
+      if (!f.email) { merged.push(f); continue }
+      const hit = byEmail.get(f.email)
+      if (!hit) { byEmail.set(f.email, f); merged.push(f); continue }
+      for (const d of f.depts) if (!hit.depts.includes(d)) hit.depts.push(d)
+      // Keep whichever record is more complete.
+      for (const k of ['office', 'phone', 'web', 'research', 'qualification']) {
+        if (!hit[k] && f[k]) hit[k] = f[k]
+      }
+    }
+    if (merged.length !== list.length) {
+      console.log(`  merged ${list.length - merged.length} duplicate profile pages by email`)
+      list.length = 0
+      list.push(...merged)
+    }
   }
 
   return {
     _source: 'https://www.iitk.ac.in/iitk-faculty',
     _fetched: new Date().toISOString(),
-    _note: 'Public faculty directory published by IIT Kanpur. The listing page shows up to 12 people per department, so this is a subset, not the full faculty roll.',
-    _capped_departments: capped,
+    _note: 'Public faculty directory published by IIT Kanpur. The listing page shows 12 per department and hides the rest behind a Load More button; this walks that endpoint, so it is the full roll.',
+    _incomplete_departments: short.map((d) => ({ dept: d.dept, got: perDept[d.dept] ?? 0, expected: d.total })),
     items: list,
   }
 }

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -67,6 +67,31 @@ if (someone) {
   ok(found, `surname "${surname}" finds ${someone.name}`)
 }
 
+// The listing page shows 12 per department behind a Load More button. If the
+// paging breaks we fall back to ~305 people and nobody notices.
+const fac = campus.faculty
+if (fac) {
+  ok(fac.items.length > 600, `faculty roll is complete (${fac.items.length})`,
+     fac.items.length <= 600 ? 'load-more paging probably broke' : '')
+  ok((fac._incomplete_departments ?? []).length === 0, 'no department came back short',
+     (fac._incomplete_departments ?? []).map((d) => `${d.dept} ${d.got}/${d.expected}`).join(', '))
+
+  // One card per person, even for the 59 with joint appointments.
+  const byUrl = new Map()
+  for (const f of fac.items) byUrl.set(f.url, (byUrl.get(f.url) ?? 0) + 1)
+  const repeats = [...byUrl].filter(([, n]) => n > 1)
+  ok(repeats.length === 0, 'no duplicate faculty records',
+     repeats.slice(0, 3).map(([u]) => u).join(', '))
+
+  // Searching a cross-listed name must return exactly one row.
+  const joint = fac.items.find((f) => f.depts?.length > 1)
+  if (joint) {
+    const hits = index.search(joint.name).filter((h) => h.person?.url === joint.url)
+    ok(hits.length === 1, `"${joint.name}" appears once despite ${joint.depts.length} departments`,
+       `${hits.length} rows`)
+  }
+}
+
 // Known gaps must return nothing rather than a bad guess.
 ok(index.search('PH101').every((h) => h.kind !== 'place' || !/PH101/i.test(h.title)),
    'PH101 has no fake course result')

--- a/src/search/engine.ts
+++ b/src/search/engine.ts
@@ -176,9 +176,9 @@ export class SearchIndex {
         id: `fac:${f.url}`,
         title: f.name,
         sub: f.title || f.dept,
-        hay: lower([f.name, f.title, f.dept, f.research, f.office, f.email, 'professor prof faculty']
-          .filter(Boolean).join(' ')),
-        keys: [...words(f.name), lower(surname), ...words(f.dept)],
+        hay: lower([f.name, f.title, ...(f.depts ?? [f.dept]), f.research, f.office, f.email,
+                    'professor prof faculty'].filter(Boolean).join(' ')),
+        keys: [...words(f.name), lower(surname), ...(f.depts ?? [f.dept]).flatMap(words)],
         person: f,
         boost: 4,
       })

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,10 @@ export interface Category {
 export interface Faculty {
   name: string
   title: string
+  /** Primary department — the first listing this person appeared under. */
   dept: string
+  /** Every department they are listed under; 59 hold joint appointments. */
+  depts: string[]
   url: string
   email?: string
   phone?: string
@@ -77,7 +80,8 @@ export interface Campus {
     _source: string
     _fetched: string
     _note: string
-    _capped_departments: string[]
+    /** Departments whose listing count did not match after paging. Empty is good. */
+    _incomplete_departments: { dept: string; got: number; expected: number }[]
     _located?: number
     items: Faculty[]
   }

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -195,9 +195,12 @@ export function showAbout(campus: Campus) {
     ${f ? `<div class="p-sec">Faculty</div>
     <p class="p-note"><b>${f.items.length}</b> people from
     <a href="${esc(f._source)}" target="_blank" rel="noopener">iitk.ac.in/iitk-faculty</a>,
-    fetched ${esc(f._fetched.slice(0, 10))}. ${f._located ?? 0} placed on the map from their listed office.
-    <br><br>This is <b>not the full faculty roll</b> — that page lists at most 12 people per
-    department, and ${f._capped_departments.length} departments hit the cap.</p>` : ''}
+    fetched ${esc(f._fetched.slice(0, 10))} — the whole roll, paged out from behind that
+    page's Load More buttons. ${f._located ?? 0} are placed on the map from their listed office.
+    ${f._incomplete_departments?.length
+      ? `<br><br><b>${f._incomplete_departments.length} departments came back short</b> on the
+         last fetch: ${f._incomplete_departments.map((d) => `${esc(d.dept)} ${d.got}/${d.expected}`).join(', ')}.`
+      : ''}</p>` : ''}
 
     ${m ? `<div class="p-sec">Mess menus</div>
     <p class="p-note"><b>${m.items.length}</b> approved menus across <b>${m.halls.length}</b> halls from


### PR DESCRIPTION
The listing page only renders 12 people per department; the rest sit behind a
Load More button. We were parsing the served HTML and stopping there, so we had
305 of 663 faculty and told users it was a subset.

That button POSTs to `/loadmore-faculty?count=N&taxon=T` with `action=replace`
and returns a fragment of 12 more cards. `data-totalcount` and `data-taxon` are
already on the button, so we know how many pages each department has. The
fetcher now walks all 21 paged departments.

Two things that came out of it:

- 59 people hold joint appointments and appear under several departments
  (Ashutosh Sharma is listed under four). They're stored once now, with a
  `depts` array, instead of once per listing. This also fixes Nitin Saxena
  showing up twice in search — the old code had no dedupe at all.
- A handful have two profile pages under different slugs (`vivek-verma` and
  `vivek_verma`). Those are merged on email after enrichment. Same-name-different-person
  cases like the two Shivam Tripathis are correctly kept separate — different
  emails, different departments.

The AJAX fragments use single-quoted attributes and `/main/`-prefixed URLs,
unlike the main page, so the card regex accepts both.

**663 people, 613 emails, 458 offices, 445 placed on the map.** No department
comes back short.

Smoke tests fail the build if the count drops back toward 305, if any
department is short, if a duplicate record appears, or if a cross-listed name
returns more than one row. Bumped the refresh workflow's sanity floor from 200
to 600.