### PR TITLE
feat(data): add Halls 1/4/6/7/14, GH1 and L8–L13 to curated places

### DIFF
--- a/data/curated/places.json
+++ b/data/curated/places.json
@@ -36,6 +36,102 @@
       "lat": 26.5101082,
       "lon": 80.2267368,
       "desc": "Not yet mapped in OpenStreetMap — coordinates surveyed on campus."
+    },
+    {
+      "id": "hall-1",
+      "name": "Hall 1",
+      "cat": "hostel",
+      "lat": 26.5095737,
+      "lon": 80.2317479,
+      "desc": "Oldest hall, on the avenue past the Sports Complex — coordinates added manually after verifying against OSM's \"Hall of Residence 1\" plot (7 dormitory blocks sit inside it)."
+    },
+    {
+      "id": "hall-4",
+      "name": "Hall 4",
+      "cat": "hostel",
+      "lat": 26.507111,
+      "lon": 80.231776,
+      "desc": "PG and co-ed hall — coordinates added manually after verifying the Hall 4 website's map against OSM's \"Hall of Residence 4\" plot, which both agree on."
+    },
+    {
+      "id": "hall-6",
+      "name": "Hall 6",
+      "cat": "hostel",
+      "lat": 26.505356,
+      "lon": 80.2343988,
+      "desc": "Girls' PG hostel, renamed Girls Hostel 2 (GH2) — coordinates added manually after verifying OSM's \"Hall of Residence for Girls 6\" plot."
+    },
+    {
+      "id": "hall-7",
+      "name": "Hall 7",
+      "cat": "hostel",
+      "lat": 26.5070563,
+      "lon": 80.2280717,
+      "desc": "PG hall beside Halls 4 and 5 — coordinates added manually after verifying OSM's \"Hall of Residence 7\" plot."
+    },
+    {
+      "id": "hall-14",
+      "name": "Hall 14",
+      "cat": "hostel",
+      "lat": 26.5123265,
+      "lon": 80.2250315,
+      "desc": "Newest hall (2023), past Hall 13 — coordinates added manually after verifying OSM's \"Hall of Residence 14\" plot."
+    },
+    {
+      "id": "girls-hostel-1",
+      "name": "Girls Hostel 1",
+      "cat": "hostel",
+      "lat": 26.5070262,
+      "lon": 80.2333933,
+      "desc": "GH1 — oldest girls' hostel (est. 1971), near the Visitor Hostel — coordinates added manually after verifying OSM's \"Hall of Residence for Girls 1\" plot (its buildings are not yet mapped there)."
+    },
+    {
+      "id": "lecture-hall-8",
+      "name": "Lecture Hall 8",
+      "cat": "lecture",
+      "lat": 26.5111724,
+      "lon": 80.2332954,
+      "desc": "L8, in the lecture hall complex — OSM carries it only as an indoor room, so the fetch misses it; coordinate added manually after verifying the OSM room outline."
+    },
+    {
+      "id": "lecture-hall-9",
+      "name": "Lecture Hall 9",
+      "cat": "lecture",
+      "lat": 26.5110572,
+      "lon": 80.2334338,
+      "desc": "L9, in the lecture hall complex — OSM carries it only as an indoor room, so the fetch misses it; coordinate added manually after verifying the OSM room outline."
+    },
+    {
+      "id": "lecture-hall-10",
+      "name": "Lecture Hall 10",
+      "cat": "lecture",
+      "lat": 26.511273,
+      "lon": 80.2334148,
+      "desc": "L10, in the lecture hall complex — OSM carries it only as an indoor room, so the fetch misses it; coordinate added manually after verifying the OSM room outline."
+    },
+    {
+      "id": "lecture-hall-11",
+      "name": "Lecture Hall 11",
+      "cat": "lecture",
+      "lat": 26.5111631,
+      "lon": 80.2335413,
+      "desc": "L11, in the lecture hall complex — OSM carries it only as an indoor room, so the fetch misses it; coordinate added manually after verifying the OSM room outline."
+    },
+    {
+      "id": "lecture-hall-12",
+      "name": "Lecture Hall 12",
+      "cat": "lecture",
+      "lat": 26.5111724,
+      "lon": 80.2332954,
+      "desc": "L12 — same room as L8, one floor up; OSM carries it only as an indoor room, so the fetch misses it; coordinate added manually after verifying the OSM room outline."
+    },
+    {
+      "id": "lecture-hall-13",
+      "name": "Lecture Hall 13",
+      "cat": "lecture",
+      "lat": 26.5110572,
+      "lon": 80.2334338,
+      "desc": "L13 — same room as L9, one floor up; OSM carries it only as an indoor room, so the fetch misses it; coordinate added manually after verifying the OSM room outline."
     }
   ]
 }


### PR DESCRIPTION
Adds the hostel and lecture-hall POIs students can't currently find. Every coordinate was **added manually after verifying** against real sources — nothing invented, and no "hand-surveyed" claims.

**Hostels** (cat `hostel`)
| place | lat, lon | verified against |
|---|---|---|
| Hall 1 | 26.5095737, 80.2317479 | OSM `Hall of Residence 1` plot — 7 dormitory blocks inside |
| Hall 4 | 26.507111, 80.231776 | Hall 4 website's own map **and** OSM `Hall of Residence 4` plot, agreeing to ~9 m |
| Hall 6 (GH2) | 26.505356, 80.2343988 | OSM `Hall of Residence for Girls 6` plot (1 dormitory inside) |
| Hall 7 | 26.5070563, 80.2280717 | OSM `Hall of Residence 7` plot — 4 dormitory blocks inside |
| Hall 14 | 26.5123265, 80.2250315 | OSM `Hall of Residence 14` plot — 5 residential blocks inside |
| Girls Hostel 1 (GH1) | 26.5070262, 80.2333933 | OSM `Hall of Residence for Girls 1` plot (short_name GH1); buildings not yet mapped there, so the plot center is the honest choice |

**Lecture halls** (cat `lecture`) — L8–L13, completing L1–L17. OSM carries these only as `indoor=room` ways, which the fetch's `building` query skips. Point-in-polygon check against both complex footprints showed they sit inside the **Old Lecture Hall Complex** polygon (L16–L17 are in the New one) — the descs say "in the lecture hall complex" to stay neutral, since the rooms' attribution differs from the common L8–L17-in-New-LHC story. L12/L13 are the same rooms as L8/L9 one floor up (OSM `level` tags), hence shared coordinates.

**Why it matters**
- Fixes 3 build warnings: campusmess halls `GH 1`, `Hall 6`, `Hall 4` previously had no feature to land on — mess menus now anchor correctly.
- Halls 1, 4, 6, 7, 14 and L8–L13 had zero POI presence; the map now searches and routes to them.

Verified with `npm run test` (typecheck + build + smoke): no warnings, all 196 pinned POIs reachable by foot and bike.

Note: all of these exist in OSM under tags the fetch ignores (`landuse=residential`, `indoor=room`). Extending `fetch-osm.mjs` later would make these curated rows redundant — descs document the exact source for that migration.