### PR TITLE
feat(ui): default to dark, remember an explicit light choice

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,11 +8,17 @@
 <meta name="description" content="A map of IIT Kanpur with the things students actually look for — lecture halls, messes, water, cycle stands, ATMs — and one fast search over all of it.">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='7' fill='%230b0d10'/><path d='M8 22 L16 9 L24 22' stroke='%2361d47c' stroke-width='2.5' fill='none' stroke-linejoin='round'/><circle cx='16' cy='23' r='2' fill='%23ffb454'/></svg>">
 <script>
-  // Set the theme before first paint so there is no flash of the wrong one.
+  // Dark unless this browser has been told otherwise. Runs before first paint
+  // so a light-mode visitor never sees a dark flash.
   try {
     var t = localStorage.getItem('campusmap.theme')
-    if (t === 'light' || t === 'dark') document.documentElement.setAttribute('data-theme', t)
-  } catch (e) {}
+    document.documentElement.setAttribute('data-theme', t === 'light' ? 'light' : 'dark')
+    if (t === 'light') {
+      document.querySelector('meta[name="theme-color"]').content = '#e9ebef'
+    }
+  } catch (e) {
+    document.documentElement.setAttribute('data-theme', 'dark')
+  }
 </script>
 </head>
 <body>

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,8 +3,11 @@
 
 @import 'maplibre-gl/dist/maplibre-gl.css';
 
-/* Dark is the base. Light overrides only the tokens. */
+/* Dark is the product default, not the system's — `prefers-color-scheme` is
+   deliberately not consulted. Light is opt-in via [data-theme="light"], which
+   theme.ts sets from localStorage before first paint. */
 :root {
+  color-scheme: dark;
   --bg: #0b0d10;
   --bg-1: #101318;
   --bg-2: #171b22;
@@ -26,34 +29,8 @@
   --r: 5px;
 }
 
-@media (prefers-color-scheme: light) {
-  :root:not([data-theme="dark"]) { color-scheme: light; }
-}
-:root[data-theme="light"] { color-scheme: light; }
-
-/* One block, applied by either the media query or the explicit attribute. */
-@media (prefers-color-scheme: light) {
-  :root:not([data-theme="dark"]) {
-    /* Warm off-white rather than pure white: less glare, and it keeps the
-       map's own white roads readable as figure against ground. Text is a
-       soft charcoal — pure black on white is the harshest pairing there is. */
-    --bg: #e9ebef;
-    --bg-1: #fbfbfc;
-    --bg-2: #f1f3f6;
-    --line: #e3e6eb;
-    --line-2: #ccd1d9;
-    --fg: #2b313a;
-    --fg-2: #626b78;
-    --fg-3: #949ba7;
-    --accent: #2a8a4d;
-    --danger: #b8443a;
-    --route: #2b6cb8;
-    --scrim: rgba(88, 98, 112, .26);
-    --lift: 0 14px 36px rgba(40, 50, 70, .13);
-    --halo: #fbfbfc;
-  }
-}
 :root[data-theme="light"] {
+  color-scheme: light;
   /* Warm off-white rather than pure white: less glare, and it keeps the
      map's own white roads readable as figure against ground. Text is a
      soft charcoal — pure black on white is the harshest pairing there is. */
@@ -116,9 +93,6 @@ kbd {
 .maplibregl-ctrl-group button + button { border-top: 1px solid var(--line) !important; }
 .maplibregl-ctrl-group button span { opacity: .55; }
 :root:not([data-theme="light"]) .maplibregl-ctrl-group button span { filter: invert(1); }
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .maplibregl-ctrl-group button span { filter: invert(1); }
-}
 .maplibregl-canvas:focus { outline: none; }
 
 /* ── top bar ─────────────────────────────────────────────────────────── */

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -1,58 +1,51 @@
-export type ThemeChoice = 'auto' | 'light' | 'dark'
 export type Resolved = 'light' | 'dark'
 
 const KEY = 'campusmap.theme'
-const media = window.matchMedia('(prefers-color-scheme: light)')
 
-let choice: ThemeChoice = read()
+/**
+ * Dark is the product's default, not the system's. Most people open this at
+ * night looking for a mess menu, and the map palette was designed dark first.
+ * Anyone who prefers light picks it once and localStorage remembers, on this
+ * browser, until they change it back.
+ */
+const DEFAULT: Resolved = 'dark'
+
+let choice: Resolved = read()
 const listeners = new Set<(t: Resolved) => void>()
 
-function read(): ThemeChoice {
-  const v = localStorage.getItem(KEY)
-  return v === 'light' || v === 'dark' ? v : 'auto'
+function read(): Resolved {
+  try {
+    const v = localStorage.getItem(KEY)
+    if (v === 'light' || v === 'dark') return v
+  } catch {
+    // Private mode or storage disabled — fall through to the default.
+  }
+  return DEFAULT
 }
 
 export function resolved(): Resolved {
-  if (choice === 'auto') return media.matches ? 'light' : 'dark'
-  return choice
-}
-
-export function current(): ThemeChoice {
   return choice
 }
 
 function apply() {
-  const r = resolved()
-  // `auto` leaves the attribute off so the media query in CSS decides.
-  if (choice === 'auto') document.documentElement.removeAttribute('data-theme')
-  else document.documentElement.setAttribute('data-theme', choice)
+  document.documentElement.setAttribute('data-theme', choice)
   document.querySelector('meta[name="theme-color"]')
-    ?.setAttribute('content', r === 'light' ? '#f2f4f7' : '#0b0d10')
-  for (const fn of listeners) fn(r)
+    ?.setAttribute('content', choice === 'light' ? '#e9ebef' : '#0b0d10')
+  for (const fn of listeners) fn(choice)
 }
 
-/**
- * Straight flip between light and dark.
- *
- * This used to cycle auto -> light -> dark -> auto, which meant that whenever
- * `auto` resolved to the theme you were already looking at, one press changed
- * nothing on screen and you had to press again. Following the system is still
- * the default until you touch this; after that it is your explicit choice.
- */
+/** Straight flip. One press, one visible change. */
 export function toggle(): Resolved {
-  const next: Resolved = resolved() === 'dark' ? 'light' : 'dark'
-  choice = next
-  localStorage.setItem(KEY, next)
+  choice = choice === 'dark' ? 'light' : 'dark'
+  try { localStorage.setItem(KEY, choice) } catch { /* nothing we can do */ }
   apply()
-  return next
+  return choice
 }
 
 export function onThemeChange(fn: (t: Resolved) => void) {
   listeners.add(fn)
 }
 
-media.addEventListener('change', () => { if (choice === 'auto') apply() })
-
-// Applied before first paint by the inline script in index.html; this syncs
-// the meta colour and notifies subscribers once the module loads.
+// The inline script in index.html sets the attribute before first paint; this
+// syncs the meta colour and notifies subscribers once the module loads.
 apply()


### PR DESCRIPTION
Dark is the product default now rather than the system's — `prefers-color-scheme`
is not consulted at all. Light is opt-in, stored in `localStorage` under
`campusmap.theme`, and survives reloads on that browser.

Three places had to change together; missing any one leaves it half-working.

- **`theme.ts`** — the `auto` state is gone. The choice is just `light | dark`.
- **`styles.css`** — deleted the `@media (prefers-color-scheme: light)` token
  block. Left in, a light-mode visitor would still have rendered light whatever
  the JS decided. Light now lives only under `[data-theme="light"]`.
- **inline pre-paint script** — previously only set the attribute when a
  preference existed, so the default relied on CSS. It always sets one now, and
  also sets `theme-color` for light, which was leaving the phone status bar dark.

Verified against both emulated system schemes:

| System | First visit | After toggle | After reload |
|---|---|---|---|
| light | dark | light, stored | light |
| dark | dark | light, stored | light |

Also added `color-scheme` to both roots so native scrollbars and form controls
follow, and wrapped the `localStorage` access in try/catch — Safari private mode
throws on it, which would otherwise take the whole theme module down on load.

Typecheck, smoke and browser verification pass.