### PR TITLE
feat(map): street lights layer with a glow, off by default

### DIFF
--- a/data/raw/pois.json
+++ b/data/raw/pois.json
@@ -1,1 +1,6334 @@
-{"version":0.6,"generator":"Overpass API 0.7.62.11 87bfad18","osm3s":{"timestamp_osm_base":"2026-06-29T05:54:00Z","copyright":"The data included in this document is from www.openstreetmap.org. The data is made available under ODbL."},"elements":[{"type":"node","id":1655763088,"lat":26.508277,"lon":80.2309014,"tags":{"amenity":"atm","brand":"State Bank of India","brand:en":"State Bank of India","brand:wikidata":"Q1340361","currency:INR":"yes","drive_through":"no","fee":"no","indoor":"yes","name":"State Bank of India","note":"Contributors are requested to not edit the \"brand\", \"brand:en\", \"brand:wikidata\", \"operator\", \"operator:en\" and \"operator:wikidata\" tags. (2025/03/03)","opening_hours":"24/7","operator":"State Bank of India","operator:en":"State Bank of India","operator:wikidata":"Q1340361","short_name":"SBI"}},{"type":"node","id":1655764679,"lat":26.5082338,"lon":80.2308988,"tags":{"amenity":"atm","brand":"Union Bank of India","brand:wikidata":"Q2004078","fee":"no","name":"Union Bank of India","operator":"Union Bank of India","operator:wikidata":"Q2004078"}},{"type":"node","id":1656958496,"lat":26.5115503,"lon":80.236353,"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","amenity":"restaurant","cuisine":"indian","name":"Campus Restaurant"}},{"type":"node","id":1656958499,"lat":26.5112702,"lon":80.2363169,"tags":{"amenity":"bank","atm":"yes","brand":"Union Bank of India","brand:wikidata":"Q2004078","drive_through":"no","name":"Union Bank of India","name:en":"Union Bank of India","short_name":"UBI","website":"https://www.unionbankofindia.co.in/"}},{"type":"node","id":2652376927,"lat":26.5070288,"lon":80.2288443,"tags":{"amenity":"atm","brand":"ICICI Bank","brand:en":"ICICI Bank","brand:wikidata":"Q1653258","cash_in":"yes","currency:INR":"yes","drive_through":"no","indoor":"yes","name":"ICICI Bank","note":"Contributors are requested to not edit the \"brand\", \"brand:en\", \"brand:wikidata\", \"operator\", \"operator:en\" and \"operator:wikidata\" tags. (2025/03/03)","opening_hours":"24/7","operator":"ICICI Bank","operator:en":"ICICI Bank","operator:wikidata":"Q1653258","short_name":"ICICI"}},{"type":"node","id":2652376937,"lat":26.5050396,"lon":80.2292403,"tags":{"addr:city":"Kanpur","addr:postcode":"208016","amenity":"fast_food","brand":"Burger Singh","cuisine":"burger","name":"Burger Singh","takeaway":"yes"}},{"type":"node","id":2652376940,"lat":26.5050597,"lon":80.2292637,"tags":{"addr:city":"Kanpur","addr:postcode":"208016","amenity":"fast_food","cuisine":"rolls","level":"0","name":"Aladdin's","website":"https://www.iitk.ac.in/new/kathi-inc"}},{"type":"node","id":2652376945,"lat":26.5047557,"lon":80.2292902,"tags":{"amenity":"library","name":"Book Club"}},{"type":"node","id":2734619313,"lat":26.511768,"lon":80.2362652,"tags":{"amenity":"toilets"}},{"type":"node","id":2734619320,"lat":26.5113535,"lon":80.2365581,"tags":{"amenity":"pharmacy","healthcare":"pharmacy"}},{"type":"node","id":2734619325,"lat":26.5113739,"lon":80.236191,"tags":{"addr:city":"Kanpur","addr:housenumber":"Shop No. 3","addr:place":"IIT Kanpur","addr:postcode":"208016","name":"Noble Book Stall","shop":"books"}},{"type":"node","id":2734619341,"lat":26.5119835,"lon":80.2364936,"tags":{"amenity":"post_office"}},{"type":"node","id":2734619343,"lat":26.5122816,"lon":80.2304354,"tags":{"service:bicycle:pump":"yes","service:bicycle:repair":"yes","service:bicycle:second_hand":"yes","shop":"bicycle"}},{"type":"node","id":2734619353,"lat":26.5116931,"lon":80.2361745,"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","name":"Looks Men Hair Salon","shop":"hairdresser"}},{"type":"node","id":2734619354,"lat":26.5112815,"lon":80.2365661,"tags":{"service:bicycle:pump":"yes","service:bicycle:repair":"yes","service:bicycle:second_hand":"yes","shop":"bicycle"}},{"type":"node","id":2734619360,"lat":26.5115191,"lon":80.2465037,"tags":{"name":"Beer Shop","shop":"alcohol"}},{"type":"node","id":3277783199,"lat":26.5117899,"lon":80.2342909,"tags":{"addr:city":"IIT Kanpur","addr:housename":"CCD ke bagal wali canteen","addr:postcode":"208016","amenity":"fast_food","designation":"Canteen","diet:vegetarian":"yes","name":"Southern Labs Canteen","source":"Local Source"}},{"type":"node","id":3862137593,"lat":26.5109119,"lon":80.2298625,"tags":{"amenity":"fast_food","cuisine":"sandwich,_samosa,_paranthas,_and_other_regular_indian_foods","delivery":"no","drive_through":"no","name":"Hall 2 Canteen","opening_hours":"14:00-02:00","smoking":"no","takeaway":"yes"}},{"type":"node","id":4311239589,"lat":26.5051135,"lon":80.2293655,"tags":{"addr:postcode":"208016","addr:street":"New SAC Road","amenity":"fast_food","brand":"Domino's","brand:wikidata":"Q839466","cuisine":"pizza","name":"Domino's","takeaway":"yes"}},{"type":"node","id":5331658992,"lat":26.5114442,"lon":80.2463364,"tags":{"amenity":"restaurant","name":"China Town"}},{"type":"node","id":6175946485,"lat":26.5050128,"lon":80.2282524,"tags":{"amenity":"restaurant","name:en":"Canteen"}},{"type":"node","id":7065213786,"lat":26.5114292,"lon":80.2361904,"tags":{"addr:city":"Kanpur","addr:housenumber":"Shop No. 4","addr:place":"IIT Kanpur","addr:postcode":"208016","name":"New Suparsh Provision Store","shop":"supermarket"}},{"type":"node","id":7108657166,"lat":26.5045986,"lon":80.2455455,"tags":{"addr:city":"kanpur","addr:postcode":"208016","leisure":"park","name":"siddharth nagar society pqrk"}},{"type":"node","id":9740268374,"lat":26.5110335,"lon":80.2395106,"tags":{"addr:city":"Kanpur","amenity":"fuel","brand":"Indian Oil","brand:wikidata":"Q1289348","name":"Indian Oil","self_service":"no"}},{"type":"node","id":9747705660,"lat":26.5109724,"lon":80.2362699,"tags":{"addr:city":"Kanpur","addr:postcode":"208016","name":"Kalyan G Bakery","shop":"bakery"}},{"type":"node","id":9992315793,"lat":26.5058666,"lon":80.2272991,"tags":{"addr:city":"Kanpur","addr:postcode":"208016","amenity":"ice_cream","name":"Mama Mio Milkshake and Icecream","outdoor_seating":"yes"}},{"type":"node","id":10537273080,"lat":26.5098141,"lon":80.2290351,"tags":{"service:bicycle:pump":"yes","service:bicycle:repair":"yes","service:bicycle:second_hand":"yes","shop":"bicycle"}},{"type":"node","id":10537273081,"lat":26.5074958,"lon":80.2271877,"tags":{"service:bicycle:pump":"yes","service:bicycle:repair":"yes","service:bicycle:second_hand":"yes","shop":"bicycle"}},{"type":"node","id":10537273082,"lat":26.5064016,"lon":80.2271718,"tags":{"service:bicycle:pump":"yes","service:bicycle:repair":"yes","service:bicycle:second_hand":"yes","shop":"bicycle"}},{"type":"node","id":10537273083,"lat":26.5045852,"lon":80.2354667,"tags":{"service:bicycle:pump":"yes","service:bicycle:repair":"yes","service:bicycle:second_hand":"yes","shop":"bicycle"}},{"type":"node","id":10537331488,"lat":26.5050752,"lon":80.2332455,"tags":{"addr:city":"Kanpur","addr:postcode":"208016","amenity":"pharmacy","brand":"Tata 1MG","brand:wikidata":"Q62562612","check_date":"2026-05-31","dispensing":"yes","healthcare":"pharmacy","name":"Tata 1MG Pharmacy","opening_hours":"24/7"}},{"type":"node","id":10537333776,"lat":26.5061737,"lon":80.2267183,"tags":{"amenity":"fast_food","fast_food":"cafeteria","name":"Hall 10 Canteen"}},{"type":"node","id":10537333777,"lat":26.5052558,"lon":80.2267157,"tags":{"amenity":"fast_food","fast_food":"cafeteria","name":"Hall 11 Canteen"}},{"type":"node","id":10537340887,"lat":26.5093362,"lon":80.2325609,"tags":{"addr:city":"Kanpur","amenity":"fast_food","cuisine":"juice;ice_cream","name":"Gupta Shake and Icecream Shop","outdoor_seating":"yes"}},{"type":"node","id":10537340889,"lat":26.5043553,"lon":80.231454,"tags":{"addr:city":"Kanpur","addr:housenumber":"Shop No 1","addr:postcode":"208016","name":"Campus E Shop","shop":"general"}},{"type":"node","id":10537340890,"lat":26.5042273,"lon":80.2314824,"tags":{"service:bicycle:pump":"yes","service:bicycle:repair":"yes","service:bicycle:second_hand":"yes","shop":"bicycle"}},{"type":"node","id":10543460611,"lat":26.5148037,"lon":80.2322222,"tags":{"addr:city":"Kanpur","name":"Jeet Bindra Unit Operations and Innovation Lab","office":"research"}},{"type":"node","id":10543460626,"lat":26.5128774,"lon":80.2306028,"tags":{"name":"Employees Association","office":"association"}},{"type":"node","id":10543460627,"lat":26.5122748,"lon":80.2305204,"tags":{"addr:city":"Kanpur","name":"Vinod Garments and Footwear","shop":"shoes"}},{"type":"node","id":10543460628,"lat":26.5122324,"lon":80.2305242,"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","amenity":"place_of_worship","name":"Sankat Mochan Hanuman Temple","name:en":"Sankat Mochan Hanuman Temple","name:hi":"संकट मोचन हनुमान मंदिर","religion":"hindu"}},{"type":"node","id":10543460633,"lat":26.5114417,"lon":80.2306189,"tags":{"name":"IITK Motorsports","office":"yes"}},{"type":"node","id":10549080635,"lat":26.5113588,"lon":80.2366299,"tags":{"name":"Amul","shop":"dairy"}},{"type":"node","id":10549080636,"lat":26.5119793,"lon":80.236301,"tags":{"addr:city":"Kanpur","name":"Divyam Naturals","shop":"health_food"}},{"type":"node","id":10549089086,"lat":26.5135534,"lon":80.2346441,"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","name":"ID Cell","name:en":"ID Cell","name:hi":"परिचय पत्र प्रकोष्ट","office":"university"}},{"type":"node","id":10554872728,"lat":26.5082593,"lon":80.2345998,"tags":{"communication:mobile_phone":"yes","man_made":"tower","tower:type":"communication"}},{"type":"node","id":10554872741,"lat":26.5101067,"lon":80.2355885,"tags":{"addr:city":"Kanpur","name":"IIT Kanpur La Trobe University Research Academy","office":"research"}},{"type":"node","id":10554872742,"lat":26.5100341,"lon":80.2355878,"tags":{"addr:city":"Kanpur","name":"Smart Grid Center of Excellence for Training, Research and Enterpreneurship","office":"research","short_name":"SG-CEnTRE","website":"https://sgcentre.iitk.ac.in/"}},{"type":"node","id":10554872747,"lat":26.5108693,"lon":80.238158,"tags":{"man_made":"tower","tower:type":"communication"}},{"type":"node","id":10562586743,"lat":26.5117682,"lon":80.2352139,"tags":{"name":"Central Cryogenics Facility","office":"research"}},{"type":"node","id":10562586748,"lat":26.5117618,"lon":80.2360289,"tags":{"amenity":"drinking_water"}},{"type":"node","id":10583048062,"lat":26.5059763,"lon":80.2264539,"tags":{"shop":"general"}},{"type":"node","id":10583048063,"lat":26.505454,"lon":80.2264888,"tags":{"shop":"general"}},{"type":"node","id":10583048064,"lat":26.5060207,"lon":80.2265007,"tags":{"shop":"copyshop"}},{"type":"node","id":10583048095,"lat":26.5061402,"lon":80.2266497,"tags":{"addr:city":"Kanpur","addr:postcode":"208016","leisure":"fitness_centre","name":"Hall 10 Gym"}},{"type":"node","id":10583065012,"lat":26.5093081,"lon":80.2274858,"tags":{"shop":"copyshop"}},{"type":"node","id":10583065013,"lat":26.5093692,"lon":80.2274839,"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","name":"Das General Store","payment:cash":"yes","payment:upi":"yes","phone":"+91-9936309179","shop":"general"}},{"type":"node","id":10583083072,"lat":26.5111712,"lon":80.2361595,"tags":{"amenity":"place_of_worship","religion":"hindu"}},{"type":"node","id":10583083073,"lat":26.5043555,"lon":80.2313282,"tags":{"addr:city":"Kanpur","addr:housenumber":"Shop No. 5","addr:place":"New Shopping Center, IIT Kanpur","addr:postcode":"208016","name":"Amul Parlor","opening_hours":"Mo-Su 07:00-22:00","shop":"dairy"}},{"type":"node","id":10583129149,"lat":26.5116339,"lon":80.2334593,"tags":{"artwork_type":"sculpture","name":"Silver Jubilee Landmark","tourism":"artwork"}},{"type":"node","id":10583174469,"lat":26.5098975,"lon":80.228606,"tags":{"name":"Hall 5 Laundry Room","self_service":"yes","shop":"laundry"}},{"type":"node","id":10583174470,"lat":26.5097808,"lon":80.2285768,"tags":{"leisure":"fitness_centre","name":"Hall 5 Gym"}},{"type":"node","id":10583209415,"lat":26.5094319,"lon":80.2280998,"tags":{"amenity":"toilets","female":"yes"}},{"type":"node","id":10583209416,"lat":26.5060854,"lon":80.2263841,"tags":{"amenity":"toilets","female":"yes"}},{"type":"node","id":10590409194,"lat":26.5094159,"lon":80.230691,"tags":{"name":"Saumya Sports","shop":"sports"}},{"type":"node","id":10598446553,"lat":26.5043743,"lon":80.2310911,"tags":{"addr:city":"Kanpur","addr:postcode":"208016","amenity":"restaurant","name":"Urban Crave"}},{"type":"node","id":10598446554,"lat":26.5043554,"lon":80.2312603,"tags":{"addr:city":"Kanpur","addr:housenumber":"Shop No. 7","addr:place":"New Shopping Center, IIT Kanpur","addr:postcode":"208016","email":"contact@campuskart.in","name":"Electronics Emporium","opening_hours":"Mo-Su 11:00-21:00","phone":"+91-7905471491","shop":"electronics","website":"https://www.campuskart.in"}},{"type":"node","id":10598446555,"lat":26.5043552,"lon":80.231295,"tags":{"addr:city":"Kanpur","addr:housenumber":"Shop No. 6","addr:place":"New Shopping Center, IIT Kanpur","addr:postcode":"208016","email":"sk1019257@gmail.com","name":"Hari Veg Store","phone":"+91-7607713162","shop":"greengrocer","website":"https://www.harivegstore.co.in"}},{"type":"node","id":10598446556,"lat":26.5043555,"lon":80.2313598,"tags":{"addr:city":"Kanpur","addr:housenumber":"Shop No. 4","addr:place":"New Shopping Center, IIT Kanpur","addr:postcode":"208016","name":"Mercury Dry Cleaning","opening_hours":"Mo-Su 10:00-20:00; Fr off","phone":"+91-9795954433","shop":"dry_cleaning"}},{"type":"node","id":10598446557,"lat":26.5043561,"lon":80.2313926,"tags":{"addr:city":"Kanpur","addr:housenumber":"Shop No. 3","addr:place":"New Shopping Center, IIT Kanpur","addr:postcode":"208016","name":"Fascia Salon","opening_hours":"Mo-Su 10:00-20:00; Tu off","shop":"hairdresser","unisex":"yes"}},{"type":"node","id":10598446589,"lat":26.5050127,"lon":80.2292162,"tags":{"amenity":"fast_food","level":"0","name":"Naughty Blenders","operator":"Burger Belly"}},{"type":"node","id":10598993155,"lat":26.5138828,"lon":80.2348833,"tags":{"access":"yes","amenity":"bicycle_parking","bicycle_parking":"shed","covered":"yes","fee":"no"}},{"type":"node","id":10598993156,"lat":26.5145022,"lon":80.2344278,"tags":{"amenity":"bicycle_parking","covered":"no","fee":"no"}},{"type":"node","id":10598993161,"lat":26.5099074,"lon":80.2289294,"tags":{"amenity":"bicycle_parking","bicycle_parking":"wall_loops","covered":"no","fee":"no"}},{"type":"node","id":10600742657,"lat":26.5108202,"lon":80.2455852,"tags":{"amenity":"bank","atm":"yes","brand":"ICICI Bank","brand:wikidata":"Q1653258","name":"ICICI Bank","short_name":"ICICI"}},{"type":"node","id":10605366657,"lat":26.5108503,"lon":80.2331485,"tags":{"amenity":"toilets"}},{"type":"node","id":10605408143,"lat":26.5049768,"lon":80.2291789,"tags":{"amenity":"drinking_water","man_made":"water_tap"}},{"type":"node","id":10605408144,"lat":26.5049672,"lon":80.2291734,"tags":{"amenity":"toilets","male":"yes"}},{"type":"node","id":10605430800,"lat":26.5139283,"lon":80.2347199,"tags":{"addr:city":"Kanpur","addr:postcode":"208016","check_date":"2026-06-28","name":"Department of Computer Science And Engineering","office":"university","short_name":"CSE;Computer Science;KD;RM","website":"https://www.cse.iitk.ac.in/"}},{"type":"node","id":10635411296,"lat":26.5138798,"lon":80.2336782,"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","name":"Department of Mechanical Engineering","office":"university","website":"https://www.iitk.ac.in/me/"}},{"type":"node","id":10648244237,"lat":26.5113462,"lon":80.2329055,"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","description":"Contributed by 1989 batch","level":"0","name":"Student Lounge","office":"coworking"}},{"type":"node","id":10648244271,"lat":26.5108693,"lon":80.2340628,"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","level":"2","name":"Lecture Hall 20","short_name":"L20"}},{"type":"node","id":10648244272,"lat":26.510983,"lon":80.2343115,"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","level":"2","name":"Lecture Hall 19","short_name":"L19"}},{"type":"node","id":10648244273,"lat":26.5109357,"lon":80.2341773,"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","level":"0","name":"Lecture Hall 18","short_name":"L18"}},{"type":"node","id":10656632243,"lat":26.5089734,"lon":80.2329614,"tags":{"amenity":"toilets"}},{"type":"node","id":10703242259,"lat":26.5100323,"lon":80.2418343,"tags":{"amenity":"place_of_worship","religion":"hindu"}},{"type":"node","id":10703242260,"lat":26.510144,"lon":80.2419345,"tags":{"addr:city":"Kanpur","addr:postcode":"208016","amenity":"police","name":"IIT Kanpur Police Chowki"}},{"type":"node","id":10760551158,"lat":26.5058062,"lon":80.2272988,"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","amenity":"restaurant","cuisine":"chinese","name":"Quiacan Chinese","outdoor_seating":"yes"}},{"type":"node","id":10760551159,"lat":26.5059201,"lon":80.2272988,"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","amenity":"restaurant","name":"Eatezee","outdoor_seating":"yes"}},{"type":"node","id":10772624143,"lat":26.5104346,"lon":80.238958,"tags":{"amenity":"fountain"}},{"type":"node","id":10775939739,"lat":26.5119495,"lon":80.2300649,"tags":{"amenity":"fire_station","name":"IIT Kanpur Fire Station"}},{"type":"node","id":10775939740,"lat":26.5119855,"lon":80.2291985,"tags":{"amenity":"place_of_worship","religion":"hindu"}},{"type":"node","id":10775939741,"lat":26.5156372,"lon":80.2305584,"tags":{"addr:city":"Kanpur","addr:postcode":"208016","name":"National Aerosol Facility","office":"research","website":"https://home.iitk.ac.in/~snt/naf/index.html"}},{"type":"node","id":10799133070,"lat":26.5047119,"lon":80.2297824,"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","leisure":"sports_centre","name":"IITK Wall Climbing Facility","sport":"climbing"}},{"type":"node","id":10803686709,"lat":26.5101031,"lon":80.2286152,"tags":{"amenity":"drinking_water","bottle":"yes","fee":"no"}},{"type":"node","id":10803686710,"lat":26.5100244,"lon":80.2281134,"tags":{"amenity":"drinking_water","bottle":"yes","fee":"no"}},{"type":"node","id":10820718222,"lat":26.5135103,"lon":80.2323625,"tags":{"emergency":"fire_hydrant"}},{"type":"node","id":10821064294,"lat":26.5121786,"lon":80.2340145,"tags":{"amenity":"bicycle_parking","bicycle_parking":"wall_loops","covered":"yes","fee":"no"}},{"type":"node","id":10892585399,"lat":26.509865,"lon":80.2325233,"tags":{"shop":"hairdresser"}},{"type":"node","id":10892616222,"lat":26.5117293,"lon":80.2361752,"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","name":"Mubeen Tailors","shop":"tailor"}},{"type":"node","id":10892616223,"lat":26.5116621,"lon":80.2361738,"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","name":"Shiv Shankar Stationary","shop":"stationery"}},{"type":"node","id":10892616224,"lat":26.5117125,"lon":80.2362369,"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","name":"A-One Photocopy Center","shop":"copyshop"}},{"type":"node","id":10892616225,"lat":26.5116285,"lon":80.2362369,"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","name":"Tarun Book Store","shop":"books"}},{"type":"node","id":10892616226,"lat":26.5115025,"lon":80.2361872,"tags":{"addr:city":"Kanpur","addr:housenumber":"Shop No. 6","addr:place":"IIT Kanpur","addr:postcode":"208016","name":"Ladina Unisex Salon","shop":"hairdresser"}},{"type":"node","id":10892616227,"lat":26.5115457,"lon":80.2361859,"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","name":"T.T. Bazaar","shop":"clothes"}},{"type":"node","id":10892616228,"lat":26.5115961,"lon":80.2361872,"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","name":"Sun Beam Dry Cleaners","shop":"dry_cleaning"}},{"type":"node","id":10892625303,"lat":26.5172421,"lon":80.242109,"tags":{"addr:city":"Kanpur","addr:postcode":"208016","amenity":"restaurant","name":"NH91 Fine Dine Restaurant","toilets":"yes","toilets:description":"it stinks really bad","toilets:fee":"no","toilets:gender_segregated":"yes"}},{"type":"node","id":10983460693,"lat":26.5069755,"lon":80.2280697,"tags":{"amenity":"fast_food","fast_food":"cafeteria","name":"Hall 7 canteen"}},{"type":"node","id":11070791233,"lat":26.5129962,"lon":80.233158,"tags":{"addr:city":"Kanpur","addr:floor":"6","addr:housenumber":"Faculty Building - 613","addr:place":"IIT Kanpur","addr:postcode":"208016","name":"Department of Humanities and Social Sciences","office":"university","website":"https://www.iitk.ac.in/hss/"}},{"type":"node","id":11070791234,"lat":26.5131642,"lon":80.2334048,"tags":{"addr:city":"Kanpur","addr:floor":"4","addr:housenumber":"Faculty Building - 431","addr:place":"IIT Kanpur","addr:postcode":"208016","name":"Department of Chemistry","office":"university","website":"https://www.iitk.ac.in/chm/"}},{"type":"node","id":11070791235,"lat":26.5153195,"lon":80.2332492,"tags":{"addr:city":"Kanpur","addr:floor":"4","addr:housenumber":"Room 430, Engineering Science Building 2","addr:place":"IIT Kanpur","addr:postcode":"208016","name":"Department of Economic Sciences","office":"university","website":"https://www.iitk.ac.in/eco/"}},{"type":"node","id":12507479519,"lat":26.5037653,"lon":80.2329786,"tags":{"leisure":"playground","name":"residentail playground"}},{"type":"node","id":12903466605,"lat":26.5157108,"lon":80.2319557,"tags":{"name":"Aerospace Engineering Office","office":"yes","opening_hours":"Mo-Fr 10:00-17:30","website":"https://www.iitk.ac.in/aero/"}},{"type":"node","id":12903484121,"lat":26.5154967,"lon":80.232939,"tags":{"level":"0,1,2","name":"Aerospace Engineering Labs","office":"research","opening_hours":"24/7","website":"https://www.iitk.ac.in/aero/"}},{"type":"node","id":12976394607,"lat":26.5114323,"lon":80.2252302,"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","guest_house":"guest_house","name":"Visitor's Hostel 2 (International Hostel)","short_name":"VH 2","source":"microsoft/BuildingFootprints","tourism":"hostel","website":"https://www.iitk.ac.in/vh/"}},{"type":"node","id":13331574826,"lat":26.5108802,"lon":80.2348596,"tags":{"amenity":"fast_food","brand":"Subway","brand:wikidata":"Q244457","cuisine":"sandwich","level":"0","name":"Subway","takeaway":"yes"}},{"type":"node","id":13331577262,"lat":26.5108763,"lon":80.2457336,"tags":{"addr:city":"Kanpur","amenity":"bank","branch":"IIT Kanpur","brand":"ICICI Bank","brand:wikidata":"Q1653258","level":"0","name":"ICICI Bank","short_name":"ICICI"}},{"type":"node","id":13647379287,"lat":26.5067829,"lon":80.2287809,"tags":{"amenity":"bank","brand":"ICICI Bank","name":"ICICI Bank","short_name":"ICICI"}},{"type":"node","id":13654151803,"lat":26.5095891,"lon":80.2476289,"tags":{"addr:floor":"G","check_date":"2026-03-16","level":"0","name":"Maharajah","shop":"convenience"}},{"type":"node","id":13654151804,"lat":26.5093742,"lon":80.2478404,"tags":{"addr:floor":"G","amenity":"restaurant","check_date":"2026-03-16","level":"0","name":"Hi-Street"}},{"type":"node","id":13654151805,"lat":26.5093033,"lon":80.2478867,"tags":{"addr:floor":"G","amenity":"atm","brand":"State Bank of India","brand:wikidata":"Q1340361","check_date":"2026-03-16","level":"0","operator":"State Bank of India","operator:wikidata":"Q1340361"}},{"type":"node","id":13658924447,"lat":26.50399,"lon":80.22976,"tags":{"amenity":"research_institute","name":"Pronite Ground"}},{"type":"node","id":13715572437,"lat":26.5171664,"lon":80.2322935,"tags":{"addr:city":"Kanpur","addr:district":"Kanpur Nagar","addr:housenumber":"4th Floor","addr:postcode":"208016","addr:street":"Research Complex Park","name":"Centre for Ganga River Basin Management & Studies (cGanga)","office":"research","opening_hours":"Mo-Sa 09:00-18:00","phone":"05126797792","website":"https://cganga.org"}},{"type":"node","id":13910161080,"lat":26.512251,"lon":80.2350162,"tags":{"addr:floor":"4","addr:housenumber":"Faculty Building Annexe","alt_name":"DOSA;DOSA Office","check_date":"2026-06-28","level":"3","name":"Dean of Student Affairs","office":"university","opening_hours":"Mo-Fr 09:00-17:00","website":"https://iitk.ac.in/dosa"}},{"type":"node","id":13910161081,"lat":26.5122112,"lon":80.2350294,"tags":{"addr:floor":"4","addr:housenumber":"Faculty Building Annexe","alt_name":"Dean of Academic Affairs;Academic Section;Academic Affairs","check_date":"2026-06-28","level":"3","name":"DOAA","office":"university","opening_hours":"Mo-Fr 09:00-17:00","website":"https://iitk.ac.in/doaa"}},{"type":"node","id":13967940303,"lat":26.5117751,"lon":80.2274698,"tags":{"shop":"bicycle"}},{"type":"node","id":13972117474,"lat":26.5099667,"lon":80.2473307,"tags":{"amenity":"restaurant","check_date":"2026-06-24","name":"Veer Ji Malai Chaap"}},{"type":"node","id":13972117475,"lat":26.5106136,"lon":80.2468806,"tags":{"check_date":"2026-06-24","name":"Digitech Systems","phone":"+91 94151 27064","shop":"electronics"}},{"type":"node","id":13972117476,"lat":26.5106101,"lon":80.2468478,"tags":{"addr:floor":"G","air_conditioning":"yes","amenity":"cafe","check_date":"2026-06-24","level":"0","name":"Cup n Cone","opening_hours":"Tu-Su 11:00-23:00","phone":"+91 95195 57485"}},{"type":"node","id":13972117477,"lat":26.5122129,"lon":80.2349915,"tags":{"addr:floor":"3","addr:postcode":"208016","alt_name":"Faculty Affairs","check_date":"2026-06-28","level":"2","name":"Dean Of Faculty Affairs","office":"university","short_name":"DOFA","website":"https://iitk.ac.in/dofa/"}},{"type":"node","id":13972117478,"lat":26.5122129,"lon":80.2349915,"tags":{"addr:floor":"3","check_date":"2026-06-28","email":"alumni@iitk.ac.in","level":"2","name":"Dean Of Resources & Alumni","office":"university","short_name":"DoRA","website":"https://iitk.ac.in/dora/"}},{"type":"way","id":30904329,"center":{"lat":26.5187921,"lon":80.2324107},"tags":{"building":"yes","name":"Flight Lab","source":"yahoo"}},{"type":"way","id":52434888,"center":{"lat":26.5131533,"lon":80.2329108},"tags":{"addr:city":"Kanpur","addr:postcode":"208016","addr:street":"IIT Kanpur","amenity":"university","check_date":"2026-03-13","internet_access":"yes","name":"Indian Institute of Technology Kanpur","name:hi":"भारतीय प्रौध्योगिकी संस्थान कानपुर","short_name":"IITK;IIT Kanpur","website":"http://www.iitk.ac.in","wikidata":"Q782682","wikipedia":"en:Indian Institute of Technology Kanpur"}},{"type":"way","id":152917997,"center":{"lat":26.5128443,"lon":80.2337488},"tags":{"access":"private","amenity":"parking","covered":"no","fee":"no","name":"Faculty Building Parking","parking":"surface","supervised":"no","surface":"asphalt"}},{"type":"way","id":152918034,"center":{"lat":26.5050699,"lon":80.231152},"tags":{"access":"official","leisure":"swimming_pool","name":"Institute Swimming Pool"}},{"type":"way","id":152918037,"center":{"lat":26.5079456,"lon":80.2277555},"tags":{"leisure":"park"}},{"type":"way","id":152930182,"center":{"lat":26.5092656,"lon":80.2335912},"tags":{"addr:city":"Kanpur","addr:postcode":"208016","alt_name":"Main Ground;Cricket ground","check_date":"2026-06-01","fee":"no","leisure":"sports_centre","name":"PE Ground","operator":"IIT Kanpur","sport":"multi","website":"https://iitk.ac.in/sports-facilities"}},{"type":"way","id":157018918,"center":{"lat":26.5029406,"lon":80.2287232},"tags":{"man_made":"wastewater_plant","name":"Water treatment area"}},{"type":"way","id":157018921,"center":{"lat":26.5136246,"lon":80.2344351},"tags":{"building":"university","name":"Computer Centre","nohousenumber":"yes"}},{"type":"way","id":157018922,"center":{"lat":26.5130939,"lon":80.2360274},"tags":{"amenity":"cinema","building":"yes","name":"Main Auditorium"}},{"type":"way","id":203657902,"center":{"lat":26.5115374,"lon":80.2291015},"tags":{"leisure":"pitch","sport":"basketball"}},{"type":"way","id":249409343,"center":{"lat":26.5073801,"lon":80.2345889},"tags":{"addr:city":"Kanpur","addr:postcode":"208016","guest_house":"guest_house","internet_access":"yes","internet_access:fee":"no","name":"Visitor Hostel","operator":"IIT Kanpur","tourism":"hostel","website":"https://iitk.ac.in/vh"}},{"type":"way","id":259781081,"center":{"lat":26.5053109,"lon":80.2336663},"tags":{"amenity":"hospital","emergency":"yes","healthcare":"hospital","name":"Health Centre"}},{"type":"way","id":259781082,"center":{"lat":26.5049468,"lon":80.2298378},"tags":{"leisure":"sports_centre","name":"Students' Activity Centre"}},{"type":"way","id":268045151,"center":{"lat":26.5121146,"lon":80.2252476},"tags":{"addr:city":"Kanpur","addr:street":"62nd Street","building":"residential","building:levels":"2","name":"Block A"}},{"type":"way","id":268045152,"center":{"lat":26.5124161,"lon":80.225119},"tags":{"addr:city":"Kanpur","addr:street":"62nd Street","building":"residential","building:levels":"2","name":"Block B"}},{"type":"way","id":268050269,"center":{"lat":26.5122335,"lon":80.2248039},"tags":{"building":"residential","name":"Block C"}},{"type":"way","id":268050272,"center":{"lat":26.5121361,"lon":80.2266265},"tags":{"leisure":"playground"}},{"type":"way","id":268050273,"center":{"lat":26.5125858,"lon":80.2267371},"tags":{"amenity":"place_of_worship","building":"yes","religion":"hindu"}},{"type":"way","id":268050278,"center":{"lat":26.511279,"lon":80.2330513},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","building:levels":"2","layer":"1","name":"Old Lecture Hall Complex"}},{"type":"way","id":268050280,"center":{"lat":26.5130145,"lon":80.2330874},"tags":{"building":"university","building:levels":"7","layer":"1","name":"Faculty Building"}},{"type":"way","id":268050281,"center":{"lat":26.5119728,"lon":80.2343029},"tags":{"addr:city":"Kanpur","addr:housenumber":"68","addr:place":"IIT Kanpur","addr:postcode":"208016","addr:suburb":"Kalyanpur","amenity":"cafe","brand":"Cafe Coffee Day","brand:wikidata":"Q5017235","building":"yes","check_date":"2026-03-14","contact:mobile":"+91 63639 24226","cuisine":"coffee_shop","image:menu":"22abfac1-62e6-4063-a803-e600a719a131","image:menu:0":"ab2aecf4-4b31-4f15-aa61-60996c926612","image:menu:1":"be75251e-7424-484d-9e28-560bf0727ce2","image:menu:10":"aacb1ad4-08d3-4b4c-9d26-11113b88caf0","image:menu:2":"4914fc84-c04f-4df2-a67a-693d96ebf17b","image:menu:3":"3e1486b7-d0f5-49c7-8ada-4668f443e5a9","image:menu:4":"462d75f5-1385-4261-8041-85d360ed2bfd","image:menu:5":"cde1913c-4477-44ac-a312-ad57b3fefb6a","image:menu:6":"3d7f2163-d795-4603-84a2-3fdd3a147d24","image:menu:7":"ef763ac9-5bd4-4476-bcc8-a31dd4af9f20","image:menu:8":"df86a5f2-b427-426d-b2ec-746ac07fbc91","image:menu:9":"6d43c5c2-95c7-406d-8324-f48721afeddd","level":"0","name":"Cafe Coffee Day","outdoor_seating":"yes","panoramax":"cf30c7b3-532b-4333-9f2c-1db66a9bc6b1","panoramax:0":"f6a8b0b0-bf2e-48e4-8735-b279d622bf93","takeaway":"yes"}},{"type":"way","id":268050282,"center":{"lat":26.5115583,"lon":80.2347049},"tags":{"building":"university","name":"Southern Labs"}},{"type":"way","id":268050283,"center":{"lat":26.5136554,"lon":80.2327792},"tags":{"building":"university","layer":"1","name":"Core Lab"}},{"type":"way","id":268050284,"center":{"lat":26.514034,"lon":80.2336132},"tags":{"addr:city":"Kanpur","addr:postcode":"208016","building":"university","name":"Northern Block Laboratories","nohousenumber":"yes"}},{"type":"way","id":268050285,"center":{"lat":26.5145836,"lon":80.2324675},"tags":{"addr:city":"Kanpur","building":"university","name":"Department of Chemical Engineering"}},{"type":"way","id":268050286,"center":{"lat":26.5144156,"lon":80.2317887},"tags":{"addr:city":"Kanpur","addr:postcode":"208016","amenity":"fast_food","building":"yes","fast_food":"cafeteria","name":"DOAA Canteen","opening_hours":"24/7","outdoor_seating":"yes"}},{"type":"way","id":268050287,"center":{"lat":26.5146761,"lon":80.2313042},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","name":"Academic Affairs Building (JEE/GATE)"}},{"type":"way","id":268050288,"center":{"lat":26.5140132,"lon":80.2312601},"tags":{"building":"university","name":"Central Workshop"}},{"type":"way","id":268061984,"center":{"lat":26.5115425,"lon":80.2313802},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","name":"Advanced Centre For Materials Science","short_name":"ACMS","website":"https://www.iitk.ac.in/acms/"}},{"type":"way","id":268061985,"center":{"lat":26.5122657,"lon":80.2317088},"tags":{"building":"university","name":"Western Labs"}},{"type":"way","id":295571076,"center":{"lat":26.5041178,"lon":80.2360754},"tags":{"leisure":"playground","name":"SBRA Jhoola Park"}},{"type":"way","id":295571716,"center":{"lat":26.5038209,"lon":80.2354117},"tags":{"addr:city":"Kanpur","building":"yes","name":"33 K.V.A. Substation","power":"substation","substation":"yes"}},{"type":"way","id":295697794,"center":{"lat":26.5084407,"lon":80.2364749},"tags":{"alt_name":"Central School","amenity":"school","brand":"Kendriya Vidyalaya","brand:wikidata":"Q1156653","grades":"1-12","name":"Kendriya Vidyalaya","operator:type":"government_non_profit","website":"https://iitkanpur.kvs.ac.in/"}},{"type":"way","id":315780946,"center":{"lat":26.5130966,"lon":80.2321082},"tags":{"building":"university","name":"ACES"}},{"type":"way","id":315780949,"center":{"lat":26.5130702,"lon":80.2313151},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","name":"Civil Engineering Lab"}},{"type":"way","id":315780951,"center":{"lat":26.5117526,"lon":80.2320647},"tags":{"addr:city":"Kanpur","building":"university","name":"Samtel Centre for Display Technologies","website":"https://www.iitk.ac.in/scdt/"}},{"type":"way","id":315780952,"center":{"lat":26.5153027,"lon":80.2311076},"tags":{"building":"university","name":"SIDBI"}},{"type":"way","id":315780953,"center":{"lat":26.5130265,"lon":80.2317239},"tags":{"building":"university","name":"Western Lab Extension"}},{"type":"way","id":315780954,"center":{"lat":26.5155281,"lon":80.2319},"tags":{"building":"university","name":"Wind Tunnel Facility"}},{"type":"way","id":315782322,"center":{"lat":26.5120916,"lon":80.2257816},"tags":{"man_made":"water_tower"}},{"type":"way","id":315782323,"center":{"lat":26.5145596,"lon":80.2334072},"tags":{"addr:city":"Kanpur","addr:postcode":"208016","building":"university","name":"Industrial & Management Engineering","website":"https://www.iitk.ac.in/ime/"}},{"type":"way","id":315782325,"center":{"lat":26.5144124,"lon":80.2339669},"tags":{"building":"university","name":"Nuclear Physics Lab","nohousenumber":"yes"}},{"type":"way","id":343506918,"center":{"lat":26.5050081,"lon":80.2293577},"tags":{"addr:city":"Kanpur","addr:postcode":"208016","amenity":"theatre","name":"Open Air Theatre","operator":"Students' Gymkhana","theatre:type":"amphi"}},{"type":"way","id":343518264,"center":{"lat":26.5124624,"lon":80.2359073},"tags":{"leisure":"park","name":"Auditorium Grounds"}},{"type":"way","id":343976510,"center":{"lat":26.5048867,"lon":80.2282673},"tags":{"leisure":"park"}},{"type":"way","id":343976511,"center":{"lat":26.5055129,"lon":80.2284914},"tags":{"leisure":"pitch"}},{"type":"way","id":343976514,"center":{"lat":26.5045841,"lon":80.2284711},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"4","name":"Hall 8 Block H"}},{"type":"way","id":343976515,"center":{"lat":26.5045766,"lon":80.2278313},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"4","name":"Hall 8 Block E"}},{"type":"way","id":343976520,"center":{"lat":26.5058906,"lon":80.2277727},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"4","name":"Hall 8 Block A"}},{"type":"way","id":343976521,"center":{"lat":26.5056355,"lon":80.2277974},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"4","name":"Hall 8 Block B"}},{"type":"way","id":343976522,"center":{"lat":26.5054013,"lon":80.2278039},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"4","name":"Hall 8 Block C"}},{"type":"way","id":343976523,"center":{"lat":26.505142,"lon":80.2277854},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"4","name":"Hall 8 Block D"}},{"type":"way","id":343976524,"center":{"lat":26.504866,"lon":80.2277834},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","amenity":"restaurant","building":"yes","name":"Hall 8 Mess"}},{"type":"way","id":343976525,"center":{"lat":26.5043274,"lon":80.2284915},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"4","name":"Hall 8 Block G"}},{"type":"way","id":343976526,"center":{"lat":26.5043199,"lon":80.2278288},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"4","name":"Hall 8 Block F"}},{"type":"way","id":376400408,"center":{"lat":26.5075587,"lon":80.2267624},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 9 Block A"}},{"type":"way","id":376400409,"center":{"lat":26.5075546,"lon":80.2261109},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 9 Block B"}},{"type":"way","id":376400410,"center":{"lat":26.5077701,"lon":80.2267587},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 9 Block C"}},{"type":"way","id":376400411,"center":{"lat":26.5077717,"lon":80.2261139},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 9 Block D"}},{"type":"way","id":376400412,"center":{"lat":26.5082945,"lon":80.2267557},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 9 Block E"}},{"type":"way","id":376400413,"center":{"lat":26.5082916,"lon":80.2261101},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 9 Block F"}},{"type":"way","id":376400414,"center":{"lat":26.5085121,"lon":80.226758},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 9 Block G"}},{"type":"way","id":376400416,"center":{"lat":26.5080276,"lon":80.2261168},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","amenity":"restaurant","building":"yes","name":"Hall 9 Mess"}},{"type":"way","id":376400429,"center":{"lat":26.5085046,"lon":80.226119},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 9 Block H"}},{"type":"way","id":376447034,"center":{"lat":26.509604,"lon":80.2294489},"tags":{"leisure":"pitch","lit":"yes","name":"C6","sport":"tennis"}},{"type":"way","id":376447035,"center":{"lat":26.5096251,"lon":80.2300761},"tags":{"leisure":"pitch","lit":"yes","name":"C3","sport":"tennis"}},{"type":"way","id":376447036,"center":{"lat":26.5096242,"lon":80.2305606},"tags":{"leisure":"pitch","lit":"yes","name":"C1","sport":"tennis"}},{"type":"way","id":376447038,"center":{"lat":26.5096236,"lon":80.229892},"tags":{"leisure":"pitch","lit":"yes","name":"C4","sport":"tennis"}},{"type":"way","id":376447040,"center":{"lat":26.5096226,"lon":80.2303766},"tags":{"leisure":"pitch","lit":"yes","name":"C2","sport":"tennis"}},{"type":"way","id":376447042,"center":{"lat":26.5096056,"lon":80.2296329},"tags":{"leisure":"pitch","lit":"yes","name":"C5","sport":"tennis"}},{"type":"way","id":376451965,"center":{"lat":26.5074633,"lon":80.2297471},"tags":{"building":"yes","name":"Electric Substation No 5","power":"substation","voltage":"11000;430"}},{"type":"way","id":376451966,"center":{"lat":26.5073998,"lon":80.2300017},"tags":{"man_made":"water_tower"}},{"type":"way","id":376451967,"center":{"lat":26.5033519,"lon":80.2330095},"tags":{"building":"residential","building:levels":"7","name":"Faculty Apartment (C-Block)"}},{"type":"way","id":376451968,"center":{"lat":26.5029173,"lon":80.2330147},"tags":{"building":"residential","building:levels":"7","name":"Faculty Apartment (D-Block)"}},{"type":"way","id":376451969,"center":{"lat":26.5041624,"lon":80.2321709},"tags":{"building":"residential","building:levels":"7","name":"Faculty Apartment (A-Block)"}},{"type":"way","id":376451970,"center":{"lat":26.5037328,"lon":80.2321755},"tags":{"building":"residential","building:levels":"7","name":"Faculty Apartment (B-block)"}},{"type":"way","id":376451986,"center":{"lat":26.5049326,"lon":80.2302723},"tags":{"building":"yes","leisure":"sports_centre","name":"Indoor Sports Complex"}},{"type":"way","id":383013949,"center":{"lat":26.511157,"lon":80.2300162},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 2 Block B"}},{"type":"way","id":383014146,"center":{"lat":26.5113219,"lon":80.2298266},"tags":{"leisure":"pitch","sport":"volleyball"}},{"type":"way","id":383014549,"center":{"lat":26.5112593,"lon":80.2293782},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 2 Block G"}},{"type":"way","id":383015318,"center":{"lat":26.5110302,"lon":80.2293882},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 2 Block A"}},{"type":"way","id":383016139,"center":{"lat":26.5108082,"lon":80.2302112},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 2 Block C"}},{"type":"way","id":383018190,"center":{"lat":26.5103467,"lon":80.2293906},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 2 Block F"}},{"type":"way","id":383018469,"center":{"lat":26.5102037,"lon":80.2299778},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 2 Block E"}},{"type":"way","id":383019229,"center":{"lat":26.5103645,"lon":80.2303371},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 2 Block D"}},{"type":"way","id":383021322,"center":{"lat":26.5115271,"lon":80.2293629},"tags":{"leisure":"pitch","sport":"soccer"}},{"type":"way","id":432735394,"center":{"lat":26.5119459,"lon":80.2359791},"tags":{"amenity":"parking","fee":"no","name":"Shopping Center Parking Lot","operator":"IIT Kanpur","parking":"surface","supervised":"no","surface":"concrete"}},{"type":"way","id":432739245,"center":{"lat":26.5102871,"lon":80.2384179},"tags":{"description":"Contributed by the class of 1967 to their alma mater","leisure":"park","name":"Park 67"}},{"type":"way","id":432740283,"center":{"lat":26.5101751,"lon":80.2367301},"tags":{"building":"kindergarten","building:levels":"1","name":"Kislaya Nursery School"}},{"type":"way","id":432741114,"center":{"lat":26.509931,"lon":80.2367335},"tags":{"area":"yes","leisure":"playground"}},{"type":"way","id":432741609,"center":{"lat":26.5102981,"lon":80.2412381},"tags":{"addr:city":"Kanpur","amenity":"community_centre","building":"yes","name":"Type 2 Community Centre"}},{"type":"way","id":432741792,"center":{"lat":26.5102748,"lon":80.2407276},"tags":{"amenity":"parking","name":"Type 2 community center parking lot","surface":"concrete"}},{"type":"way","id":432742031,"center":{"lat":26.5089209,"lon":80.2443891},"tags":{"area":"yes","leisure":"sports_centre","name":"ACES ground","sport":"cricket"}},{"type":"way","id":440941546,"center":{"lat":26.5084009,"lon":80.23177},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","fee":"no","leisure":"sports_centre","name":"Old Sports Complex"}},{"type":"way","id":470033926,"center":{"lat":26.5080478,"lon":80.2265644},"tags":{"leisure":"park","name":"Hall 9 Quad"}},{"type":"way","id":488149101,"center":{"lat":26.5143279,"lon":80.2348663},"tags":{"addr:city":"Kanpur","addr:postcode":"208016","building":"university","building:levels":"7","name":"Rajeev Motwani Building","nohousenumber":"yes","website":"https://cse.iitk.ac.in/"}},{"type":"way","id":488149102,"center":{"lat":26.5140145,"lon":80.234829},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","alt_name":"KD","building":"university","building:levels":"4","description":"Department of Computer Science and Engineering","internet_access":"yes","name":"H.R. Kadim Diwan Building","nohousenumber":"yes","operator":"Department of Computer Science and Engineering","roof:shape":"flat","website":"https://cse.iitk.ac.in/","wheelchair":"yes"}},{"type":"way","id":501657126,"center":{"lat":26.5135685,"lon":80.2348955},"tags":{"access":"permissive","amenity":"parking","area":"yes","capacity":"8","parking":"street_side","supervised":"no","surface":"asphalt"}},{"type":"way","id":501658530,"center":{"lat":26.5141086,"lon":80.2342838},"tags":{"amenity":"fast_food","building":"yes","cuisine":"regional","fast_food":"cafeteria","internet_access":"yes","internet_access:fee":"no","internet_access:ssid":"iitk","level":"1","name":"Computer Center Canteen","opening_hours":"Mo-Su 09:00-21:00+","outdoor_seating":"yes","smoking":"no"}},{"type":"way","id":659863829,"center":{"lat":26.5060959,"lon":80.2294728},"tags":{"leisure":"pitch","lit":"yes","sport":"soccer"}},{"type":"way","id":659863830,"center":{"lat":26.5059313,"lon":80.2302509},"tags":{"leisure":"pitch","lit":"yes","name":"Hockey Field","sport":"field_hockey"}},{"type":"way","id":682695134,"center":{"lat":26.5096873,"lon":80.2475424},"tags":{"addr:city":"Kanpur","addr:postcode":"208016","amenity":"restaurant","building":"yes","check_date":"2026-03-16","name":"IIT 78 Cafe and Restaurant"}},{"type":"way","id":682695144,"center":{"lat":26.5102691,"lon":80.2469698},"tags":{"addr:city":"Kanpur","addr:postcode":"208016","amenity":"restaurant","building":"yes","name":"Highway 2.0"}},{"type":"way","id":682695186,"center":{"lat":26.5052337,"lon":80.2357223},"tags":{"addr:city":"Kanpur","addr:housenumber":"509 Type 5","addr:place":"IIT Kanpur","addr:postcode":"208016","amenity":"childcare","building":"yes","name":"Snehan Child Care Centre","opening_hours":"Mo-Fr 09:00-18:00","operator":"IIT Kanpur","website":"https://www.iitk.ac.in/snehan/"}},{"type":"way","id":682695218,"center":{"lat":26.5060411,"lon":80.2357053},"tags":{"addr:city":"Kanpur","addr:housenumber":"503 Type 5","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"yes","healthcare":"counselling","name":"Counselling Service","operator":"IIT Kanpur","website":"https://www.iitk.ac.in/counsel/"}},{"type":"way","id":1060146288,"center":{"lat":26.5122497,"lon":80.2350092},"tags":{"addr:postcode":"208016","alt_name":"New FB;FBA","building":"university","name":"Faculty Building Annexe","operator":"Indian Institute Of Technology Kanpur","smoking":"no","wheelchair":"yes"}},{"type":"way","id":1090937351,"center":{"lat":26.509108,"lon":80.2345787},"tags":{"addr:city":"Kanpur","addr:postcode":"208016","amenity":"conference_centre","building":"yes","name":"Outreach Auditorium"}},{"type":"way","id":1090939149,"center":{"lat":26.5110953,"lon":80.2374489},"tags":{"leisure":"park"}},{"type":"way","id":1102507059,"center":{"lat":26.5100141,"lon":80.2286377},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 5 Block C"}},{"type":"way","id":1102507060,"center":{"lat":26.5102305,"lon":80.22864},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 5 Block D"}},{"type":"way","id":1102507061,"center":{"lat":26.509551,"lon":80.2278831},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","amenity":"restaurant","building":"yes","name":"Hall 5 Mess"}},{"type":"way","id":1102507062,"center":{"lat":26.5094041,"lon":80.2283895},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","amenity":"fast_food","building":"yes","drive_through":"no","fast_food":"cafeteria","name":"Hall 5 Canteen","opening_hours":"Mo-Su 14:00-02:00"}},{"type":"way","id":1102507063,"center":{"lat":26.505893,"lon":80.2260158},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","amenity":"restaurant","building":"yes","name":"Hall 10 Mess"}},{"type":"way","id":1102507064,"center":{"lat":26.505526,"lon":80.2260151},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","amenity":"restaurant","building":"yes","name":"Hall 11 Mess"}},{"type":"way","id":1104867049,"center":{"lat":26.5153719,"lon":80.2331601},"tags":{"addr:city":"Kanpur","addr:postcode":"208016","building":"university","name":"Engineering Science Building 2"}},{"type":"way","id":1107954196,"center":{"lat":26.5043259,"lon":80.2312795},"tags":{"addr:city":"Kanpur","addr:postcode":"208016","building":"retail","name":"New Shopping Center"}},{"type":"way","id":1107954994,"center":{"lat":26.5094874,"lon":80.234241},"tags":{"leisure":"pitch","lit":"yes","sport":"volleyball"}},{"type":"way","id":1107954995,"center":{"lat":26.5083243,"lon":80.2342707},"tags":{"leisure":"pitch","sport":"basketball"}},{"type":"way","id":1107954996,"center":{"lat":26.5086255,"lon":80.2329731},"tags":{"leisure":"pitch","sport":"basketball"}},{"type":"way","id":1107954997,"center":{"lat":26.5083021,"lon":80.2329724},"tags":{"leisure":"pitch","sport":"basketball"}},{"type":"way","id":1107954998,"center":{"lat":26.5098865,"lon":80.2329096},"tags":{"amenity":"parking"}},{"type":"way","id":1107955568,"center":{"lat":26.5101738,"lon":80.2273077},"tags":{"leisure":"pitch","name":"Hall 12 Basketball Court","sport":"basketball"}},{"type":"way","id":1107955569,"center":{"lat":26.5090497,"lon":80.2273843},"tags":{"leisure":"pitch","sport":"basketball"}},{"type":"way","id":1107955570,"center":{"lat":26.5079561,"lon":80.2294751},"tags":{"leisure":"pitch","sport":"basketball"}},{"type":"way","id":1107955571,"center":{"lat":26.5070425,"lon":80.2269723},"tags":{"leisure":"pitch","sport":"basketball"}},{"type":"way","id":1107955572,"center":{"lat":26.5063905,"lon":80.2275772},"tags":{"leisure":"pitch","sport":"basketball"}},{"type":"way","id":1107955917,"center":{"lat":26.5096844,"lon":80.2260251},"tags":{"leisure":"pitch","sport":"basketball"}},{"type":"way","id":1109194372,"center":{"lat":26.507504,"lon":80.2330472},"tags":{"leisure":"pitch","sport":"basketball"}},{"type":"way","id":1130615170,"center":{"lat":26.5101189,"lon":80.2281457},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 5 Block F"}},{"type":"way","id":1130615171,"center":{"lat":26.5098976,"lon":80.2281492},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 5 Block E"}},{"type":"way","id":1130673238,"center":{"lat":26.5091167,"lon":80.22865},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 5 Block B"}},{"type":"way","id":1130673239,"center":{"lat":26.5088944,"lon":80.228638},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 5 Block A"}},{"type":"way","id":1130673240,"center":{"lat":26.5087838,"lon":80.2281484},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 5 Block I"}},{"type":"way","id":1130673241,"center":{"lat":26.5090072,"lon":80.2281477},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 5 Block H"}},{"type":"way","id":1130673242,"center":{"lat":26.5092285,"lon":80.2281501},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"3","name":"Hall 5 Block G"}},{"type":"way","id":1131208300,"center":{"lat":26.5151989,"lon":80.2304094},"tags":{"addr:city":"Kanpur","building":"yes","name":"Central AC Plant"}},{"type":"way","id":1131208301,"center":{"lat":26.5146117,"lon":80.2304489},"tags":{"addr:city":"Kanpur","building":"university","name":"Interdisciplinary Centre for Cyber Security and Cyber Defence of Critical Infrastructures","nohousenumber":"yes","short_name":"C3i Center","website":"https://security.cse.iitk.ac.in/"}},{"type":"way","id":1131208302,"center":{"lat":26.5135241,"lon":80.2302647},"tags":{"addr:city":"Kanpur","building":"university","name":"Central Store","name:hi":"केंद्रीय भंडार","nohousenumber":"yes"}},{"type":"way","id":1131208303,"center":{"lat":26.511651,"lon":80.2304585},"tags":{"addr:city":"Kanpur","building":"yes","name":"Security Control Room","office":"security"}},{"type":"way","id":1131618534,"center":{"lat":26.5129194,"lon":80.2350129},"tags":{"leisure":"garden"}},{"type":"way","id":1131619521,"center":{"lat":26.5117718,"lon":80.2359388},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"yes","name":"Campus D Shop","shop":"general"}},{"type":"way","id":1131622792,"center":{"lat":26.5119225,"lon":80.2310988},"tags":{"building":"university","name":"National Centre for Flexible Electronics","website":"http://www.ncflexe.in/"}},{"type":"way","id":1131994408,"center":{"lat":26.5084527,"lon":80.2350465},"tags":{"building":"yes","name":"Electrical Maintenance Office (Hostel Area)","office":"government"}},{"type":"way","id":1131994409,"center":{"lat":26.5101271,"lon":80.2358747},"tags":{"addr:city":"Kanpur","building":"university","name":"Department of Sustainable Energy Engineering","website":"https://www.iitk.ac.in/see/"}},{"type":"way","id":1132835027,"center":{"lat":26.5078126,"lon":80.2356238},"tags":{"leisure":"pitch","sport":"basketball"}},{"type":"way","id":1132835032,"center":{"lat":26.5107445,"lon":80.2346265},"tags":{"access":"customers","amenity":"parking","fee":"no","parking":"surface"}},{"type":"way","id":1132835033,"center":{"lat":26.5120576,"lon":80.23683},"tags":{"amenity":"parking"}},{"type":"way","id":1135333023,"center":{"lat":26.5101251,"lon":80.228505},"tags":{"leisure":"pitch","lit":"yes","sport":"badminton","surface":"ground"}},{"type":"way","id":1135333024,"center":{"lat":26.5097498,"lon":80.2279614},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"yes","name":"Hall 5 Multipurpose hall"}},{"type":"way","id":1135334283,"center":{"lat":26.50657,"lon":80.226872},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"4","name":"Hall 10 Block A"}},{"type":"way","id":1135339093,"center":{"lat":26.514019,"lon":80.2316882},"tags":{"building":"university","name":"Workshop"}},{"type":"way","id":1135339096,"center":{"lat":26.5108302,"lon":80.233882},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","building:levels":"3","name":"New Lecture Hall Complex"}},{"type":"way","id":1135339284,"center":{"lat":26.5148956,"lon":80.2304015},"tags":{"building":"yes","name":"Electric Substation No 12","power":"substation","voltage":"11000;430"}},{"type":"way","id":1135346535,"center":{"lat":26.5152204,"lon":80.2348384},"tags":{"building":"university","name":"Atmospheric Monitoring Station"}},{"type":"way","id":1135346536,"center":{"lat":26.5156943,"lon":80.2342359},"tags":{"building":"university","name":"Centre for Environmental Science & Engineering","short_name":"CESE","website":"https://www.iitk.ac.in/cese/"}},{"type":"way","id":1135352252,"center":{"lat":26.5063114,"lon":80.2264215},"tags":{"building":"yes","name":"Hall 10 Laundry Room","self_service":"yes","shop":"laundry"}},{"type":"way","id":1135352253,"center":{"lat":26.5058995,"lon":80.2285402},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"4","name":"Hall 8 Block I"}},{"type":"way","id":1135358779,"center":{"lat":26.5129767,"lon":80.2336352},"tags":{"leisure":"garden"}},{"type":"way","id":1135360257,"center":{"lat":26.5040101,"lon":80.2289386},"tags":{"amenity":"toilets","building":"yes"}},{"type":"way","id":1135360258,"center":{"lat":26.5093868,"lon":80.2285497},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"yes","name":"Hall 5 TV Room"}},{"type":"way","id":1135360259,"center":{"lat":26.5052616,"lon":80.2262511},"tags":{"building":"yes","name":"Hall 11 Laundry Room","self_service":"yes","shop":"laundry"}},{"type":"way","id":1135360260,"center":{"lat":26.5043966,"lon":80.2259478},"tags":{"leisure":"pitch","sport":"basketball"}},{"type":"way","id":1135867088,"center":{"lat":26.5057126,"lon":80.2267144},"tags":{"leisure":"park"}},{"type":"way","id":1135867089,"center":{"lat":26.5095565,"lon":80.2283773},"tags":{"leisure":"park"}},{"type":"way","id":1136100086,"center":{"lat":26.5134895,"lon":80.2350691},"tags":{"leisure":"garden"}},{"type":"way","id":1136100090,"center":{"lat":26.5084897,"lon":80.2322466},"tags":{"leisure":"pitch","sport":"volleyball"}},{"type":"way","id":1136100091,"center":{"lat":26.5082361,"lon":80.2322123},"tags":{"leisure":"pitch","sport":"volleyball"}},{"type":"way","id":1136930282,"center":{"lat":26.5048046,"lon":80.2350723},"tags":{"leisure":"pitch","sport":"badminton"}},{"type":"way","id":1136942412,"center":{"lat":26.5161782,"lon":80.2332856},"tags":{"building":"university","name":"Helicopter Labs","source":"microsoft/BuildingFootprints"}},{"type":"way","id":1136942413,"center":{"lat":26.505543,"lon":80.232818},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","name":"Old RA Hostel","source":"microsoft/BuildingFootprints"}},{"type":"way","id":1136989049,"center":{"lat":26.5137239,"lon":80.2347861},"tags":{"amenity":"fountain"}},{"type":"way","id":1136989050,"center":{"lat":26.5137709,"lon":80.2347839},"tags":{"leisure":"garden"}},{"type":"way","id":1136989052,"center":{"lat":26.5100963,"lon":80.2287252},"tags":{"amenity":"bicycle_parking","bicycle_parking":"shed","building":"yes","covered":"yes","fee":"no"}},{"type":"way","id":1137181479,"center":{"lat":26.5040517,"lon":80.2351709},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","name":"Smart Grid Control Centre"}},{"type":"way","id":1137189332,"center":{"lat":26.5063048,"lon":80.2345},"tags":{"leisure":"pitch","sport":"basketball"}},{"type":"way","id":1137189333,"center":{"lat":26.5061521,"lon":80.2346525},"tags":{"addr:city":"Kanpur","addr:postcode":"208016","amenity":"school","name":"Campus School","phone":"+91 512 2597354;+91 512 2597770","website":"https://www.iitk.ac.in/campusschool/"}},{"type":"way","id":1137190599,"center":{"lat":26.5108986,"lon":80.2451864},"tags":{"amenity":"bicycle_parking","bicycle_parking":"stands","covered":"no","fee":"yes"}},{"type":"way","id":1137755506,"center":{"lat":26.5142809,"lon":80.2302765},"tags":{"addr:city":"Kanpur","addr:postcode":"208016","building":"university","name":"Rural Technology Action Group","nohousenumber":"yes","short_name":"RuTAG"}},{"type":"way","id":1137755507,"center":{"lat":26.5106875,"lon":80.2334215},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","name":"Lecture Hall 16","short_name":"L16"}},{"type":"way","id":1137755508,"center":{"lat":26.5106902,"lon":80.2337334},"tags":{"addr:city":"Kanpur","addr:postcode":"208016","building":"university","name":"Lecture Hall 17","short_name":"L17"}},{"type":"way","id":1137756289,"center":{"lat":26.5141195,"lon":80.2375538},"tags":{"addr:city":"Kanpur","addr:postcode":"208016","building":"university","name":"Smart Grid Semi-Urban Field Pilot (Lanes 32 and 33)","source":"microsoft/BuildingFootprints"}},{"type":"way","id":1137756293,"center":{"lat":26.511672,"lon":80.2366955},"tags":{"addr:city":"Kanpur","amenity":"bank","atm":"yes","brand":"State Bank of India","brand:wikidata":"Q1340361","building":"yes","drive_through":"no","name":"State Bank of India","short_name":"SBI","source":"microsoft/BuildingFootprints"}},{"type":"way","id":1137984878,"center":{"lat":26.5094349,"lon":80.2282736},"tags":{"building":"yes","name":"Hall 5 Reading Room"}},{"type":"way","id":1138186701,"center":{"lat":26.5041705,"lon":80.2317365},"tags":{"garden:type":"residential","leisure":"garden"}},{"type":"way","id":1138189976,"center":{"lat":26.509206,"lon":80.2483128},"tags":{"building":"train_station","building:levels":"4","building:min_levels":"2","layer":"1","name":"IIT Kanpur","name:hi":"आई आई टी कानपुर","network":"Kanpur Metro","note":"Contributors are requested to not edit the \"network\" and the \"operator\" tags. (2023/11/08)","operator":"Uttar Pradesh Metro Rail Corporation Limited","public_transport":"station","wikidata":"Q110300579","wikipedia":"en:IIT Kanpur metro station"}},{"type":"way","id":1138190698,"center":{"lat":26.5091107,"lon":80.2335968},"tags":{"leisure":"track","lit":"yes","sport":"running","surface":"grass"}},{"type":"way","id":1142120961,"center":{"lat":26.5048668,"lon":80.2268626},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"4","name":"Hall 11 Block A"}},{"type":"way","id":1142120962,"center":{"lat":26.504857,"lon":80.2260352},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"4","name":"Hall 11 Block C"}},{"type":"way","id":1142120963,"center":{"lat":26.5044683,"lon":80.22645},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"4","name":"Hall 11 Block B"}},{"type":"way","id":1142120964,"center":{"lat":26.5069618,"lon":80.2264455},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"4","name":"Hall 10 Block B"}},{"type":"way","id":1142120965,"center":{"lat":26.506559,"lon":80.2260146},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","building:levels":"4","name":"Hall 10 Block C"}},{"type":"way","id":1143854836,"center":{"lat":26.5116544,"lon":80.2329008},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","layer":"1","level":"1","name":"Lecture Hall 7","short_name":"L7"}},{"type":"way","id":1143854837,"center":{"lat":26.5115213,"lon":80.2326291},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","layer":"1","level":"1","name":"Lecture Hall 5","short_name":"L5"}},{"type":"way","id":1143854838,"center":{"lat":26.5113784,"lon":80.232623},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","layer":"1","level":"1","name":"Lecture Hall 6","short_name":"L6"}},{"type":"way","id":1143854839,"center":{"lat":26.5112051,"lon":80.2327992},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","layer":"1","level":"1","name":"Lecture Hall 1","short_name":"L1"}},{"type":"way","id":1143854840,"center":{"lat":26.5112074,"lon":80.2330068},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","layer":"1","level":"1","name":"Lecture Hall 2","short_name":"L2"}},{"type":"way","id":1143854841,"center":{"lat":26.5113776,"lon":80.2331781},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","layer":"1","level":"1","name":"Lecture Hall 3","short_name":"L3"}},{"type":"way","id":1143854842,"center":{"lat":26.5115328,"lon":80.2331703},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","layer":"1","level":"1","name":"Lecture Hall 4","short_name":"L4"}},{"type":"way","id":1143854843,"center":{"lat":26.5109964,"lon":80.2332043},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","level":"1","name":"Lecture Hall 14","short_name":"L14"}},{"type":"way","id":1143854844,"center":{"lat":26.5109037,"lon":80.233324},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","level":"1","name":"Lecture Hall 15","short_name":"L15"}},{"type":"way","id":1144794388,"center":{"lat":26.5077941,"lon":80.2426599},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","amenity":"place_of_worship","building":"yes","name":"Gurdwara IIT Kanpur","religion":"sikh"}},{"type":"way","id":1144794390,"center":{"lat":26.5083353,"lon":80.2412141},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"residential","name":"Type 2 Apartments"}},{"type":"way","id":1145006311,"center":{"lat":26.5069709,"lon":80.2359395},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","addr:street":"Lane 24","building":"house","name":"Director's Residence"}},{"type":"way","id":1150599656,"center":{"lat":26.5099261,"lon":80.2407412},"tags":{"amenity":"charging_station","brand":"EV charging station"}},{"type":"way","id":1154890624,"center":{"lat":26.5099742,"lon":80.2425939},"tags":{"building":"yes","name":"Electric Substation No 6","power":"substation","voltage":"11000;430"}},{"type":"way","id":1157377782,"center":{"lat":26.510301,"lon":80.242599},"tags":{"man_made":"water_tower"}},{"type":"way","id":1158746039,"center":{"lat":26.5120407,"lon":80.230389},"tags":{"building":"yes","name":"Electric Substation No 1","power":"substation","voltage":"11000;430"}},{"type":"way","id":1158746041,"center":{"lat":26.5173326,"lon":80.2304391},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","name":"NCC IIT Kanpur"}},{"type":"way","id":1160854063,"center":{"lat":26.5058516,"lon":80.2309785},"tags":{"amenity":"parking"}},{"type":"way","id":1160854067,"center":{"lat":26.5084981,"lon":80.2313518},"tags":{"addr:city":"Kanpur","addr:postcode":"208016","building":"yes","leisure":"fitness_centre","name":"Old Sports Complex Gym"}},{"type":"way","id":1160854068,"center":{"lat":26.5085258,"lon":80.2309818},"tags":{"area":"yes","leisure":"pitch","sport":"roller_skating"}},{"type":"way","id":1161063538,"center":{"lat":26.5152608,"lon":80.2320831},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"university","name":"Hypersonic Experimental Aerodynamics Lab","short_name":"HEAL"}},{"type":"way","id":1161593034,"center":{"lat":26.5101267,"lon":80.2324684},"tags":{"leisure":"pitch","sport":"basketball"}},{"type":"way","id":1161593960,"center":{"lat":26.516294,"lon":80.230194},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"construction","building:levels":"8","construction":"yes","name":"Engineering Sciences Building 3","roof:shape":"flat","short_name":"ESB3"}},{"type":"way","id":1161607384,"center":{"lat":26.5080473,"lon":80.2303657},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","name":"Hall 3 Block 4"}},{"type":"way","id":1161607385,"center":{"lat":26.5085976,"lon":80.2302226},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","name":"Hall 3 Block 3"}},{"type":"way","id":1161607386,"center":{"lat":26.5089093,"lon":80.2300032},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","name":"Hall 3 Block 2"}},{"type":"way","id":1161607387,"center":{"lat":26.508784,"lon":80.2293887},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","name":"Hall 3 Block 1"}},{"type":"way","id":1161607388,"center":{"lat":26.5090205,"lon":80.2293875},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","name":"Hall 3 Block 7"}},{"type":"way","id":1161607389,"center":{"lat":26.5081028,"lon":80.2293976},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","name":"Hall 3 Block 6"}},{"type":"way","id":1161607390,"center":{"lat":26.5079634,"lon":80.2299918},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"dormitory","name":"Hall 3 Block 5"}},{"type":"way","id":1161607391,"center":{"lat":26.5084407,"lon":80.2295151},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","amenity":"restaurant","building":"yes","name":"Hall 3 Mess"}},{"type":"way","id":1161607392,"center":{"lat":26.5086271,"lon":80.2299751},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","amenity":"fast_food","building":"yes","drive_through":"no","fast_food":"cafeteria","name":"Hall 3 Canteen","opening_hours":"Mo-Su 14:00-02:00"}},{"type":"way","id":1161607393,"center":{"lat":26.5082765,"lon":80.2299281},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","building":"yes","name":"Hall 3 TV Room"}},{"type":"way","id":1161607394,"center":{"lat":26.5080134,"lon":80.2291364},"tags":{"amenity":"bicycle_parking","bicycle_parking":"shed","building":"yes","covered":"yes","fee":"no"}},{"type":"way","id":1161607395,"center":{"lat":26.5078542,"lon":80.2290281},"tags":{"leisure":"pitch","sport":"volleyball"}},{"type":"way","id":1161612852,"center":{"lat":26.5084937,"lon":80.2325058},"tags":{"leisure":"pitch","name":"Tennis Wall","sport":"tennis"}},{"type":"way","id":1162105833,"center":{"lat":26.5103162,"lon":80.2287305},"tags":{"amenity":"bicycle_parking","bicycle_parking":"shed","building":"yes","covered":"yes","fee":"no"}},{"type":"way","id":1162116104,"center":{"lat":26.5106765,"lon":80.2294581},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","amenity":"restaurant","building":"yes","name":"Hall 2 Mess"}},{"type":"way","id":1162995031,"center":{"lat":26.5083901,"lon":80.2318125},"tags":{"leisure":"pitch","sport":"volleyball"}},{"type":"way","id":1162995032,"center":{"lat":26.508552,"lon":80.2318206},"tags":{"leisure":"pitch","sport":"volleyball"}},{"type":"way","id":1163530654,"center":{"lat":26.511932,"lon":80.2338453},"tags":{"amenity":"fountain"}},{"type":"way","id":1167531620,"center":{"lat":26.5072259,"lon":80.2278623},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","amenity":"restaurant","building":"yes","name":"Hall 7 Mess"}},{"type":"way","id":1167533930,"center":{"lat":26.5094946,"lon":80.2320189},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","amenity":"restaurant","building":"yes","name":"Hall 1 Mess"}},{"type":"way","id":1169296957,"center":{"lat":26.5149349,"lon":80.2342027},"tags":{"amenity":"parking"}},{"type":"way","id":1172337971,"center":{"lat":26.5178723,"lon":80.2417171},"tags":{"addr:city":"Kanpur","addr:housenumber":"6, Naramau","addr:postcode":"208016","amenity":"school","email":"wendyhighschoolnaramau@gmail.com","name":"Wendy High School","phone":"+91-7311133336","website":"https://www.wendyhighschool.com/"}},{"type":"way","id":1172337972,"center":{"lat":26.5186272,"lon":80.2412966},"tags":{"addr:city":"Kanpur","addr:postcode":"208016","building":"yes","leisure":"fitness_centre","name":"Shri Purnananda Ajapa Yog Sansthan","name:en":"Shri Purnananda Ajapa Yog Sansthan","name:hi":"श्री पूर्णानन्द अजपा योग संस्थान","sport":"yoga","website":"https://ajapayog.org/"}},{"type":"way","id":1256623109,"center":{"lat":26.5052345,"lon":80.2337102},"tags":{"addr:postcode":"208016","building":"hospital","description":"University clinic","name":"Health Centre","phone":"05122597777","short_name":"HC","website":"https://iitk.ac.in/hc","wheelchair":"yes"}},{"type":"way","id":1351872214,"center":{"lat":26.5027817,"lon":80.2325924},"tags":{"leisure":"park"}},{"type":"way","id":1394026546,"center":{"lat":26.5155182,"lon":80.2325508},"tags":{"building":"university","building:levels":"1","description":"Department of Aerospace Engineering","name":"Aeronautical Engineering Lab"}},{"type":"way","id":1394027089,"center":{"lat":26.5159297,"lon":80.2325782},"tags":{"building":"university","building:levels":"1","name":"High Speed Aerodynamics Lab (HSAL)"}},{"type":"way","id":1394029120,"center":{"lat":26.5158589,"lon":80.2330965},"tags":{"building":"university","name":"Propulsion Labs"}},{"type":"way","id":1465113052,"center":{"lat":26.5152353,"lon":80.2315465},"tags":{"building":"yes","name":"House 1"}},{"type":"way","id":1465113053,"center":{"lat":26.5155734,"lon":80.2315551},"tags":{"building":"yes","name":"House 2"}},{"type":"way","id":1465113054,"center":{"lat":26.5159853,"lon":80.2304156},"tags":{"building":"yes","name":"Building 2"}},{"type":"way","id":1486428403,"center":{"lat":26.5107684,"lon":80.234878},"tags":{"addr:city":"Kanpur","addr:district":"Kanpur","addr:housenumber":"Unit No.04","addr:postcode":"208016","addr:street":"Ground Floor, Indian Institute of Technology Kanpur, Sixth Ave, Nankari, Kalyanpur","air_conditioning":"yes","amenity":"cafe","brand":"Starbucks","brand:wikidata":"Q37158","building":"yes","cuisine":"coffee_shop","internet_access":"wlan","internet_access:fee":"no","layer":"-1","level":"0","location":"surface","name":"Starbucks","official_name":"Starbucks Coffee","opening_hours":"Mo-Su 08:00-23:00","outdoor_seating":"no","phone":"+91 1860 266 0010","takeaway":"yes","website":"https://www.starbucks.in/"}},{"type":"way","id":1486428582,"center":{"lat":26.5082777,"lon":80.2298171},"tags":{"addr:city":"Kanpur","addr:district":"Kanpur","addr:postcode":"208016","addr:street":"Hall 3, IIT Kanpur","building":"yes","building:levels":"1","name":"Electronics Club IITK","website":"https://electronicsclub-iitk.github.io/"}},{"type":"way","id":1486429148,"center":{"lat":26.5105874,"lon":80.2272234},"tags":{"access":"yes","addr:city":"Kanpur","addr:district":"Kanpur","addr:postcode":"208016","addr:street":"Hall 12 back connector, IITK","amenity":"fast_food","building":"yes","fast_food":"cafeteria","name":"Hall12 Canteen","opening_hours":"Mo-Su 14:00-2:00"}},{"type":"way","id":1486430418,"center":{"lat":26.5106436,"lon":80.2277952},"tags":{"addr:city":"Kanpur","addr:district":"Kanpur","addr:postcode":"208016","addr:street":"Hall 12 , IITK","building":"residential","building:levels":"7","name":"Hall 12 Block A"}},{"type":"way","id":1486430419,"center":{"lat":26.5109256,"lon":80.227348},"tags":{"addr:city":"Kanpur","addr:district":"Kanpur","addr:postcode":"208016","addr:street":"Hall 12 , IITK","building":"residential","building:levels":"7","name":"Hall 12 Block C"}},{"type":"way","id":1486430420,"center":{"lat":26.5109308,"lon":80.2277812},"tags":{"addr:city":"Kanpur","addr:district":"Kanpur","addr:postcode":"208016","addr:street":"Hall 12 , IITK","building":"residential","building:levels":"7","name":"Hall 12 Block B"}},{"type":"way","id":1486430421,"center":{"lat":26.5112073,"lon":80.2277961},"tags":{"addr:city":"Kanpur","addr:district":"Kanpur","addr:postcode":"208016","addr:street":"Hall 12 , IITK","building":"residential","building:levels":"7","name":"Hall 12 Block D"}},{"type":"way","id":1486430422,"center":{"lat":26.5112024,"lon":80.2273571},"tags":{"addr:city":"Kanpur","addr:district":"Kanpur","addr:postcode":"208016","addr:street":"Hall 12 , IITK","building":"residential","building:levels":"7","name":"Hall 12 Block E"}},{"type":"way","id":1486430423,"center":{"lat":26.5114882,"lon":80.227787},"tags":{"addr:city":"Kanpur","addr:district":"Kanpur","addr:postcode":"208016","addr:street":"Hall 12 , IITK","building":"residential","building:levels":"7","name":"Hall 12 Block F"}},{"type":"way","id":1486430424,"center":{"lat":26.5114666,"lon":80.2271907},"tags":{"access":"yes","addr:city":"Kanpur","addr:district":"Kanpur","addr:postcode":"208016","addr:street":"Hall 12, IITK","amenity":"fast_food","building":"yes","fast_food":"cafeteria","name":"Hall 12 Mess","opening_hours":"Mo-Su 07:30-21:30"}},{"type":"way","id":1486430425,"center":{"lat":26.511057,"lon":80.2278754},"tags":{"leisure":"pitch","name":"Hall 12 Badminton Court","sport":"badminton"}},{"type":"way","id":1486430426,"center":{"lat":26.5110063,"lon":80.2280806},"tags":{"leisure":"pitch","name":"Hall 12 Volleyball Court","sport":"volleyball"}},{"type":"way","id":1488772205,"center":{"lat":26.5110572,"lon":80.2334338},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","indoor":"room","level":"1","name":"Lecture Hall 13","room":"class","short_name":"L13"}},{"type":"way","id":1488772206,"center":{"lat":26.5111631,"lon":80.2335413},"tags":{"indoor":"room","level":"1","name":"Lecture Hall 11","room":"class","short_name":"L11"}},{"type":"way","id":1488772207,"center":{"lat":26.5110572,"lon":80.2334338},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","indoor":"room","level":"0","name":"Lecture Hall 9","room":"class","short_name":"L9"}},{"type":"way","id":1488772208,"center":{"lat":26.5111724,"lon":80.2332954},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","indoor":"room","level":"1","name":"Lecture Hall 12","room":"class","short_name":"L12"}},{"type":"way","id":1488772209,"center":{"lat":26.5111724,"lon":80.2332954},"tags":{"addr:city":"Kanpur","addr:place":"IIT Kanpur","addr:postcode":"208016","indoor":"room","level":"0","name":"Lecture Hall 8","room":"class","short_name":"L8"}},{"type":"way","id":1488772210,"center":{"lat":26.511273,"lon":80.2334148},"tags":{"indoor":"room","level":"1","name":"Lecture Hall 10","room":"class","short_name":"L10"}},{"type":"way","id":1488889185,"center":{"lat":26.5111146,"lon":80.2334842},"tags":{"indoor":"room","level":"1","name":"Lecture Hall Complex Office Staff","room":"office"}},{"type":"way","id":1488889201,"center":{"lat":26.5112164,"lon":80.233359},"tags":{"indoor":"room","level":"1","name":"Lecture Hall Complex Office Staff","room":"office"}},{"type":"way","id":1488889203,"center":{"lat":26.5054971,"lon":80.2309237},"tags":{"leisure":"swimming_pool","sport":"swimming"}},{"type":"way","id":1489040304,"center":{"lat":26.5109948,"lon":80.2321612},"tags":{"indoor":"room","level":"0","name":"107","room":"class"}},{"type":"way","id":1489040307,"center":{"lat":26.5111054,"lon":80.2323183},"tags":{"indoor":"room","level":"1","name":"210","room":"class"}},{"type":"way","id":1489040308,"center":{"lat":26.5108178,"lon":80.2324839},"tags":{"indoor":"room","level":"0","name":"101","room":"class"}},{"type":"way","id":1489040309,"center":{"lat":26.5107883,"lon":80.2324412},"tags":{"indoor":"room","level":"1","name":"202","room":"class"}},{"type":"way","id":1489040310,"center":{"lat":26.510838,"lon":80.2321818},"tags":{"indoor":"room","level":"0","name":"105","room":"class"}},{"type":"way","id":1489040311,"center":{"lat":26.5110374,"lon":80.2321827},"tags":{"indoor":"room","level":"1","name":"208","room":"class"}},{"type":"way","id":1489040312,"center":{"lat":26.5107706,"lon":80.2323205},"tags":{"indoor":"room","level":"0","name":"103","room":"class"}},{"type":"way","id":1489040313,"center":{"lat":26.5110883,"lon":80.2324381},"tags":{"indoor":"room","level":"0","name":"111","room":"class"}},{"type":"way","id":1489040314,"center":{"lat":26.5108838,"lon":80.2321618},"tags":{"indoor":"room","level":"1","name":"206","room":"class"}},{"type":"way","id":1489040315,"center":{"lat":26.5111054,"lon":80.2323183},"tags":{"indoor":"room","level":"0","name":"110","room":"class"}},{"type":"way","id":1489040316,"center":{"lat":26.5110374,"lon":80.2321827},"tags":{"indoor":"room","level":"0","name":"108","room":"class"}},{"type":"way","id":1489040317,"center":{"lat":26.5107097,"lon":80.2324106},"tags":{"access":"permissive","amenity":"toilets","fee":"no","female":"yes","level":"1","toilets:disposal":"flush","toilets:handwashing":"yes","toilets:position":"squat","wheelchair":"limited"}},{"type":"way","id":1489040318,"center":{"lat":26.5107073,"lon":80.2323803},"tags":{"access":"permissive","amenity":"toilets","fee":"no","level":"0","male":"yes","toilets:disposal":"flush","toilets:handwashing":"yes","toilets:position":"squat;urinal","wheelchair":"limited"}},{"type":"way","id":1489040319,"center":{"lat":26.5108838,"lon":80.2321618},"tags":{"indoor":"room","level":"0","name":"106","room":"class"}},{"type":"way","id":1489040321,"center":{"lat":26.5110589,"lon":80.2324848},"tags":{"indoor":"room","level":"1","name":"212","room":"class"}},{"type":"way","id":1489040324,"center":{"lat":26.5110947,"lon":80.2322638},"tags":{"indoor":"room","level":"0","name":"109","room":"class"}},{"type":"way","id":1489040325,"center":{"lat":26.5109948,"lon":80.2321612},"tags":{"indoor":"room","level":"1","name":"207","room":"class"}},{"type":"way","id":1489040326,"center":{"lat":26.5110589,"lon":80.2324848},"tags":{"indoor":"room","level":"0","name":"112","room":"class"}},{"type":"way","id":1489040327,"center":{"lat":26.5110883,"lon":80.2324384},"tags":{"indoor":"room","level":"1","name":"211","room":"class"}},{"type":"way","id":1489040328,"center":{"lat":26.5108178,"lon":80.2324839},"tags":{"indoor":"room","level":"1","name":"201","room":"class"}},{"type":"way","id":1489040329,"center":{"lat":26.5107073,"lon":80.2323803},"tags":{"access":"permissive","amenity":"toilets","fee":"no","level":"1","male":"yes","toilets:disposal":"flush","toilets:handwashing":"yes","toilets:position":"squat;urinal","wheelchair":"limited"}},{"type":"way","id":1489040330,"center":{"lat":26.5107706,"lon":80.2323205},"tags":{"indoor":"room","level":"1","name":"203","room":"class"}},{"type":"way","id":1489040331,"center":{"lat":26.5110947,"lon":80.2322638},"tags":{"indoor":"room","level":"1","name":"209","room":"class"}},{"type":"way","id":1489040332,"center":{"lat":26.5107883,"lon":80.2324412},"tags":{"indoor":"room","level":"0","name":"102","room":"class"}},{"type":"way","id":1489040334,"center":{"lat":26.510838,"lon":80.2321818},"tags":{"indoor":"room","level":"1","name":"205","room":"class"}},{"type":"way","id":1489040335,"center":{"lat":26.5107097,"lon":80.2324106},"tags":{"access":"permissive","amenity":"toilets","fee":"no","female":"yes","level":"0","toilets:disposal":"flush","toilets:handwashing":"yes","toilets:position":"squat","wheelchair":"limited"}},{"type":"way","id":1489040336,"center":{"lat":26.5107811,"lon":80.2322644},"tags":{"indoor":"room","level":"0","name":"104","room":"class"}},{"type":"way","id":1489040337,"center":{"lat":26.5107811,"lon":80.2322644},"tags":{"indoor":"room","level":"1","name":"204","room":"class"}},{"type":"way","id":1489183404,"center":{"lat":26.5109555,"lon":80.2329015},"tags":{"amenity":"place_of_worship","religion":"hindu"}},{"type":"way","id":1489183406,"center":{"lat":26.510872,"lon":80.2336638},"tags":{"leisure":"bleachers"}},{"type":"way","id":1532673704,"center":{"lat":26.5123862,"lon":80.2257563},"tags":{"amenity":"restaurant","building":"yes","name":"Mess Hall 14"}},{"type":"relation","id":5609184,"center":{"lat":26.5048207,"lon":80.2321449},"tags":{"building":"residential","building:levels":"2","name":"New RA Hostel","type":"multipolygon"}},{"type":"relation","id":7219496,"center":{"lat":26.5109376,"lon":80.2323135},"tags":{"building":"university","building:levels":"2","name":"Tutorial Block","type":"multipolygon"}},{"type":"relation","id":20322513,"center":{"lat":26.5123849,"lon":80.2339019},"tags":{"amenity":"library","building":"yes","internet_access":"wlan","internet_access:fee":"no","name":"P K Kelkar Library","opening_hours":"Mo-Fr 08:00-23:59; Sa 09:00-23:59; Su,PH 09:00-17:30","operator":"IIT Kanpur","type":"multipolygon","website":"https://pkklib.iitk.ac.in"}},{"type":"relation","id":20327839,"center":{"lat":26.5162857,"lon":80.2310607},"tags":{"addr:city":"Kanpur","addr:postcode":"208016","building":"university","building:levels":"4","name":"New Core Labs","roof:shape":"flat","short_name":"NCL","type":"multipolygon"}},{"type":"relation","id":20327840,"center":{"lat":26.5163661,"lon":80.231856},"tags":{"building":"university","name":"Diamond Jubilee Academic Complex","short_name":"DJAC","type":"multipolygon"}}]}
+{
+  "version": 0.6,
+  "generator": "Overpass API 0.7.62.11 87bfad18",
+  "osm3s": {
+    "timestamp_osm_base": "2026-06-17T10:30:37Z",
+    "copyright": "The data included in this document is from www.openstreetmap.org. The data is made available under ODbL."
+  },
+  "elements": [
+
+{
+  "type": "node",
+  "id": 1655763088,
+  "lat": 26.5082770,
+  "lon": 80.2309014,
+  "tags": {
+    "amenity": "atm",
+    "brand": "State Bank of India",
+    "brand:en": "State Bank of India",
+    "brand:wikidata": "Q1340361",
+    "currency:INR": "yes",
+    "drive_through": "no",
+    "fee": "no",
+    "indoor": "yes",
+    "name": "State Bank of India",
+    "note": "Contributors are requested to not edit the \"brand\", \"brand:en\", \"brand:wikidata\", \"operator\", \"operator:en\" and \"operator:wikidata\" tags. (2025/03/03)",
+    "opening_hours": "24/7",
+    "operator": "State Bank of India",
+    "operator:en": "State Bank of India",
+    "operator:wikidata": "Q1340361",
+    "short_name": "SBI"
+  }
+},
+{
+  "type": "node",
+  "id": 1655764679,
+  "lat": 26.5082338,
+  "lon": 80.2308988,
+  "tags": {
+    "amenity": "atm",
+    "brand": "Union Bank of India",
+    "brand:wikidata": "Q2004078",
+    "fee": "no",
+    "name": "Union Bank of India",
+    "operator": "Union Bank of India",
+    "operator:wikidata": "Q2004078"
+  }
+},
+{
+  "type": "node",
+  "id": 1656958496,
+  "lat": 26.5115503,
+  "lon": 80.2363530,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "restaurant",
+    "cuisine": "indian",
+    "name": "Campus Restaurant"
+  }
+},
+{
+  "type": "node",
+  "id": 1656958499,
+  "lat": 26.5112702,
+  "lon": 80.2363169,
+  "tags": {
+    "amenity": "bank",
+    "atm": "yes",
+    "brand": "Union Bank of India",
+    "brand:wikidata": "Q2004078",
+    "drive_through": "no",
+    "name": "Union Bank of India",
+    "name:en": "Union Bank of India",
+    "short_name": "UBI",
+    "website": "https://www.unionbankofindia.co.in/"
+  }
+},
+{
+  "type": "node",
+  "id": 2652376927,
+  "lat": 26.5070288,
+  "lon": 80.2288443,
+  "tags": {
+    "amenity": "atm",
+    "brand": "ICICI Bank",
+    "brand:en": "ICICI Bank",
+    "brand:wikidata": "Q1653258",
+    "cash_in": "yes",
+    "currency:INR": "yes",
+    "drive_through": "no",
+    "indoor": "yes",
+    "name": "ICICI Bank",
+    "note": "Contributors are requested to not edit the \"brand\", \"brand:en\", \"brand:wikidata\", \"operator\", \"operator:en\" and \"operator:wikidata\" tags. (2025/03/03)",
+    "opening_hours": "24/7",
+    "operator": "ICICI Bank",
+    "operator:en": "ICICI Bank",
+    "operator:wikidata": "Q1653258",
+    "short_name": "ICICI"
+  }
+},
+{
+  "type": "node",
+  "id": 2652376937,
+  "lat": 26.5050396,
+  "lon": 80.2292403,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "fast_food",
+    "brand": "Burger Singh",
+    "cuisine": "burger",
+    "name": "Burger Singh",
+    "takeaway": "yes"
+  }
+},
+{
+  "type": "node",
+  "id": 2652376940,
+  "lat": 26.5050597,
+  "lon": 80.2292637,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "fast_food",
+    "cuisine": "rolls",
+    "level": "0",
+    "name": "Aladdin's",
+    "website": "https://www.iitk.ac.in/new/kathi-inc"
+  }
+},
+{
+  "type": "node",
+  "id": 2652376945,
+  "lat": 26.5047557,
+  "lon": 80.2292902,
+  "tags": {
+    "amenity": "library",
+    "name": "Book Club"
+  }
+},
+{
+  "type": "node",
+  "id": 2734619313,
+  "lat": 26.5117680,
+  "lon": 80.2362652,
+  "tags": {
+    "amenity": "toilets"
+  }
+},
+{
+  "type": "node",
+  "id": 2734619320,
+  "lat": 26.5113535,
+  "lon": 80.2365581,
+  "tags": {
+    "amenity": "pharmacy",
+    "healthcare": "pharmacy"
+  }
+},
+{
+  "type": "node",
+  "id": 2734619325,
+  "lat": 26.5113739,
+  "lon": 80.2361910,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:housenumber": "Shop No. 3",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "name": "Noble Book Stall",
+    "shop": "books"
+  }
+},
+{
+  "type": "node",
+  "id": 2734619341,
+  "lat": 26.5119835,
+  "lon": 80.2364936,
+  "tags": {
+    "amenity": "post_office"
+  }
+},
+{
+  "type": "node",
+  "id": 2734619343,
+  "lat": 26.5122816,
+  "lon": 80.2304354,
+  "tags": {
+    "service:bicycle:pump": "yes",
+    "service:bicycle:repair": "yes",
+    "service:bicycle:second_hand": "yes",
+    "shop": "bicycle"
+  }
+},
+{
+  "type": "node",
+  "id": 2734619353,
+  "lat": 26.5116931,
+  "lon": 80.2361745,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "name": "Looks Men Hair Salon",
+    "shop": "hairdresser"
+  }
+},
+{
+  "type": "node",
+  "id": 2734619354,
+  "lat": 26.5112815,
+  "lon": 80.2365661,
+  "tags": {
+    "service:bicycle:pump": "yes",
+    "service:bicycle:repair": "yes",
+    "service:bicycle:second_hand": "yes",
+    "shop": "bicycle"
+  }
+},
+{
+  "type": "node",
+  "id": 2734619360,
+  "lat": 26.5115191,
+  "lon": 80.2465037,
+  "tags": {
+    "name": "Beer Shop",
+    "shop": "alcohol"
+  }
+},
+{
+  "type": "node",
+  "id": 3277783199,
+  "lat": 26.5117899,
+  "lon": 80.2342909,
+  "tags": {
+    "addr:city": "IIT Kanpur",
+    "addr:housename": "CCD ke bagal wali canteen",
+    "addr:postcode": "208016",
+    "amenity": "fast_food",
+    "designation": "Canteen",
+    "diet:vegetarian": "yes",
+    "name": "Southern Labs Canteen",
+    "source": "Local Source"
+  }
+},
+{
+  "type": "node",
+  "id": 3862137593,
+  "lat": 26.5109119,
+  "lon": 80.2298625,
+  "tags": {
+    "amenity": "fast_food",
+    "cuisine": "sandwich,_samosa,_paranthas,_and_other_regular_indian_foods",
+    "delivery": "no",
+    "drive_through": "no",
+    "name": "Hall 2 Canteen",
+    "opening_hours": "14:00-02:00",
+    "smoking": "no",
+    "takeaway": "yes"
+  }
+},
+{
+  "type": "node",
+  "id": 4311239589,
+  "lat": 26.5051135,
+  "lon": 80.2293655,
+  "tags": {
+    "addr:postcode": "208016",
+    "addr:street": "New SAC Road",
+    "amenity": "fast_food",
+    "brand": "Domino's",
+    "brand:wikidata": "Q839466",
+    "cuisine": "pizza",
+    "name": "Domino's",
+    "takeaway": "yes"
+  }
+},
+{
+  "type": "node",
+  "id": 5331658992,
+  "lat": 26.5114442,
+  "lon": 80.2463364,
+  "tags": {
+    "amenity": "restaurant",
+    "name": "China Town"
+  }
+},
+{
+  "type": "node",
+  "id": 6175946485,
+  "lat": 26.5050128,
+  "lon": 80.2282524,
+  "tags": {
+    "amenity": "restaurant",
+    "name:en": "Canteen"
+  }
+},
+{
+  "type": "node",
+  "id": 7065213786,
+  "lat": 26.5114292,
+  "lon": 80.2361904,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:housenumber": "Shop No. 4",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "name": "New Suparsh Provision Store",
+    "shop": "supermarket"
+  }
+},
+{
+  "type": "node",
+  "id": 7108657166,
+  "lat": 26.5045986,
+  "lon": 80.2455455,
+  "tags": {
+    "addr:city": "kanpur",
+    "addr:postcode": "208016",
+    "leisure": "park",
+    "name": "siddharth nagar society pqrk"
+  }
+},
+{
+  "type": "node",
+  "id": 9740268374,
+  "lat": 26.5110335,
+  "lon": 80.2395106,
+  "tags": {
+    "addr:city": "Kanpur",
+    "amenity": "fuel",
+    "brand": "Indian Oil",
+    "brand:wikidata": "Q1289348",
+    "name": "Indian Oil",
+    "self_service": "no"
+  }
+},
+{
+  "type": "node",
+  "id": 9747705660,
+  "lat": 26.5109724,
+  "lon": 80.2362699,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "name": "Kalyan G Bakery",
+    "shop": "bakery"
+  }
+},
+{
+  "type": "node",
+  "id": 9992315793,
+  "lat": 26.5058666,
+  "lon": 80.2272991,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "ice_cream",
+    "name": "Mama Mio Milkshake and Icecream",
+    "outdoor_seating": "yes"
+  }
+},
+{
+  "type": "node",
+  "id": 10537273080,
+  "lat": 26.5098141,
+  "lon": 80.2290351,
+  "tags": {
+    "service:bicycle:pump": "yes",
+    "service:bicycle:repair": "yes",
+    "service:bicycle:second_hand": "yes",
+    "shop": "bicycle"
+  }
+},
+{
+  "type": "node",
+  "id": 10537273081,
+  "lat": 26.5074958,
+  "lon": 80.2271877,
+  "tags": {
+    "service:bicycle:pump": "yes",
+    "service:bicycle:repair": "yes",
+    "service:bicycle:second_hand": "yes",
+    "shop": "bicycle"
+  }
+},
+{
+  "type": "node",
+  "id": 10537273082,
+  "lat": 26.5064016,
+  "lon": 80.2271718,
+  "tags": {
+    "service:bicycle:pump": "yes",
+    "service:bicycle:repair": "yes",
+    "service:bicycle:second_hand": "yes",
+    "shop": "bicycle"
+  }
+},
+{
+  "type": "node",
+  "id": 10537273083,
+  "lat": 26.5045852,
+  "lon": 80.2354667,
+  "tags": {
+    "service:bicycle:pump": "yes",
+    "service:bicycle:repair": "yes",
+    "service:bicycle:second_hand": "yes",
+    "shop": "bicycle"
+  }
+},
+{
+  "type": "node",
+  "id": 10537331488,
+  "lat": 26.5050752,
+  "lon": 80.2332455,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "pharmacy",
+    "brand": "Tata 1MG",
+    "brand:wikidata": "Q62562612",
+    "check_date": "2026-05-31",
+    "dispensing": "yes",
+    "healthcare": "pharmacy",
+    "name": "Tata 1MG Pharmacy",
+    "opening_hours": "24/7"
+  }
+},
+{
+  "type": "node",
+  "id": 10537333776,
+  "lat": 26.5061737,
+  "lon": 80.2267183,
+  "tags": {
+    "amenity": "fast_food",
+    "fast_food": "cafeteria",
+    "name": "Hall 10 Canteen"
+  }
+},
+{
+  "type": "node",
+  "id": 10537333777,
+  "lat": 26.5052558,
+  "lon": 80.2267157,
+  "tags": {
+    "amenity": "fast_food",
+    "fast_food": "cafeteria",
+    "name": "Hall 11 Canteen"
+  }
+},
+{
+  "type": "node",
+  "id": 10537340887,
+  "lat": 26.5093362,
+  "lon": 80.2325609,
+  "tags": {
+    "addr:city": "Kanpur",
+    "amenity": "fast_food",
+    "cuisine": "juice;ice_cream",
+    "name": "Gupta Shake and Icecream Shop",
+    "outdoor_seating": "yes"
+  }
+},
+{
+  "type": "node",
+  "id": 10537340889,
+  "lat": 26.5043553,
+  "lon": 80.2314540,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:housenumber": "Shop No 1",
+    "addr:postcode": "208016",
+    "name": "Campus E Shop",
+    "shop": "general"
+  }
+},
+{
+  "type": "node",
+  "id": 10537340890,
+  "lat": 26.5042273,
+  "lon": 80.2314824,
+  "tags": {
+    "service:bicycle:pump": "yes",
+    "service:bicycle:repair": "yes",
+    "service:bicycle:second_hand": "yes",
+    "shop": "bicycle"
+  }
+},
+{
+  "type": "node",
+  "id": 10543460611,
+  "lat": 26.5148037,
+  "lon": 80.2322222,
+  "tags": {
+    "addr:city": "Kanpur",
+    "name": "Jeet Bindra Unit Operations and Innovation Lab",
+    "office": "research"
+  }
+},
+{
+  "type": "node",
+  "id": 10543460626,
+  "lat": 26.5128774,
+  "lon": 80.2306028,
+  "tags": {
+    "name": "Employees Association",
+    "office": "association"
+  }
+},
+{
+  "type": "node",
+  "id": 10543460627,
+  "lat": 26.5122748,
+  "lon": 80.2305204,
+  "tags": {
+    "addr:city": "Kanpur",
+    "name": "Vinod Garments and Footwear",
+    "shop": "shoes"
+  }
+},
+{
+  "type": "node",
+  "id": 10543460628,
+  "lat": 26.5122324,
+  "lon": 80.2305242,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "place_of_worship",
+    "name": "Sankat Mochan Hanuman Temple",
+    "name:en": "Sankat Mochan Hanuman Temple",
+    "name:hi": "संकट मोचन हनुमान मंदिर",
+    "religion": "hindu"
+  }
+},
+{
+  "type": "node",
+  "id": 10543460633,
+  "lat": 26.5114417,
+  "lon": 80.2306189,
+  "tags": {
+    "name": "IITK Motorsports",
+    "office": "yes"
+  }
+},
+{
+  "type": "node",
+  "id": 10549080635,
+  "lat": 26.5113588,
+  "lon": 80.2366299,
+  "tags": {
+    "name": "Amul",
+    "shop": "dairy"
+  }
+},
+{
+  "type": "node",
+  "id": 10549080636,
+  "lat": 26.5119793,
+  "lon": 80.2363010,
+  "tags": {
+    "addr:city": "Kanpur",
+    "name": "Divyam Naturals",
+    "shop": "health_food"
+  }
+},
+{
+  "type": "node",
+  "id": 10549089086,
+  "lat": 26.5135534,
+  "lon": 80.2346441,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "name": "ID Cell",
+    "name:en": "ID Cell",
+    "name:hi": "परिचय पत्र प्रकोष्ट",
+    "office": "university"
+  }
+},
+{
+  "type": "node",
+  "id": 10554872728,
+  "lat": 26.5082593,
+  "lon": 80.2345998,
+  "tags": {
+    "communication:mobile_phone": "yes",
+    "man_made": "tower",
+    "tower:type": "communication"
+  }
+},
+{
+  "type": "node",
+  "id": 10554872741,
+  "lat": 26.5101067,
+  "lon": 80.2355885,
+  "tags": {
+    "addr:city": "Kanpur",
+    "name": "IIT Kanpur La Trobe University Research Academy",
+    "office": "research"
+  }
+},
+{
+  "type": "node",
+  "id": 10554872742,
+  "lat": 26.5100341,
+  "lon": 80.2355878,
+  "tags": {
+    "addr:city": "Kanpur",
+    "name": "Smart Grid Center of Excellence for Training, Research and Enterpreneurship",
+    "office": "research",
+    "short_name": "SG-CEnTRE",
+    "website": "https://sgcentre.iitk.ac.in/"
+  }
+},
+{
+  "type": "node",
+  "id": 10554872747,
+  "lat": 26.5108693,
+  "lon": 80.2381580,
+  "tags": {
+    "man_made": "tower",
+    "tower:type": "communication"
+  }
+},
+{
+  "type": "node",
+  "id": 10562586743,
+  "lat": 26.5117682,
+  "lon": 80.2352139,
+  "tags": {
+    "name": "Central Cryogenics Facility",
+    "office": "research"
+  }
+},
+{
+  "type": "node",
+  "id": 10562586748,
+  "lat": 26.5117618,
+  "lon": 80.2360289,
+  "tags": {
+    "amenity": "drinking_water"
+  }
+},
+{
+  "type": "node",
+  "id": 10583048062,
+  "lat": 26.5059763,
+  "lon": 80.2264539,
+  "tags": {
+    "shop": "general"
+  }
+},
+{
+  "type": "node",
+  "id": 10583048063,
+  "lat": 26.5054540,
+  "lon": 80.2264888,
+  "tags": {
+    "shop": "general"
+  }
+},
+{
+  "type": "node",
+  "id": 10583048064,
+  "lat": 26.5060207,
+  "lon": 80.2265007,
+  "tags": {
+    "shop": "copyshop"
+  }
+},
+{
+  "type": "node",
+  "id": 10583048095,
+  "lat": 26.5061402,
+  "lon": 80.2266497,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "leisure": "fitness_centre",
+    "name": "Hall 10 Gym"
+  }
+},
+{
+  "type": "node",
+  "id": 10583065012,
+  "lat": 26.5093081,
+  "lon": 80.2274858,
+  "tags": {
+    "shop": "copyshop"
+  }
+},
+{
+  "type": "node",
+  "id": 10583065013,
+  "lat": 26.5093692,
+  "lon": 80.2274839,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "name": "Das General Store",
+    "payment:cash": "yes",
+    "payment:upi": "yes",
+    "phone": "+91-9936309179",
+    "shop": "general"
+  }
+},
+{
+  "type": "node",
+  "id": 10583083072,
+  "lat": 26.5111712,
+  "lon": 80.2361595,
+  "tags": {
+    "amenity": "place_of_worship",
+    "religion": "hindu"
+  }
+},
+{
+  "type": "node",
+  "id": 10583083073,
+  "lat": 26.5043555,
+  "lon": 80.2313282,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:housenumber": "Shop No. 5",
+    "addr:place": "New Shopping Center, IIT Kanpur",
+    "addr:postcode": "208016",
+    "name": "Amul Parlor",
+    "opening_hours": "Mo-Su 07:00-22:00",
+    "shop": "dairy"
+  }
+},
+{
+  "type": "node",
+  "id": 10583129149,
+  "lat": 26.5116339,
+  "lon": 80.2334593,
+  "tags": {
+    "artwork_type": "sculpture",
+    "name": "Silver Jubilee Landmark",
+    "tourism": "artwork"
+  }
+},
+{
+  "type": "node",
+  "id": 10583174469,
+  "lat": 26.5098975,
+  "lon": 80.2286060,
+  "tags": {
+    "name": "Hall 5 Laundry Room",
+    "self_service": "yes",
+    "shop": "laundry"
+  }
+},
+{
+  "type": "node",
+  "id": 10583174470,
+  "lat": 26.5097808,
+  "lon": 80.2285768,
+  "tags": {
+    "leisure": "fitness_centre",
+    "name": "Hall 5 Gym"
+  }
+},
+{
+  "type": "node",
+  "id": 10583209415,
+  "lat": 26.5094319,
+  "lon": 80.2280998,
+  "tags": {
+    "amenity": "toilets",
+    "female": "yes"
+  }
+},
+{
+  "type": "node",
+  "id": 10583209416,
+  "lat": 26.5060854,
+  "lon": 80.2263841,
+  "tags": {
+    "amenity": "toilets",
+    "female": "yes"
+  }
+},
+{
+  "type": "node",
+  "id": 10590409194,
+  "lat": 26.5094159,
+  "lon": 80.2306910,
+  "tags": {
+    "name": "Saumya Sports",
+    "shop": "sports"
+  }
+},
+{
+  "type": "node",
+  "id": 10598446553,
+  "lat": 26.5043743,
+  "lon": 80.2310911,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "restaurant",
+    "name": "Urban Crave"
+  }
+},
+{
+  "type": "node",
+  "id": 10598446554,
+  "lat": 26.5043554,
+  "lon": 80.2312603,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:housenumber": "Shop No. 7",
+    "addr:place": "New Shopping Center, IIT Kanpur",
+    "addr:postcode": "208016",
+    "email": "contact@campuskart.in",
+    "name": "Electronics Emporium",
+    "opening_hours": "Mo-Su 11:00-21:00",
+    "phone": "+91-7905471491",
+    "shop": "electronics",
+    "website": "https://www.campuskart.in"
+  }
+},
+{
+  "type": "node",
+  "id": 10598446555,
+  "lat": 26.5043552,
+  "lon": 80.2312950,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:housenumber": "Shop No. 6",
+    "addr:place": "New Shopping Center, IIT Kanpur",
+    "addr:postcode": "208016",
+    "email": "sk1019257@gmail.com",
+    "name": "Hari Veg Store",
+    "phone": "+91-7607713162",
+    "shop": "greengrocer",
+    "website": "https://www.harivegstore.co.in"
+  }
+},
+{
+  "type": "node",
+  "id": 10598446556,
+  "lat": 26.5043555,
+  "lon": 80.2313598,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:housenumber": "Shop No. 4",
+    "addr:place": "New Shopping Center, IIT Kanpur",
+    "addr:postcode": "208016",
+    "name": "Mercury Dry Cleaning",
+    "opening_hours": "Mo-Su 10:00-20:00; Fr off",
+    "phone": "+91-9795954433",
+    "shop": "dry_cleaning"
+  }
+},
+{
+  "type": "node",
+  "id": 10598446557,
+  "lat": 26.5043561,
+  "lon": 80.2313926,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:housenumber": "Shop No. 3",
+    "addr:place": "New Shopping Center, IIT Kanpur",
+    "addr:postcode": "208016",
+    "name": "Fascia Salon",
+    "opening_hours": "Mo-Su 10:00-20:00; Tu off",
+    "shop": "hairdresser",
+    "unisex": "yes"
+  }
+},
+{
+  "type": "node",
+  "id": 10598446589,
+  "lat": 26.5050127,
+  "lon": 80.2292162,
+  "tags": {
+    "amenity": "fast_food",
+    "level": "0",
+    "name": "Naughty Blenders",
+    "operator": "Burger Belly"
+  }
+},
+{
+  "type": "node",
+  "id": 10598993155,
+  "lat": 26.5138828,
+  "lon": 80.2348833,
+  "tags": {
+    "access": "yes",
+    "amenity": "bicycle_parking",
+    "bicycle_parking": "shed",
+    "covered": "yes",
+    "fee": "no"
+  }
+},
+{
+  "type": "node",
+  "id": 10598993156,
+  "lat": 26.5145022,
+  "lon": 80.2344278,
+  "tags": {
+    "amenity": "bicycle_parking",
+    "covered": "no",
+    "fee": "no"
+  }
+},
+{
+  "type": "node",
+  "id": 10598993161,
+  "lat": 26.5099074,
+  "lon": 80.2289294,
+  "tags": {
+    "amenity": "bicycle_parking",
+    "bicycle_parking": "wall_loops",
+    "covered": "no",
+    "fee": "no"
+  }
+},
+{
+  "type": "node",
+  "id": 10600742657,
+  "lat": 26.5108202,
+  "lon": 80.2455852,
+  "tags": {
+    "amenity": "bank",
+    "atm": "yes",
+    "brand": "ICICI Bank",
+    "brand:wikidata": "Q1653258",
+    "name": "ICICI Bank",
+    "short_name": "ICICI"
+  }
+},
+{
+  "type": "node",
+  "id": 10605366657,
+  "lat": 26.5108503,
+  "lon": 80.2331485,
+  "tags": {
+    "amenity": "toilets"
+  }
+},
+{
+  "type": "node",
+  "id": 10605408143,
+  "lat": 26.5049768,
+  "lon": 80.2291789,
+  "tags": {
+    "amenity": "drinking_water",
+    "man_made": "water_tap"
+  }
+},
+{
+  "type": "node",
+  "id": 10605408144,
+  "lat": 26.5049672,
+  "lon": 80.2291734,
+  "tags": {
+    "amenity": "toilets",
+    "male": "yes"
+  }
+},
+{
+  "type": "node",
+  "id": 10605430800,
+  "lat": 26.5139283,
+  "lon": 80.2347199,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "name": "Department of Computer Science",
+    "office": "university",
+    "website": "https://www.cse.iitk.ac.in/"
+  }
+},
+{
+  "type": "node",
+  "id": 10635411296,
+  "lat": 26.5138798,
+  "lon": 80.2336782,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "name": "Department of Mechanical Engineering",
+    "office": "university",
+    "website": "https://www.iitk.ac.in/me/"
+  }
+},
+{
+  "type": "node",
+  "id": 10648244237,
+  "lat": 26.5113462,
+  "lon": 80.2329055,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "description": "Contributed by 1989 batch",
+    "level": "0",
+    "name": "Student Lounge",
+    "office": "coworking"
+  }
+},
+{
+  "type": "node",
+  "id": 10648244271,
+  "lat": 26.5108693,
+  "lon": 80.2340628,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "level": "2",
+    "name": "Lecture Hall 20",
+    "short_name": "L20"
+  }
+},
+{
+  "type": "node",
+  "id": 10648244272,
+  "lat": 26.5109830,
+  "lon": 80.2343115,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "level": "2",
+    "name": "Lecture Hall 19",
+    "short_name": "L19"
+  }
+},
+{
+  "type": "node",
+  "id": 10648244273,
+  "lat": 26.5109357,
+  "lon": 80.2341773,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "level": "0",
+    "name": "Lecture Hall 18",
+    "short_name": "L18"
+  }
+},
+{
+  "type": "node",
+  "id": 10656632243,
+  "lat": 26.5089734,
+  "lon": 80.2329614,
+  "tags": {
+    "amenity": "toilets"
+  }
+},
+{
+  "type": "node",
+  "id": 10703242259,
+  "lat": 26.5100323,
+  "lon": 80.2418343,
+  "tags": {
+    "amenity": "place_of_worship",
+    "religion": "hindu"
+  }
+},
+{
+  "type": "node",
+  "id": 10703242260,
+  "lat": 26.5101440,
+  "lon": 80.2419345,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "police",
+    "name": "IIT Kanpur Police Chowki"
+  }
+},
+{
+  "type": "node",
+  "id": 10760551158,
+  "lat": 26.5058062,
+  "lon": 80.2272988,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "restaurant",
+    "cuisine": "chinese",
+    "name": "Quiacan Chinese",
+    "outdoor_seating": "yes"
+  }
+},
+{
+  "type": "node",
+  "id": 10760551159,
+  "lat": 26.5059201,
+  "lon": 80.2272988,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "restaurant",
+    "name": "Eatezee",
+    "outdoor_seating": "yes"
+  }
+},
+{
+  "type": "node",
+  "id": 10772624143,
+  "lat": 26.5104346,
+  "lon": 80.2389580,
+  "tags": {
+    "amenity": "fountain"
+  }
+},
+{
+  "type": "node",
+  "id": 10775939739,
+  "lat": 26.5119495,
+  "lon": 80.2300649,
+  "tags": {
+    "amenity": "fire_station",
+    "name": "IIT Kanpur Fire Station"
+  }
+},
+{
+  "type": "node",
+  "id": 10775939740,
+  "lat": 26.5119855,
+  "lon": 80.2291985,
+  "tags": {
+    "amenity": "place_of_worship",
+    "religion": "hindu"
+  }
+},
+{
+  "type": "node",
+  "id": 10775939741,
+  "lat": 26.5156372,
+  "lon": 80.2305584,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "name": "National Aerosol Facility",
+    "office": "research",
+    "website": "https://home.iitk.ac.in/~snt/naf/index.html"
+  }
+},
+{
+  "type": "node",
+  "id": 10799133070,
+  "lat": 26.5047119,
+  "lon": 80.2297824,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "leisure": "sports_centre",
+    "name": "IITK Wall Climbing Facility",
+    "sport": "climbing"
+  }
+},
+{
+  "type": "node",
+  "id": 10803686709,
+  "lat": 26.5101031,
+  "lon": 80.2286152,
+  "tags": {
+    "amenity": "drinking_water",
+    "bottle": "yes",
+    "fee": "no"
+  }
+},
+{
+  "type": "node",
+  "id": 10803686710,
+  "lat": 26.5100244,
+  "lon": 80.2281134,
+  "tags": {
+    "amenity": "drinking_water",
+    "bottle": "yes",
+    "fee": "no"
+  }
+},
+{
+  "type": "node",
+  "id": 10820718222,
+  "lat": 26.5135103,
+  "lon": 80.2323625,
+  "tags": {
+    "emergency": "fire_hydrant"
+  }
+},
+{
+  "type": "node",
+  "id": 10821064294,
+  "lat": 26.5121786,
+  "lon": 80.2340145,
+  "tags": {
+    "amenity": "bicycle_parking",
+    "bicycle_parking": "wall_loops",
+    "covered": "yes",
+    "fee": "no"
+  }
+},
+{
+  "type": "node",
+  "id": 10892585399,
+  "lat": 26.5098650,
+  "lon": 80.2325233,
+  "tags": {
+    "shop": "hairdresser"
+  }
+},
+{
+  "type": "node",
+  "id": 10892616222,
+  "lat": 26.5117293,
+  "lon": 80.2361752,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "name": "Mubeen Tailors",
+    "shop": "tailor"
+  }
+},
+{
+  "type": "node",
+  "id": 10892616223,
+  "lat": 26.5116621,
+  "lon": 80.2361738,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "name": "Shiv Shankar Stationary",
+    "shop": "stationery"
+  }
+},
+{
+  "type": "node",
+  "id": 10892616224,
+  "lat": 26.5117125,
+  "lon": 80.2362369,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "name": "A-One Photocopy Center",
+    "shop": "copyshop"
+  }
+},
+{
+  "type": "node",
+  "id": 10892616225,
+  "lat": 26.5116285,
+  "lon": 80.2362369,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "name": "Tarun Book Store",
+    "shop": "books"
+  }
+},
+{
+  "type": "node",
+  "id": 10892616226,
+  "lat": 26.5115025,
+  "lon": 80.2361872,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:housenumber": "Shop No. 6",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "name": "Ladina Unisex Salon",
+    "shop": "hairdresser"
+  }
+},
+{
+  "type": "node",
+  "id": 10892616227,
+  "lat": 26.5115457,
+  "lon": 80.2361859,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "name": "T.T. Bazaar",
+    "shop": "clothes"
+  }
+},
+{
+  "type": "node",
+  "id": 10892616228,
+  "lat": 26.5115961,
+  "lon": 80.2361872,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "name": "Sun Beam Dry Cleaners",
+    "shop": "dry_cleaning"
+  }
+},
+{
+  "type": "node",
+  "id": 10892625303,
+  "lat": 26.5172421,
+  "lon": 80.2421090,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "restaurant",
+    "name": "NH91 Fine Dine Restaurant",
+    "toilets": "yes",
+    "toilets:description": "it stinks really bad",
+    "toilets:fee": "no",
+    "toilets:gender_segregated": "yes"
+  }
+},
+{
+  "type": "node",
+  "id": 10983460693,
+  "lat": 26.5069755,
+  "lon": 80.2280697,
+  "tags": {
+    "amenity": "fast_food",
+    "fast_food": "cafeteria",
+    "name": "Hall 7 canteen"
+  }
+},
+{
+  "type": "node",
+  "id": 11070791233,
+  "lat": 26.5129962,
+  "lon": 80.2331580,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:floor": "6",
+    "addr:housenumber": "Faculty Building - 613",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "name": "Department of Humanities and Social Sciences",
+    "office": "university",
+    "website": "https://www.iitk.ac.in/hss/"
+  }
+},
+{
+  "type": "node",
+  "id": 11070791234,
+  "lat": 26.5131642,
+  "lon": 80.2334048,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:floor": "4",
+    "addr:housenumber": "Faculty Building - 431",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "name": "Department of Chemistry",
+    "office": "university",
+    "website": "https://www.iitk.ac.in/chm/"
+  }
+},
+{
+  "type": "node",
+  "id": 11070791235,
+  "lat": 26.5153195,
+  "lon": 80.2332492,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:floor": "4",
+    "addr:housenumber": "Room 430, Engineering Science Building 2",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "name": "Department of Economic Sciences",
+    "office": "university",
+    "website": "https://www.iitk.ac.in/eco/"
+  }
+},
+{
+  "type": "node",
+  "id": 12507479519,
+  "lat": 26.5037653,
+  "lon": 80.2329786,
+  "tags": {
+    "leisure": "playground",
+    "name": "residentail playground"
+  }
+},
+{
+  "type": "node",
+  "id": 12903466605,
+  "lat": 26.5157108,
+  "lon": 80.2319557,
+  "tags": {
+    "name": "Aerospace Engineering Office",
+    "office": "yes",
+    "opening_hours": "Mo-Fr 10:00-17:30",
+    "website": "https://www.iitk.ac.in/aero/"
+  }
+},
+{
+  "type": "node",
+  "id": 12903484121,
+  "lat": 26.5154967,
+  "lon": 80.2329390,
+  "tags": {
+    "level": "0,1,2",
+    "name": "Aerospace Engineering Labs",
+    "office": "research",
+    "opening_hours": "24/7",
+    "website": "https://www.iitk.ac.in/aero/"
+  }
+},
+{
+  "type": "node",
+  "id": 12976394607,
+  "lat": 26.5114323,
+  "lon": 80.2252302,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "guest_house": "guest_house",
+    "name": "Visitor's Hostel 2 (International Hostel)",
+    "short_name": "VH 2",
+    "source": "microsoft/BuildingFootprints",
+    "tourism": "hostel",
+    "website": "https://www.iitk.ac.in/vh/"
+  }
+},
+{
+  "type": "node",
+  "id": 13331574826,
+  "lat": 26.5108802,
+  "lon": 80.2348596,
+  "tags": {
+    "amenity": "fast_food",
+    "brand": "Subway",
+    "brand:wikidata": "Q244457",
+    "cuisine": "sandwich",
+    "level": "0",
+    "name": "Subway",
+    "takeaway": "yes"
+  }
+},
+{
+  "type": "node",
+  "id": 13331577262,
+  "lat": 26.5108763,
+  "lon": 80.2457336,
+  "tags": {
+    "addr:city": "Kanpur",
+    "amenity": "bank",
+    "branch": "IIT Kanpur",
+    "brand": "ICICI Bank",
+    "brand:wikidata": "Q1653258",
+    "level": "0",
+    "name": "ICICI Bank",
+    "short_name": "ICICI"
+  }
+},
+{
+  "type": "node",
+  "id": 13647379287,
+  "lat": 26.5067829,
+  "lon": 80.2287809,
+  "tags": {
+    "amenity": "bank",
+    "brand": "ICICI Bank",
+    "name": "ICICI Bank",
+    "short_name": "ICICI"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274058,
+  "lat": 26.5109942,
+  "lon": 80.2353840,
+  "tags": {
+    "direction": "270",
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274059,
+  "lat": 26.5105106,
+  "lon": 80.2349577,
+  "tags": {
+    "direction": "181",
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274060,
+  "lat": 26.5105131,
+  "lon": 80.2347404,
+  "tags": {
+    "direction": "182",
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274061,
+  "lat": 26.5105116,
+  "lon": 80.2344490,
+  "tags": {
+    "direction": "179",
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274062,
+  "lat": 26.5105051,
+  "lon": 80.2341310,
+  "tags": {
+    "direction": "180",
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274063,
+  "lat": 26.5105089,
+  "lon": 80.2338631,
+  "tags": {
+    "direction": "179",
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274064,
+  "lat": 26.5105248,
+  "lon": 80.2335814,
+  "tags": {
+    "direction": "179",
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274065,
+  "lat": 26.5105250,
+  "lon": 80.2333327,
+  "tags": {
+    "direction": "180",
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274066,
+  "lat": 26.5105402,
+  "lon": 80.2330643,
+  "tags": {
+    "direction": "179",
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274067,
+  "lat": 26.5105404,
+  "lon": 80.2327464,
+  "tags": {
+    "direction": "180",
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274068,
+  "lat": 26.5105403,
+  "lon": 80.2324823,
+  "tags": {
+    "direction": "178",
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274069,
+  "lat": 26.5105456,
+  "lon": 80.2322122,
+  "tags": {
+    "direction": "181",
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274070,
+  "lat": 26.5105374,
+  "lon": 80.2318523,
+  "tags": {
+    "direction": "179",
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274071,
+  "lat": 26.5105398,
+  "lon": 80.2315925,
+  "tags": {
+    "direction": "180",
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274072,
+  "lat": 26.5105410,
+  "lon": 80.2313205,
+  "tags": {
+    "direction": "178",
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274073,
+  "lat": 26.5105448,
+  "lon": 80.2310706,
+  "tags": {
+    "direction": "179",
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274074,
+  "lat": 26.5091147,
+  "lon": 80.2307028,
+  "tags": {
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274075,
+  "lat": 26.5089741,
+  "lon": 80.2307074,
+  "tags": {
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274076,
+  "lat": 26.5087491,
+  "lon": 80.2307135,
+  "tags": {
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274077,
+  "lat": 26.5083493,
+  "lon": 80.2307158,
+  "tags": {
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274078,
+  "lat": 26.5081724,
+  "lon": 80.2307204,
+  "tags": {
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274079,
+  "lat": 26.5078425,
+  "lon": 80.2307281,
+  "tags": {
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13648274080,
+  "lat": 26.5075525,
+  "lon": 80.2307143,
+  "tags": {
+    "highway": "street_lamp",
+    "lamp_mount": "angled_mast",
+    "lamp_type": "led",
+    "support": "pole"
+  }
+},
+{
+  "type": "node",
+  "id": 13654151803,
+  "lat": 26.5095891,
+  "lon": 80.2476289,
+  "tags": {
+    "addr:floor": "G",
+    "check_date": "2026-03-16",
+    "level": "0",
+    "name": "Maharajah",
+    "shop": "convenience"
+  }
+},
+{
+  "type": "node",
+  "id": 13654151804,
+  "lat": 26.5093742,
+  "lon": 80.2478404,
+  "tags": {
+    "addr:floor": "G",
+    "amenity": "restaurant",
+    "check_date": "2026-03-16",
+    "level": "0",
+    "name": "Hi-Street"
+  }
+},
+{
+  "type": "node",
+  "id": 13654151805,
+  "lat": 26.5093033,
+  "lon": 80.2478867,
+  "tags": {
+    "addr:floor": "G",
+    "amenity": "atm",
+    "brand": "State Bank of India",
+    "brand:wikidata": "Q1340361",
+    "check_date": "2026-03-16",
+    "level": "0",
+    "operator": "State Bank of India",
+    "operator:wikidata": "Q1340361"
+  }
+},
+{
+  "type": "node",
+  "id": 13658924447,
+  "lat": 26.5039900,
+  "lon": 80.2297600,
+  "tags": {
+    "amenity": "research_institute",
+    "name": "Pronite Ground"
+  }
+},
+{
+  "type": "node",
+  "id": 13715572437,
+  "lat": 26.5171664,
+  "lon": 80.2322935,
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:district": "Kanpur Nagar",
+    "addr:housenumber": "4th Floor",
+    "addr:postcode": "208016",
+    "addr:street": "Research Complex Park",
+    "name": "Centre for Ganga River Basin Management & Studies (cGanga)",
+    "office": "research",
+    "opening_hours": "Mo-Sa 09:00-18:00",
+    "phone": "05126797792",
+    "website": "https://cganga.org"
+  }
+},
+{
+  "type": "node",
+  "id": 13910161080,
+  "lat": 26.5122510,
+  "lon": 80.2350162,
+  "tags": {
+    "addr:housenumber": "Faculty Building Annexe",
+    "alt_name": "DOSA;DOSA Office",
+    "name": "Dean of Student Affairs",
+    "office": "university",
+    "opening_hours": "Mo-Fr 09:00-17:00",
+    "website": "https://iitk.ac.in/dosa"
+  }
+},
+{
+  "type": "node",
+  "id": 13910161081,
+  "lat": 26.5122112,
+  "lon": 80.2350294,
+  "tags": {
+    "addr:housenumber": "Faculty Building Annexe",
+    "alt_name": "Dean of Academic Affairs;Academic Section;Academic Affairs",
+    "name": "DOAA",
+    "office": "university",
+    "opening_hours": "Mo-Fr 09:00-17:00",
+    "website": "https://iitk.ac.in/doaa"
+  }
+},
+{
+  "type": "way",
+  "id": 30904329,
+  "center": {
+    "lat": 26.5187921,
+    "lon": 80.2324107
+  },
+  "tags": {
+    "building": "yes",
+    "name": "Flight Lab",
+    "source": "yahoo"
+  }
+},
+{
+  "type": "way",
+  "id": 52434888,
+  "center": {
+    "lat": 26.5131533,
+    "lon": 80.2329108
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "addr:street": "IIT Kanpur",
+    "amenity": "university",
+    "check_date": "2026-03-13",
+    "internet_access": "yes",
+    "name": "Indian Institute of Technology Kanpur",
+    "name:hi": "भारतीय प्रौध्योगिकी संस्थान कानपुर",
+    "short_name": "IITK;IIT Kanpur",
+    "website": "http://www.iitk.ac.in",
+    "wikidata": "Q782682",
+    "wikipedia": "en:Indian Institute of Technology Kanpur"
+  }
+},
+{
+  "type": "way",
+  "id": 152917997,
+  "center": {
+    "lat": 26.5128443,
+    "lon": 80.2337488
+  },
+  "tags": {
+    "access": "private",
+    "amenity": "parking",
+    "covered": "no",
+    "fee": "no",
+    "name": "Faculty Building Parking",
+    "parking": "surface",
+    "supervised": "no",
+    "surface": "asphalt"
+  }
+},
+{
+  "type": "way",
+  "id": 152918034,
+  "center": {
+    "lat": 26.5050699,
+    "lon": 80.2311520
+  },
+  "tags": {
+    "access": "official",
+    "leisure": "swimming_pool",
+    "name": "Institute Swimming Pool"
+  }
+},
+{
+  "type": "way",
+  "id": 152918037,
+  "center": {
+    "lat": 26.5079456,
+    "lon": 80.2277555
+  },
+  "tags": {
+    "leisure": "park"
+  }
+},
+{
+  "type": "way",
+  "id": 152930182,
+  "center": {
+    "lat": 26.5092656,
+    "lon": 80.2335912
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "alt_name": "Main Ground;Cricket ground",
+    "check_date": "2026-06-01",
+    "fee": "no",
+    "leisure": "sports_centre",
+    "name": "PE Ground",
+    "operator": "IIT Kanpur",
+    "sport": "multi",
+    "website": "https://iitk.ac.in/sports-facilities"
+  }
+},
+{
+  "type": "way",
+  "id": 157018918,
+  "center": {
+    "lat": 26.5029406,
+    "lon": 80.2287232
+  },
+  "tags": {
+    "man_made": "wastewater_plant",
+    "name": "Water treatment area"
+  }
+},
+{
+  "type": "way",
+  "id": 157018921,
+  "center": {
+    "lat": 26.5136246,
+    "lon": 80.2344351
+  },
+  "tags": {
+    "building": "university",
+    "name": "Computer Centre",
+    "nohousenumber": "yes"
+  }
+},
+{
+  "type": "way",
+  "id": 157018922,
+  "center": {
+    "lat": 26.5130939,
+    "lon": 80.2360274
+  },
+  "tags": {
+    "amenity": "cinema",
+    "building": "yes",
+    "name": "Main Auditorium"
+  }
+},
+{
+  "type": "way",
+  "id": 203657902,
+  "center": {
+    "lat": 26.5115374,
+    "lon": 80.2291015
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "basketball"
+  }
+},
+{
+  "type": "way",
+  "id": 249409343,
+  "center": {
+    "lat": 26.5073801,
+    "lon": 80.2345889
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "guest_house": "guest_house",
+    "internet_access": "yes",
+    "internet_access:fee": "no",
+    "name": "Visitor Hostel",
+    "operator": "IIT Kanpur",
+    "tourism": "hostel",
+    "website": "https://iitk.ac.in/vh"
+  }
+},
+{
+  "type": "way",
+  "id": 259781081,
+  "center": {
+    "lat": 26.5053109,
+    "lon": 80.2336663
+  },
+  "tags": {
+    "amenity": "hospital",
+    "emergency": "yes",
+    "healthcare": "hospital",
+    "name": "Health Centre"
+  }
+},
+{
+  "type": "way",
+  "id": 259781082,
+  "center": {
+    "lat": 26.5049468,
+    "lon": 80.2298378
+  },
+  "tags": {
+    "leisure": "sports_centre",
+    "name": "Students' Activity Centre"
+  }
+},
+{
+  "type": "way",
+  "id": 268045151,
+  "center": {
+    "lat": 26.5121146,
+    "lon": 80.2252476
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:street": "62nd Street",
+    "building": "residential",
+    "building:levels": "2",
+    "name": "Block A"
+  }
+},
+{
+  "type": "way",
+  "id": 268045152,
+  "center": {
+    "lat": 26.5124161,
+    "lon": 80.2251190
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:street": "62nd Street",
+    "building": "residential",
+    "building:levels": "2",
+    "name": "Block B"
+  }
+},
+{
+  "type": "way",
+  "id": 268050269,
+  "center": {
+    "lat": 26.5122335,
+    "lon": 80.2248039
+  },
+  "tags": {
+    "building": "residential",
+    "name": "Block C"
+  }
+},
+{
+  "type": "way",
+  "id": 268050272,
+  "center": {
+    "lat": 26.5121361,
+    "lon": 80.2266265
+  },
+  "tags": {
+    "leisure": "playground"
+  }
+},
+{
+  "type": "way",
+  "id": 268050273,
+  "center": {
+    "lat": 26.5125858,
+    "lon": 80.2267371
+  },
+  "tags": {
+    "amenity": "place_of_worship",
+    "building": "yes",
+    "religion": "hindu"
+  }
+},
+{
+  "type": "way",
+  "id": 268050278,
+  "center": {
+    "lat": 26.5112790,
+    "lon": 80.2330513
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "building:levels": "2",
+    "layer": "1",
+    "name": "Old Lecture Hall Complex"
+  }
+},
+{
+  "type": "way",
+  "id": 268050280,
+  "center": {
+    "lat": 26.5130145,
+    "lon": 80.2330874
+  },
+  "tags": {
+    "building": "university",
+    "building:levels": "7",
+    "layer": "1",
+    "name": "Faculty Building"
+  }
+},
+{
+  "type": "way",
+  "id": 268050281,
+  "center": {
+    "lat": 26.5119728,
+    "lon": 80.2343029
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:housenumber": "68",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "addr:suburb": "Kalyanpur",
+    "amenity": "cafe",
+    "brand": "Cafe Coffee Day",
+    "brand:wikidata": "Q5017235",
+    "building": "yes",
+    "check_date": "2026-03-14",
+    "contact:mobile": "+91 63639 24226",
+    "cuisine": "coffee_shop",
+    "image:menu": "22abfac1-62e6-4063-a803-e600a719a131",
+    "image:menu:0": "ab2aecf4-4b31-4f15-aa61-60996c926612",
+    "image:menu:1": "be75251e-7424-484d-9e28-560bf0727ce2",
+    "image:menu:10": "aacb1ad4-08d3-4b4c-9d26-11113b88caf0",
+    "image:menu:2": "4914fc84-c04f-4df2-a67a-693d96ebf17b",
+    "image:menu:3": "3e1486b7-d0f5-49c7-8ada-4668f443e5a9",
+    "image:menu:4": "462d75f5-1385-4261-8041-85d360ed2bfd",
+    "image:menu:5": "cde1913c-4477-44ac-a312-ad57b3fefb6a",
+    "image:menu:6": "3d7f2163-d795-4603-84a2-3fdd3a147d24",
+    "image:menu:7": "ef763ac9-5bd4-4476-bcc8-a31dd4af9f20",
+    "image:menu:8": "df86a5f2-b427-426d-b2ec-746ac07fbc91",
+    "image:menu:9": "6d43c5c2-95c7-406d-8324-f48721afeddd",
+    "level": "0",
+    "name": "Cafe Coffee Day",
+    "outdoor_seating": "yes",
+    "panoramax": "cf30c7b3-532b-4333-9f2c-1db66a9bc6b1",
+    "panoramax:0": "f6a8b0b0-bf2e-48e4-8735-b279d622bf93",
+    "takeaway": "yes"
+  }
+},
+{
+  "type": "way",
+  "id": 268050282,
+  "center": {
+    "lat": 26.5115583,
+    "lon": 80.2347049
+  },
+  "tags": {
+    "building": "university",
+    "name": "Southern Labs"
+  }
+},
+{
+  "type": "way",
+  "id": 268050283,
+  "center": {
+    "lat": 26.5136554,
+    "lon": 80.2327792
+  },
+  "tags": {
+    "building": "university",
+    "layer": "1",
+    "name": "Core Lab"
+  }
+},
+{
+  "type": "way",
+  "id": 268050284,
+  "center": {
+    "lat": 26.5140340,
+    "lon": 80.2336132
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "name": "Northern Block Laboratories",
+    "nohousenumber": "yes"
+  }
+},
+{
+  "type": "way",
+  "id": 268050285,
+  "center": {
+    "lat": 26.5145836,
+    "lon": 80.2324675
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "building": "university",
+    "name": "Department of Chemical Engineering"
+  }
+},
+{
+  "type": "way",
+  "id": 268050286,
+  "center": {
+    "lat": 26.5144156,
+    "lon": 80.2317887
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "fast_food",
+    "building": "yes",
+    "fast_food": "cafeteria",
+    "name": "DOAA Canteen",
+    "opening_hours": "24/7",
+    "outdoor_seating": "yes"
+  }
+},
+{
+  "type": "way",
+  "id": 268050287,
+  "center": {
+    "lat": 26.5146761,
+    "lon": 80.2313042
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "name": "Academic Affairs Building (JEE/GATE)"
+  }
+},
+{
+  "type": "way",
+  "id": 268050288,
+  "center": {
+    "lat": 26.5140132,
+    "lon": 80.2312601
+  },
+  "tags": {
+    "building": "university",
+    "name": "Central Workshop"
+  }
+},
+{
+  "type": "way",
+  "id": 268061984,
+  "center": {
+    "lat": 26.5115425,
+    "lon": 80.2313802
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "name": "Advanced Centre For Materials Science",
+    "short_name": "ACMS",
+    "website": "https://www.iitk.ac.in/acms/"
+  }
+},
+{
+  "type": "way",
+  "id": 268061985,
+  "center": {
+    "lat": 26.5122657,
+    "lon": 80.2317088
+  },
+  "tags": {
+    "building": "university",
+    "name": "Western Labs"
+  }
+},
+{
+  "type": "way",
+  "id": 295571076,
+  "center": {
+    "lat": 26.5041178,
+    "lon": 80.2360754
+  },
+  "tags": {
+    "leisure": "playground",
+    "name": "SBRA Jhoola Park"
+  }
+},
+{
+  "type": "way",
+  "id": 295571716,
+  "center": {
+    "lat": 26.5038209,
+    "lon": 80.2354117
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "building": "yes",
+    "name": "33 K.V.A. Substation",
+    "power": "substation",
+    "substation": "yes"
+  }
+},
+{
+  "type": "way",
+  "id": 295697794,
+  "center": {
+    "lat": 26.5084407,
+    "lon": 80.2364749
+  },
+  "tags": {
+    "alt_name": "Central School",
+    "amenity": "school",
+    "brand": "Kendriya Vidyalaya",
+    "brand:wikidata": "Q1156653",
+    "grades": "1-12",
+    "name": "Kendriya Vidyalaya",
+    "operator:type": "government_non_profit",
+    "website": "https://iitkanpur.kvs.ac.in/"
+  }
+},
+{
+  "type": "way",
+  "id": 315780946,
+  "center": {
+    "lat": 26.5130966,
+    "lon": 80.2321082
+  },
+  "tags": {
+    "building": "university",
+    "name": "ACES"
+  }
+},
+{
+  "type": "way",
+  "id": 315780949,
+  "center": {
+    "lat": 26.5130702,
+    "lon": 80.2313151
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "name": "Civil Engineering Lab"
+  }
+},
+{
+  "type": "way",
+  "id": 315780951,
+  "center": {
+    "lat": 26.5117526,
+    "lon": 80.2320647
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "building": "university",
+    "name": "Samtel Centre for Display Technologies",
+    "website": "https://www.iitk.ac.in/scdt/"
+  }
+},
+{
+  "type": "way",
+  "id": 315780952,
+  "center": {
+    "lat": 26.5153027,
+    "lon": 80.2311076
+  },
+  "tags": {
+    "building": "university",
+    "name": "SIDBI"
+  }
+},
+{
+  "type": "way",
+  "id": 315780953,
+  "center": {
+    "lat": 26.5130265,
+    "lon": 80.2317239
+  },
+  "tags": {
+    "building": "university",
+    "name": "Western Lab Extension"
+  }
+},
+{
+  "type": "way",
+  "id": 315780954,
+  "center": {
+    "lat": 26.5155281,
+    "lon": 80.2319000
+  },
+  "tags": {
+    "building": "university",
+    "name": "Wind Tunnel Facility"
+  }
+},
+{
+  "type": "way",
+  "id": 315782322,
+  "center": {
+    "lat": 26.5120916,
+    "lon": 80.2257816
+  },
+  "tags": {
+    "man_made": "water_tower"
+  }
+},
+{
+  "type": "way",
+  "id": 315782323,
+  "center": {
+    "lat": 26.5145596,
+    "lon": 80.2334072
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "name": "Industrial & Management Engineering",
+    "website": "https://www.iitk.ac.in/ime/"
+  }
+},
+{
+  "type": "way",
+  "id": 315782325,
+  "center": {
+    "lat": 26.5144124,
+    "lon": 80.2339669
+  },
+  "tags": {
+    "building": "university",
+    "name": "Nuclear Physics Lab",
+    "nohousenumber": "yes"
+  }
+},
+{
+  "type": "way",
+  "id": 343506918,
+  "center": {
+    "lat": 26.5050081,
+    "lon": 80.2293577
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "theatre",
+    "name": "Open Air Theatre",
+    "operator": "Students' Gymkhana",
+    "theatre:type": "amphi"
+  }
+},
+{
+  "type": "way",
+  "id": 343518264,
+  "center": {
+    "lat": 26.5124624,
+    "lon": 80.2359073
+  },
+  "tags": {
+    "leisure": "park",
+    "name": "Auditorium Grounds"
+  }
+},
+{
+  "type": "way",
+  "id": 343976510,
+  "center": {
+    "lat": 26.5048867,
+    "lon": 80.2282673
+  },
+  "tags": {
+    "leisure": "park"
+  }
+},
+{
+  "type": "way",
+  "id": 343976511,
+  "center": {
+    "lat": 26.5055129,
+    "lon": 80.2284914
+  },
+  "tags": {
+    "leisure": "pitch"
+  }
+},
+{
+  "type": "way",
+  "id": 343976514,
+  "center": {
+    "lat": 26.5045841,
+    "lon": 80.2284711
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "4",
+    "name": "Hall 8 Block H"
+  }
+},
+{
+  "type": "way",
+  "id": 343976515,
+  "center": {
+    "lat": 26.5045766,
+    "lon": 80.2278313
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "4",
+    "name": "Hall 8 Block E"
+  }
+},
+{
+  "type": "way",
+  "id": 343976520,
+  "center": {
+    "lat": 26.5058906,
+    "lon": 80.2277727
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "4",
+    "name": "Hall 8 Block A"
+  }
+},
+{
+  "type": "way",
+  "id": 343976521,
+  "center": {
+    "lat": 26.5056355,
+    "lon": 80.2277974
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "4",
+    "name": "Hall 8 Block B"
+  }
+},
+{
+  "type": "way",
+  "id": 343976522,
+  "center": {
+    "lat": 26.5054013,
+    "lon": 80.2278039
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "4",
+    "name": "Hall 8 Block C"
+  }
+},
+{
+  "type": "way",
+  "id": 343976523,
+  "center": {
+    "lat": 26.5051420,
+    "lon": 80.2277854
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "4",
+    "name": "Hall 8 Block D"
+  }
+},
+{
+  "type": "way",
+  "id": 343976524,
+  "center": {
+    "lat": 26.5048660,
+    "lon": 80.2277834
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "restaurant",
+    "building": "yes",
+    "name": "Hall 8 Mess"
+  }
+},
+{
+  "type": "way",
+  "id": 343976525,
+  "center": {
+    "lat": 26.5043274,
+    "lon": 80.2284915
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "4",
+    "name": "Hall 8 Block G"
+  }
+},
+{
+  "type": "way",
+  "id": 343976526,
+  "center": {
+    "lat": 26.5043199,
+    "lon": 80.2278288
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "4",
+    "name": "Hall 8 Block F"
+  }
+},
+{
+  "type": "way",
+  "id": 376400408,
+  "center": {
+    "lat": 26.5075587,
+    "lon": 80.2267624
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 9 Block A"
+  }
+},
+{
+  "type": "way",
+  "id": 376400409,
+  "center": {
+    "lat": 26.5075546,
+    "lon": 80.2261109
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 9 Block B"
+  }
+},
+{
+  "type": "way",
+  "id": 376400410,
+  "center": {
+    "lat": 26.5077701,
+    "lon": 80.2267587
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 9 Block C"
+  }
+},
+{
+  "type": "way",
+  "id": 376400411,
+  "center": {
+    "lat": 26.5077717,
+    "lon": 80.2261139
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 9 Block D"
+  }
+},
+{
+  "type": "way",
+  "id": 376400412,
+  "center": {
+    "lat": 26.5082945,
+    "lon": 80.2267557
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 9 Block E"
+  }
+},
+{
+  "type": "way",
+  "id": 376400413,
+  "center": {
+    "lat": 26.5082916,
+    "lon": 80.2261101
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 9 Block F"
+  }
+},
+{
+  "type": "way",
+  "id": 376400414,
+  "center": {
+    "lat": 26.5085121,
+    "lon": 80.2267580
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 9 Block G"
+  }
+},
+{
+  "type": "way",
+  "id": 376400416,
+  "center": {
+    "lat": 26.5080276,
+    "lon": 80.2261168
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "restaurant",
+    "building": "yes",
+    "name": "Hall 9 Mess"
+  }
+},
+{
+  "type": "way",
+  "id": 376400429,
+  "center": {
+    "lat": 26.5085046,
+    "lon": 80.2261190
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 9 Block H"
+  }
+},
+{
+  "type": "way",
+  "id": 376447034,
+  "center": {
+    "lat": 26.5096040,
+    "lon": 80.2294489
+  },
+  "tags": {
+    "leisure": "pitch",
+    "lit": "yes",
+    "name": "C6",
+    "sport": "tennis"
+  }
+},
+{
+  "type": "way",
+  "id": 376447035,
+  "center": {
+    "lat": 26.5096251,
+    "lon": 80.2300761
+  },
+  "tags": {
+    "leisure": "pitch",
+    "lit": "yes",
+    "name": "C3",
+    "sport": "tennis"
+  }
+},
+{
+  "type": "way",
+  "id": 376447036,
+  "center": {
+    "lat": 26.5096242,
+    "lon": 80.2305606
+  },
+  "tags": {
+    "leisure": "pitch",
+    "lit": "yes",
+    "name": "C1",
+    "sport": "tennis"
+  }
+},
+{
+  "type": "way",
+  "id": 376447038,
+  "center": {
+    "lat": 26.5096236,
+    "lon": 80.2298920
+  },
+  "tags": {
+    "leisure": "pitch",
+    "lit": "yes",
+    "name": "C4",
+    "sport": "tennis"
+  }
+},
+{
+  "type": "way",
+  "id": 376447040,
+  "center": {
+    "lat": 26.5096226,
+    "lon": 80.2303766
+  },
+  "tags": {
+    "leisure": "pitch",
+    "lit": "yes",
+    "name": "C2",
+    "sport": "tennis"
+  }
+},
+{
+  "type": "way",
+  "id": 376447042,
+  "center": {
+    "lat": 26.5096056,
+    "lon": 80.2296329
+  },
+  "tags": {
+    "leisure": "pitch",
+    "lit": "yes",
+    "name": "C5",
+    "sport": "tennis"
+  }
+},
+{
+  "type": "way",
+  "id": 376451965,
+  "center": {
+    "lat": 26.5074633,
+    "lon": 80.2297471
+  },
+  "tags": {
+    "building": "yes",
+    "name": "Electric Substation No 5",
+    "power": "substation",
+    "voltage": "11000;430"
+  }
+},
+{
+  "type": "way",
+  "id": 376451966,
+  "center": {
+    "lat": 26.5073998,
+    "lon": 80.2300017
+  },
+  "tags": {
+    "man_made": "water_tower"
+  }
+},
+{
+  "type": "way",
+  "id": 376451967,
+  "center": {
+    "lat": 26.5033519,
+    "lon": 80.2330095
+  },
+  "tags": {
+    "building": "residential",
+    "building:levels": "7",
+    "name": "Faculty Apartment (C-Block)"
+  }
+},
+{
+  "type": "way",
+  "id": 376451968,
+  "center": {
+    "lat": 26.5029173,
+    "lon": 80.2330147
+  },
+  "tags": {
+    "building": "residential",
+    "building:levels": "7",
+    "name": "Faculty Apartment (D-Block)"
+  }
+},
+{
+  "type": "way",
+  "id": 376451969,
+  "center": {
+    "lat": 26.5041624,
+    "lon": 80.2321709
+  },
+  "tags": {
+    "building": "residential",
+    "building:levels": "7",
+    "name": "Faculty Apartment (A-Block)"
+  }
+},
+{
+  "type": "way",
+  "id": 376451970,
+  "center": {
+    "lat": 26.5037328,
+    "lon": 80.2321755
+  },
+  "tags": {
+    "building": "residential",
+    "building:levels": "7",
+    "name": "Faculty Apartment (B-block)"
+  }
+},
+{
+  "type": "way",
+  "id": 376451986,
+  "center": {
+    "lat": 26.5049326,
+    "lon": 80.2302723
+  },
+  "tags": {
+    "building": "yes",
+    "leisure": "sports_centre",
+    "name": "Indoor Sports Complex"
+  }
+},
+{
+  "type": "way",
+  "id": 383013949,
+  "center": {
+    "lat": 26.5111570,
+    "lon": 80.2300162
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 2 Block B"
+  }
+},
+{
+  "type": "way",
+  "id": 383014146,
+  "center": {
+    "lat": 26.5113219,
+    "lon": 80.2298266
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "volleyball"
+  }
+},
+{
+  "type": "way",
+  "id": 383014549,
+  "center": {
+    "lat": 26.5112593,
+    "lon": 80.2293782
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 2 Block G"
+  }
+},
+{
+  "type": "way",
+  "id": 383015318,
+  "center": {
+    "lat": 26.5110302,
+    "lon": 80.2293882
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 2 Block A"
+  }
+},
+{
+  "type": "way",
+  "id": 383016139,
+  "center": {
+    "lat": 26.5108082,
+    "lon": 80.2302112
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 2 Block C"
+  }
+},
+{
+  "type": "way",
+  "id": 383018190,
+  "center": {
+    "lat": 26.5103467,
+    "lon": 80.2293906
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 2 Block F"
+  }
+},
+{
+  "type": "way",
+  "id": 383018469,
+  "center": {
+    "lat": 26.5102037,
+    "lon": 80.2299778
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 2 Block E"
+  }
+},
+{
+  "type": "way",
+  "id": 383019229,
+  "center": {
+    "lat": 26.5103645,
+    "lon": 80.2303371
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 2 Block D"
+  }
+},
+{
+  "type": "way",
+  "id": 383021322,
+  "center": {
+    "lat": 26.5115271,
+    "lon": 80.2293629
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "soccer"
+  }
+},
+{
+  "type": "way",
+  "id": 432735394,
+  "center": {
+    "lat": 26.5119459,
+    "lon": 80.2359791
+  },
+  "tags": {
+    "amenity": "parking",
+    "fee": "no",
+    "name": "Shopping Center Parking Lot",
+    "operator": "IIT Kanpur",
+    "parking": "surface",
+    "supervised": "no",
+    "surface": "concrete"
+  }
+},
+{
+  "type": "way",
+  "id": 432739245,
+  "center": {
+    "lat": 26.5102871,
+    "lon": 80.2384179
+  },
+  "tags": {
+    "description": "Contributed by the class of 1967 to their alma mater",
+    "leisure": "park",
+    "name": "Park 67"
+  }
+},
+{
+  "type": "way",
+  "id": 432740283,
+  "center": {
+    "lat": 26.5101751,
+    "lon": 80.2367301
+  },
+  "tags": {
+    "building": "kindergarten",
+    "building:levels": "1",
+    "name": "Kislaya Nursery School"
+  }
+},
+{
+  "type": "way",
+  "id": 432741114,
+  "center": {
+    "lat": 26.5099310,
+    "lon": 80.2367335
+  },
+  "tags": {
+    "area": "yes",
+    "leisure": "playground"
+  }
+},
+{
+  "type": "way",
+  "id": 432741609,
+  "center": {
+    "lat": 26.5102981,
+    "lon": 80.2412381
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "amenity": "community_centre",
+    "building": "yes",
+    "name": "Type 2 Community Centre"
+  }
+},
+{
+  "type": "way",
+  "id": 432741792,
+  "center": {
+    "lat": 26.5102748,
+    "lon": 80.2407276
+  },
+  "tags": {
+    "amenity": "parking",
+    "name": "Type 2 community center parking lot",
+    "surface": "concrete"
+  }
+},
+{
+  "type": "way",
+  "id": 432742031,
+  "center": {
+    "lat": 26.5089209,
+    "lon": 80.2443891
+  },
+  "tags": {
+    "area": "yes",
+    "leisure": "sports_centre",
+    "name": "ACES ground",
+    "sport": "cricket"
+  }
+},
+{
+  "type": "way",
+  "id": 440941546,
+  "center": {
+    "lat": 26.5084009,
+    "lon": 80.2317700
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "fee": "no",
+    "leisure": "sports_centre",
+    "name": "Old Sports Complex"
+  }
+},
+{
+  "type": "way",
+  "id": 470033926,
+  "center": {
+    "lat": 26.5080478,
+    "lon": 80.2265644
+  },
+  "tags": {
+    "leisure": "park",
+    "name": "Hall 9 Quad"
+  }
+},
+{
+  "type": "way",
+  "id": 488149101,
+  "center": {
+    "lat": 26.5143279,
+    "lon": 80.2348663
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "building:levels": "7",
+    "name": "Rajeev Motwani Building",
+    "nohousenumber": "yes",
+    "website": "https://cse.iitk.ac.in/"
+  }
+},
+{
+  "type": "way",
+  "id": 488149102,
+  "center": {
+    "lat": 26.5140145,
+    "lon": 80.2348290
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "alt_name": "KD",
+    "building": "university",
+    "building:levels": "4",
+    "description": "Department of Computer Science and Engineering",
+    "internet_access": "yes",
+    "name": "H.R. Kadim Diwan Building",
+    "nohousenumber": "yes",
+    "operator": "Department of Computer Science and Engineering",
+    "roof:shape": "flat",
+    "website": "https://cse.iitk.ac.in/",
+    "wheelchair": "yes"
+  }
+},
+{
+  "type": "way",
+  "id": 501657126,
+  "center": {
+    "lat": 26.5135685,
+    "lon": 80.2348955
+  },
+  "tags": {
+    "access": "permissive",
+    "amenity": "parking",
+    "area": "yes",
+    "capacity": "8",
+    "parking": "street_side",
+    "supervised": "no",
+    "surface": "asphalt"
+  }
+},
+{
+  "type": "way",
+  "id": 501658530,
+  "center": {
+    "lat": 26.5141086,
+    "lon": 80.2342838
+  },
+  "tags": {
+    "amenity": "fast_food",
+    "building": "yes",
+    "cuisine": "regional",
+    "fast_food": "cafeteria",
+    "internet_access": "yes",
+    "internet_access:fee": "no",
+    "internet_access:ssid": "iitk",
+    "level": "1",
+    "name": "Computer Center Canteen",
+    "opening_hours": "Mo-Su 09:00-21:00+",
+    "outdoor_seating": "yes",
+    "smoking": "no"
+  }
+},
+{
+  "type": "way",
+  "id": 659863829,
+  "center": {
+    "lat": 26.5060959,
+    "lon": 80.2294728
+  },
+  "tags": {
+    "leisure": "pitch",
+    "lit": "yes",
+    "sport": "soccer"
+  }
+},
+{
+  "type": "way",
+  "id": 659863830,
+  "center": {
+    "lat": 26.5059313,
+    "lon": 80.2302509
+  },
+  "tags": {
+    "leisure": "pitch",
+    "lit": "yes",
+    "name": "Hockey Field",
+    "sport": "field_hockey"
+  }
+},
+{
+  "type": "way",
+  "id": 682695134,
+  "center": {
+    "lat": 26.5096873,
+    "lon": 80.2475424
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "restaurant",
+    "building": "yes",
+    "check_date": "2026-03-16",
+    "name": "IIT 78 Cafe and Restaurant"
+  }
+},
+{
+  "type": "way",
+  "id": 682695144,
+  "center": {
+    "lat": 26.5102691,
+    "lon": 80.2469698
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "restaurant",
+    "building": "yes",
+    "name": "Highway 2.0"
+  }
+},
+{
+  "type": "way",
+  "id": 682695186,
+  "center": {
+    "lat": 26.5052337,
+    "lon": 80.2357223
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:housenumber": "509 Type 5",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "childcare",
+    "building": "yes",
+    "name": "Snehan Child Care Centre",
+    "opening_hours": "Mo-Fr 09:00-18:00",
+    "operator": "IIT Kanpur",
+    "website": "https://www.iitk.ac.in/snehan/"
+  }
+},
+{
+  "type": "way",
+  "id": 682695218,
+  "center": {
+    "lat": 26.5060411,
+    "lon": 80.2357053
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:housenumber": "503 Type 5",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "yes",
+    "healthcare": "counselling",
+    "name": "Counselling Service",
+    "operator": "IIT Kanpur",
+    "website": "https://www.iitk.ac.in/counsel/"
+  }
+},
+{
+  "type": "way",
+  "id": 1060146288,
+  "center": {
+    "lat": 26.5122497,
+    "lon": 80.2350092
+  },
+  "tags": {
+    "addr:postcode": "208016",
+    "alt_name": "New FB;FBA",
+    "building": "university",
+    "name": "Faculty Building Annexe",
+    "operator": "Indian Institute Of Technology Kanpur",
+    "smoking": "no",
+    "wheelchair": "yes"
+  }
+},
+{
+  "type": "way",
+  "id": 1090937351,
+  "center": {
+    "lat": 26.5091080,
+    "lon": 80.2345787
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "conference_centre",
+    "building": "yes",
+    "name": "Outreach Auditorium"
+  }
+},
+{
+  "type": "way",
+  "id": 1090939149,
+  "center": {
+    "lat": 26.5110953,
+    "lon": 80.2374489
+  },
+  "tags": {
+    "leisure": "park"
+  }
+},
+{
+  "type": "way",
+  "id": 1102507059,
+  "center": {
+    "lat": 26.5100141,
+    "lon": 80.2286377
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 5 Block C"
+  }
+},
+{
+  "type": "way",
+  "id": 1102507060,
+  "center": {
+    "lat": 26.5102305,
+    "lon": 80.2286400
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 5 Block D"
+  }
+},
+{
+  "type": "way",
+  "id": 1102507061,
+  "center": {
+    "lat": 26.5095510,
+    "lon": 80.2278831
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "restaurant",
+    "building": "yes",
+    "name": "Hall 5 Mess"
+  }
+},
+{
+  "type": "way",
+  "id": 1102507062,
+  "center": {
+    "lat": 26.5094041,
+    "lon": 80.2283895
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "fast_food",
+    "building": "yes",
+    "drive_through": "no",
+    "fast_food": "cafeteria",
+    "name": "Hall 5 Canteen",
+    "opening_hours": "Mo-Su 14:00-02:00"
+  }
+},
+{
+  "type": "way",
+  "id": 1102507063,
+  "center": {
+    "lat": 26.5058930,
+    "lon": 80.2260158
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "restaurant",
+    "building": "yes",
+    "name": "Hall 10 Mess"
+  }
+},
+{
+  "type": "way",
+  "id": 1102507064,
+  "center": {
+    "lat": 26.5055260,
+    "lon": 80.2260151
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "restaurant",
+    "building": "yes",
+    "name": "Hall 11 Mess"
+  }
+},
+{
+  "type": "way",
+  "id": 1104867049,
+  "center": {
+    "lat": 26.5153719,
+    "lon": 80.2331601
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "name": "Engineering Science Building 2"
+  }
+},
+{
+  "type": "way",
+  "id": 1107954196,
+  "center": {
+    "lat": 26.5043259,
+    "lon": 80.2312795
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "building": "retail",
+    "name": "New Shopping Center"
+  }
+},
+{
+  "type": "way",
+  "id": 1107954994,
+  "center": {
+    "lat": 26.5094874,
+    "lon": 80.2342410
+  },
+  "tags": {
+    "leisure": "pitch",
+    "lit": "yes",
+    "sport": "volleyball"
+  }
+},
+{
+  "type": "way",
+  "id": 1107954995,
+  "center": {
+    "lat": 26.5083243,
+    "lon": 80.2342707
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "basketball"
+  }
+},
+{
+  "type": "way",
+  "id": 1107954996,
+  "center": {
+    "lat": 26.5086255,
+    "lon": 80.2329731
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "basketball"
+  }
+},
+{
+  "type": "way",
+  "id": 1107954997,
+  "center": {
+    "lat": 26.5083021,
+    "lon": 80.2329724
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "basketball"
+  }
+},
+{
+  "type": "way",
+  "id": 1107954998,
+  "center": {
+    "lat": 26.5098865,
+    "lon": 80.2329096
+  },
+  "tags": {
+    "amenity": "parking"
+  }
+},
+{
+  "type": "way",
+  "id": 1107955568,
+  "center": {
+    "lat": 26.5101738,
+    "lon": 80.2273077
+  },
+  "tags": {
+    "leisure": "pitch",
+    "name": "Hall 12 Basketball Court",
+    "sport": "basketball"
+  }
+},
+{
+  "type": "way",
+  "id": 1107955569,
+  "center": {
+    "lat": 26.5090497,
+    "lon": 80.2273843
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "basketball"
+  }
+},
+{
+  "type": "way",
+  "id": 1107955570,
+  "center": {
+    "lat": 26.5079561,
+    "lon": 80.2294751
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "basketball"
+  }
+},
+{
+  "type": "way",
+  "id": 1107955571,
+  "center": {
+    "lat": 26.5070425,
+    "lon": 80.2269723
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "basketball"
+  }
+},
+{
+  "type": "way",
+  "id": 1107955572,
+  "center": {
+    "lat": 26.5063905,
+    "lon": 80.2275772
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "basketball"
+  }
+},
+{
+  "type": "way",
+  "id": 1107955917,
+  "center": {
+    "lat": 26.5096844,
+    "lon": 80.2260251
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "basketball"
+  }
+},
+{
+  "type": "way",
+  "id": 1109194372,
+  "center": {
+    "lat": 26.5075040,
+    "lon": 80.2330472
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "basketball"
+  }
+},
+{
+  "type": "way",
+  "id": 1130615170,
+  "center": {
+    "lat": 26.5101189,
+    "lon": 80.2281457
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 5 Block F"
+  }
+},
+{
+  "type": "way",
+  "id": 1130615171,
+  "center": {
+    "lat": 26.5098976,
+    "lon": 80.2281492
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 5 Block E"
+  }
+},
+{
+  "type": "way",
+  "id": 1130673238,
+  "center": {
+    "lat": 26.5091167,
+    "lon": 80.2286500
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 5 Block B"
+  }
+},
+{
+  "type": "way",
+  "id": 1130673239,
+  "center": {
+    "lat": 26.5088944,
+    "lon": 80.2286380
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 5 Block A"
+  }
+},
+{
+  "type": "way",
+  "id": 1130673240,
+  "center": {
+    "lat": 26.5087838,
+    "lon": 80.2281484
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 5 Block I"
+  }
+},
+{
+  "type": "way",
+  "id": 1130673241,
+  "center": {
+    "lat": 26.5090072,
+    "lon": 80.2281477
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 5 Block H"
+  }
+},
+{
+  "type": "way",
+  "id": 1130673242,
+  "center": {
+    "lat": 26.5092285,
+    "lon": 80.2281501
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "3",
+    "name": "Hall 5 Block G"
+  }
+},
+{
+  "type": "way",
+  "id": 1131208300,
+  "center": {
+    "lat": 26.5151989,
+    "lon": 80.2304094
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "building": "yes",
+    "name": "Central AC Plant"
+  }
+},
+{
+  "type": "way",
+  "id": 1131208301,
+  "center": {
+    "lat": 26.5146117,
+    "lon": 80.2304489
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "building": "university",
+    "name": "Interdisciplinary Centre for Cyber Security and Cyber Defence of Critical Infrastructures",
+    "nohousenumber": "yes",
+    "short_name": "C3i Center",
+    "website": "https://security.cse.iitk.ac.in/"
+  }
+},
+{
+  "type": "way",
+  "id": 1131208302,
+  "center": {
+    "lat": 26.5135241,
+    "lon": 80.2302647
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "building": "university",
+    "name": "Central Store",
+    "name:hi": "केंद्रीय भंडार",
+    "nohousenumber": "yes"
+  }
+},
+{
+  "type": "way",
+  "id": 1131208303,
+  "center": {
+    "lat": 26.5116510,
+    "lon": 80.2304585
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "building": "yes",
+    "name": "Security Control Room",
+    "office": "security"
+  }
+},
+{
+  "type": "way",
+  "id": 1131618534,
+  "center": {
+    "lat": 26.5129194,
+    "lon": 80.2350129
+  },
+  "tags": {
+    "leisure": "garden"
+  }
+},
+{
+  "type": "way",
+  "id": 1131619521,
+  "center": {
+    "lat": 26.5117718,
+    "lon": 80.2359388
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "yes",
+    "name": "Campus D Shop",
+    "shop": "general"
+  }
+},
+{
+  "type": "way",
+  "id": 1131622792,
+  "center": {
+    "lat": 26.5119225,
+    "lon": 80.2310988
+  },
+  "tags": {
+    "building": "university",
+    "name": "National Centre for Flexible Electronics",
+    "website": "http://www.ncflexe.in/"
+  }
+},
+{
+  "type": "way",
+  "id": 1131994408,
+  "center": {
+    "lat": 26.5084527,
+    "lon": 80.2350465
+  },
+  "tags": {
+    "building": "yes",
+    "name": "Electrical Maintenance Office (Hostel Area)",
+    "office": "government"
+  }
+},
+{
+  "type": "way",
+  "id": 1131994409,
+  "center": {
+    "lat": 26.5101271,
+    "lon": 80.2358747
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "building": "university",
+    "name": "Department of Sustainable Energy Engineering",
+    "website": "https://www.iitk.ac.in/see/"
+  }
+},
+{
+  "type": "way",
+  "id": 1132835027,
+  "center": {
+    "lat": 26.5078126,
+    "lon": 80.2356238
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "basketball"
+  }
+},
+{
+  "type": "way",
+  "id": 1132835032,
+  "center": {
+    "lat": 26.5107445,
+    "lon": 80.2346265
+  },
+  "tags": {
+    "access": "customers",
+    "amenity": "parking",
+    "fee": "no",
+    "parking": "surface"
+  }
+},
+{
+  "type": "way",
+  "id": 1132835033,
+  "center": {
+    "lat": 26.5120576,
+    "lon": 80.2368300
+  },
+  "tags": {
+    "amenity": "parking"
+  }
+},
+{
+  "type": "way",
+  "id": 1135333023,
+  "center": {
+    "lat": 26.5101251,
+    "lon": 80.2285050
+  },
+  "tags": {
+    "leisure": "pitch",
+    "lit": "yes",
+    "sport": "badminton",
+    "surface": "ground"
+  }
+},
+{
+  "type": "way",
+  "id": 1135333024,
+  "center": {
+    "lat": 26.5097498,
+    "lon": 80.2279614
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "yes",
+    "name": "Hall 5 Multipurpose hall"
+  }
+},
+{
+  "type": "way",
+  "id": 1135334283,
+  "center": {
+    "lat": 26.5065700,
+    "lon": 80.2268720
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "4",
+    "name": "Hall 10 Block A"
+  }
+},
+{
+  "type": "way",
+  "id": 1135339093,
+  "center": {
+    "lat": 26.5140190,
+    "lon": 80.2316882
+  },
+  "tags": {
+    "building": "university",
+    "name": "Workshop"
+  }
+},
+{
+  "type": "way",
+  "id": 1135339096,
+  "center": {
+    "lat": 26.5108302,
+    "lon": 80.2338820
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "building:levels": "3",
+    "name": "New Lecture Hall Complex"
+  }
+},
+{
+  "type": "way",
+  "id": 1135339284,
+  "center": {
+    "lat": 26.5148956,
+    "lon": 80.2304015
+  },
+  "tags": {
+    "building": "yes",
+    "name": "Electric Substation No 12",
+    "power": "substation",
+    "voltage": "11000;430"
+  }
+},
+{
+  "type": "way",
+  "id": 1135346535,
+  "center": {
+    "lat": 26.5152204,
+    "lon": 80.2348384
+  },
+  "tags": {
+    "building": "university",
+    "name": "Atmospheric Monitoring Station"
+  }
+},
+{
+  "type": "way",
+  "id": 1135346536,
+  "center": {
+    "lat": 26.5156943,
+    "lon": 80.2342359
+  },
+  "tags": {
+    "building": "university",
+    "name": "Centre for Environmental Science & Engineering",
+    "short_name": "CESE",
+    "website": "https://www.iitk.ac.in/cese/"
+  }
+},
+{
+  "type": "way",
+  "id": 1135352252,
+  "center": {
+    "lat": 26.5063114,
+    "lon": 80.2264215
+  },
+  "tags": {
+    "building": "yes",
+    "name": "Hall 10 Laundry Room",
+    "self_service": "yes",
+    "shop": "laundry"
+  }
+},
+{
+  "type": "way",
+  "id": 1135352253,
+  "center": {
+    "lat": 26.5058995,
+    "lon": 80.2285402
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "4",
+    "name": "Hall 8 Block I"
+  }
+},
+{
+  "type": "way",
+  "id": 1135358779,
+  "center": {
+    "lat": 26.5129767,
+    "lon": 80.2336352
+  },
+  "tags": {
+    "leisure": "garden"
+  }
+},
+{
+  "type": "way",
+  "id": 1135360257,
+  "center": {
+    "lat": 26.5040101,
+    "lon": 80.2289386
+  },
+  "tags": {
+    "amenity": "toilets",
+    "building": "yes"
+  }
+},
+{
+  "type": "way",
+  "id": 1135360258,
+  "center": {
+    "lat": 26.5093868,
+    "lon": 80.2285497
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "yes",
+    "name": "Hall 5 TV Room"
+  }
+},
+{
+  "type": "way",
+  "id": 1135360259,
+  "center": {
+    "lat": 26.5052616,
+    "lon": 80.2262511
+  },
+  "tags": {
+    "building": "yes",
+    "name": "Hall 11 Laundry Room",
+    "self_service": "yes",
+    "shop": "laundry"
+  }
+},
+{
+  "type": "way",
+  "id": 1135360260,
+  "center": {
+    "lat": 26.5043966,
+    "lon": 80.2259478
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "basketball"
+  }
+},
+{
+  "type": "way",
+  "id": 1135867088,
+  "center": {
+    "lat": 26.5057126,
+    "lon": 80.2267144
+  },
+  "tags": {
+    "leisure": "park"
+  }
+},
+{
+  "type": "way",
+  "id": 1135867089,
+  "center": {
+    "lat": 26.5095565,
+    "lon": 80.2283773
+  },
+  "tags": {
+    "leisure": "park"
+  }
+},
+{
+  "type": "way",
+  "id": 1136100086,
+  "center": {
+    "lat": 26.5134895,
+    "lon": 80.2350691
+  },
+  "tags": {
+    "leisure": "garden"
+  }
+},
+{
+  "type": "way",
+  "id": 1136100090,
+  "center": {
+    "lat": 26.5084897,
+    "lon": 80.2322466
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "volleyball"
+  }
+},
+{
+  "type": "way",
+  "id": 1136100091,
+  "center": {
+    "lat": 26.5082361,
+    "lon": 80.2322123
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "volleyball"
+  }
+},
+{
+  "type": "way",
+  "id": 1136930282,
+  "center": {
+    "lat": 26.5048046,
+    "lon": 80.2350723
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "badminton"
+  }
+},
+{
+  "type": "way",
+  "id": 1136942412,
+  "center": {
+    "lat": 26.5161782,
+    "lon": 80.2332856
+  },
+  "tags": {
+    "building": "university",
+    "name": "Helicopter Labs",
+    "source": "microsoft/BuildingFootprints"
+  }
+},
+{
+  "type": "way",
+  "id": 1136942413,
+  "center": {
+    "lat": 26.5055430,
+    "lon": 80.2328180
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "name": "Old RA Hostel",
+    "source": "microsoft/BuildingFootprints"
+  }
+},
+{
+  "type": "way",
+  "id": 1136989049,
+  "center": {
+    "lat": 26.5137239,
+    "lon": 80.2347861
+  },
+  "tags": {
+    "amenity": "fountain"
+  }
+},
+{
+  "type": "way",
+  "id": 1136989050,
+  "center": {
+    "lat": 26.5137709,
+    "lon": 80.2347839
+  },
+  "tags": {
+    "leisure": "garden"
+  }
+},
+{
+  "type": "way",
+  "id": 1136989052,
+  "center": {
+    "lat": 26.5100963,
+    "lon": 80.2287252
+  },
+  "tags": {
+    "amenity": "bicycle_parking",
+    "bicycle_parking": "shed",
+    "building": "yes",
+    "covered": "yes",
+    "fee": "no"
+  }
+},
+{
+  "type": "way",
+  "id": 1137181479,
+  "center": {
+    "lat": 26.5040517,
+    "lon": 80.2351709
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "name": "Smart Grid Control Centre"
+  }
+},
+{
+  "type": "way",
+  "id": 1137189332,
+  "center": {
+    "lat": 26.5063048,
+    "lon": 80.2345000
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "basketball"
+  }
+},
+{
+  "type": "way",
+  "id": 1137189333,
+  "center": {
+    "lat": 26.5061521,
+    "lon": 80.2346525
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "school",
+    "name": "Campus School",
+    "phone": "+91 512 2597354;+91 512 2597770",
+    "website": "https://www.iitk.ac.in/campusschool/"
+  }
+},
+{
+  "type": "way",
+  "id": 1137190599,
+  "center": {
+    "lat": 26.5108986,
+    "lon": 80.2451864
+  },
+  "tags": {
+    "amenity": "bicycle_parking",
+    "bicycle_parking": "stands",
+    "covered": "no",
+    "fee": "yes"
+  }
+},
+{
+  "type": "way",
+  "id": 1137755506,
+  "center": {
+    "lat": 26.5142809,
+    "lon": 80.2302765
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "name": "Rural Technology Action Group",
+    "nohousenumber": "yes",
+    "short_name": "RuTAG"
+  }
+},
+{
+  "type": "way",
+  "id": 1137755507,
+  "center": {
+    "lat": 26.5106875,
+    "lon": 80.2334215
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "name": "Lecture Hall 16",
+    "short_name": "L16"
+  }
+},
+{
+  "type": "way",
+  "id": 1137755508,
+  "center": {
+    "lat": 26.5106902,
+    "lon": 80.2337334
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "name": "Lecture Hall 17",
+    "short_name": "L17"
+  }
+},
+{
+  "type": "way",
+  "id": 1137756289,
+  "center": {
+    "lat": 26.5141195,
+    "lon": 80.2375538
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "name": "Smart Grid Semi-Urban Field Pilot (Lanes 32 and 33)",
+    "source": "microsoft/BuildingFootprints"
+  }
+},
+{
+  "type": "way",
+  "id": 1137756293,
+  "center": {
+    "lat": 26.5116720,
+    "lon": 80.2366955
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "amenity": "bank",
+    "atm": "yes",
+    "brand": "State Bank of India",
+    "brand:wikidata": "Q1340361",
+    "building": "yes",
+    "drive_through": "no",
+    "name": "State Bank of India",
+    "short_name": "SBI",
+    "source": "microsoft/BuildingFootprints"
+  }
+},
+{
+  "type": "way",
+  "id": 1137984878,
+  "center": {
+    "lat": 26.5094349,
+    "lon": 80.2282736
+  },
+  "tags": {
+    "building": "yes",
+    "name": "Hall 5 Reading Room"
+  }
+},
+{
+  "type": "way",
+  "id": 1138186701,
+  "center": {
+    "lat": 26.5041705,
+    "lon": 80.2317365
+  },
+  "tags": {
+    "garden:type": "residential",
+    "leisure": "garden"
+  }
+},
+{
+  "type": "way",
+  "id": 1138189976,
+  "center": {
+    "lat": 26.5092060,
+    "lon": 80.2483128
+  },
+  "tags": {
+    "building": "train_station",
+    "building:levels": "4",
+    "building:min_levels": "2",
+    "layer": "1",
+    "name": "IIT Kanpur",
+    "name:hi": "आई आई टी कानपुर",
+    "network": "Kanpur Metro",
+    "note": "Contributors are requested to not edit the \"network\" and the \"operator\" tags. (2023/11/08)",
+    "operator": "Uttar Pradesh Metro Rail Corporation Limited",
+    "public_transport": "station",
+    "wikidata": "Q110300579",
+    "wikipedia": "en:IIT Kanpur metro station"
+  }
+},
+{
+  "type": "way",
+  "id": 1138190698,
+  "center": {
+    "lat": 26.5091107,
+    "lon": 80.2335968
+  },
+  "tags": {
+    "leisure": "track",
+    "lit": "yes",
+    "sport": "running",
+    "surface": "grass"
+  }
+},
+{
+  "type": "way",
+  "id": 1142120961,
+  "center": {
+    "lat": 26.5048668,
+    "lon": 80.2268626
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "4",
+    "name": "Hall 11 Block A"
+  }
+},
+{
+  "type": "way",
+  "id": 1142120962,
+  "center": {
+    "lat": 26.5048570,
+    "lon": 80.2260352
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "4",
+    "name": "Hall 11 Block C"
+  }
+},
+{
+  "type": "way",
+  "id": 1142120963,
+  "center": {
+    "lat": 26.5044683,
+    "lon": 80.2264500
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "4",
+    "name": "Hall 11 Block B"
+  }
+},
+{
+  "type": "way",
+  "id": 1142120964,
+  "center": {
+    "lat": 26.5069618,
+    "lon": 80.2264455
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "4",
+    "name": "Hall 10 Block B"
+  }
+},
+{
+  "type": "way",
+  "id": 1142120965,
+  "center": {
+    "lat": 26.5065590,
+    "lon": 80.2260146
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "building:levels": "4",
+    "name": "Hall 10 Block C"
+  }
+},
+{
+  "type": "way",
+  "id": 1143854836,
+  "center": {
+    "lat": 26.5116544,
+    "lon": 80.2329008
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "layer": "1",
+    "level": "1",
+    "name": "Lecture Hall 7",
+    "short_name": "L7"
+  }
+},
+{
+  "type": "way",
+  "id": 1143854837,
+  "center": {
+    "lat": 26.5115213,
+    "lon": 80.2326291
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "layer": "1",
+    "level": "1",
+    "name": "Lecture Hall 5",
+    "short_name": "L5"
+  }
+},
+{
+  "type": "way",
+  "id": 1143854838,
+  "center": {
+    "lat": 26.5113784,
+    "lon": 80.2326230
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "layer": "1",
+    "level": "1",
+    "name": "Lecture Hall 6",
+    "short_name": "L6"
+  }
+},
+{
+  "type": "way",
+  "id": 1143854839,
+  "center": {
+    "lat": 26.5112051,
+    "lon": 80.2327992
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "layer": "1",
+    "level": "1",
+    "name": "Lecture Hall 1",
+    "short_name": "L1"
+  }
+},
+{
+  "type": "way",
+  "id": 1143854840,
+  "center": {
+    "lat": 26.5112074,
+    "lon": 80.2330068
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "layer": "1",
+    "level": "1",
+    "name": "Lecture Hall 2",
+    "short_name": "L2"
+  }
+},
+{
+  "type": "way",
+  "id": 1143854841,
+  "center": {
+    "lat": 26.5113776,
+    "lon": 80.2331781
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "layer": "1",
+    "level": "1",
+    "name": "Lecture Hall 3",
+    "short_name": "L3"
+  }
+},
+{
+  "type": "way",
+  "id": 1143854842,
+  "center": {
+    "lat": 26.5115328,
+    "lon": 80.2331703
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "layer": "1",
+    "level": "1",
+    "name": "Lecture Hall 4",
+    "short_name": "L4"
+  }
+},
+{
+  "type": "way",
+  "id": 1143854843,
+  "center": {
+    "lat": 26.5109964,
+    "lon": 80.2332043
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "level": "1",
+    "name": "Lecture Hall 14",
+    "short_name": "L14"
+  }
+},
+{
+  "type": "way",
+  "id": 1143854844,
+  "center": {
+    "lat": 26.5109037,
+    "lon": 80.2333240
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "level": "1",
+    "name": "Lecture Hall 15",
+    "short_name": "L15"
+  }
+},
+{
+  "type": "way",
+  "id": 1144794388,
+  "center": {
+    "lat": 26.5077941,
+    "lon": 80.2426599
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "place_of_worship",
+    "building": "yes",
+    "name": "Gurdwara IIT Kanpur",
+    "religion": "sikh"
+  }
+},
+{
+  "type": "way",
+  "id": 1144794390,
+  "center": {
+    "lat": 26.5083353,
+    "lon": 80.2412141
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "residential",
+    "name": "Type 2 Apartments"
+  }
+},
+{
+  "type": "way",
+  "id": 1145006311,
+  "center": {
+    "lat": 26.5069709,
+    "lon": 80.2359395
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "addr:street": "Lane 24",
+    "building": "house",
+    "name": "Director's Residence"
+  }
+},
+{
+  "type": "way",
+  "id": 1150599656,
+  "center": {
+    "lat": 26.5099261,
+    "lon": 80.2407412
+  },
+  "tags": {
+    "amenity": "charging_station",
+    "brand": "EV charging station"
+  }
+},
+{
+  "type": "way",
+  "id": 1154890624,
+  "center": {
+    "lat": 26.5099742,
+    "lon": 80.2425939
+  },
+  "tags": {
+    "building": "yes",
+    "name": "Electric Substation No 6",
+    "power": "substation",
+    "voltage": "11000;430"
+  }
+},
+{
+  "type": "way",
+  "id": 1157377782,
+  "center": {
+    "lat": 26.5103010,
+    "lon": 80.2425990
+  },
+  "tags": {
+    "man_made": "water_tower"
+  }
+},
+{
+  "type": "way",
+  "id": 1158746039,
+  "center": {
+    "lat": 26.5120407,
+    "lon": 80.2303890
+  },
+  "tags": {
+    "building": "yes",
+    "name": "Electric Substation No 1",
+    "power": "substation",
+    "voltage": "11000;430"
+  }
+},
+{
+  "type": "way",
+  "id": 1158746041,
+  "center": {
+    "lat": 26.5173326,
+    "lon": 80.2304391
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "name": "NCC IIT Kanpur"
+  }
+},
+{
+  "type": "way",
+  "id": 1160854063,
+  "center": {
+    "lat": 26.5058516,
+    "lon": 80.2309785
+  },
+  "tags": {
+    "amenity": "parking"
+  }
+},
+{
+  "type": "way",
+  "id": 1160854067,
+  "center": {
+    "lat": 26.5084981,
+    "lon": 80.2313518
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "building": "yes",
+    "leisure": "fitness_centre",
+    "name": "Old Sports Complex Gym"
+  }
+},
+{
+  "type": "way",
+  "id": 1160854068,
+  "center": {
+    "lat": 26.5085258,
+    "lon": 80.2309818
+  },
+  "tags": {
+    "area": "yes",
+    "leisure": "pitch",
+    "sport": "roller_skating"
+  }
+},
+{
+  "type": "way",
+  "id": 1161063538,
+  "center": {
+    "lat": 26.5152608,
+    "lon": 80.2320831
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "name": "Hypersonic Experimental Aerodynamics Lab",
+    "short_name": "HEAL"
+  }
+},
+{
+  "type": "way",
+  "id": 1161593034,
+  "center": {
+    "lat": 26.5101267,
+    "lon": 80.2324684
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "basketball"
+  }
+},
+{
+  "type": "way",
+  "id": 1161593960,
+  "center": {
+    "lat": 26.5162940,
+    "lon": 80.2301940
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "construction",
+    "building:levels": "8",
+    "construction": "yes",
+    "name": "Engineering Sciences Building 3",
+    "roof:shape": "flat",
+    "short_name": "ESB3"
+  }
+},
+{
+  "type": "way",
+  "id": 1161607384,
+  "center": {
+    "lat": 26.5080473,
+    "lon": 80.2303657
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "name": "Hall 3 Block 4"
+  }
+},
+{
+  "type": "way",
+  "id": 1161607385,
+  "center": {
+    "lat": 26.5085976,
+    "lon": 80.2302226
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "name": "Hall 3 Block 3"
+  }
+},
+{
+  "type": "way",
+  "id": 1161607386,
+  "center": {
+    "lat": 26.5089093,
+    "lon": 80.2300032
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "name": "Hall 3 Block 2"
+  }
+},
+{
+  "type": "way",
+  "id": 1161607387,
+  "center": {
+    "lat": 26.5087840,
+    "lon": 80.2293887
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "name": "Hall 3 Block 1"
+  }
+},
+{
+  "type": "way",
+  "id": 1161607388,
+  "center": {
+    "lat": 26.5090205,
+    "lon": 80.2293875
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "name": "Hall 3 Block 7"
+  }
+},
+{
+  "type": "way",
+  "id": 1161607389,
+  "center": {
+    "lat": 26.5081028,
+    "lon": 80.2293976
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "name": "Hall 3 Block 6"
+  }
+},
+{
+  "type": "way",
+  "id": 1161607390,
+  "center": {
+    "lat": 26.5079634,
+    "lon": 80.2299918
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "dormitory",
+    "name": "Hall 3 Block 5"
+  }
+},
+{
+  "type": "way",
+  "id": 1161607391,
+  "center": {
+    "lat": 26.5084407,
+    "lon": 80.2295151
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "restaurant",
+    "building": "yes",
+    "name": "Hall 3 Mess"
+  }
+},
+{
+  "type": "way",
+  "id": 1161607392,
+  "center": {
+    "lat": 26.5086271,
+    "lon": 80.2299751
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "fast_food",
+    "building": "yes",
+    "drive_through": "no",
+    "fast_food": "cafeteria",
+    "name": "Hall 3 Canteen",
+    "opening_hours": "Mo-Su 14:00-02:00"
+  }
+},
+{
+  "type": "way",
+  "id": 1161607393,
+  "center": {
+    "lat": 26.5082765,
+    "lon": 80.2299281
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "building": "yes",
+    "name": "Hall 3 TV Room"
+  }
+},
+{
+  "type": "way",
+  "id": 1161607394,
+  "center": {
+    "lat": 26.5080134,
+    "lon": 80.2291364
+  },
+  "tags": {
+    "amenity": "bicycle_parking",
+    "bicycle_parking": "shed",
+    "building": "yes",
+    "covered": "yes",
+    "fee": "no"
+  }
+},
+{
+  "type": "way",
+  "id": 1161607395,
+  "center": {
+    "lat": 26.5078542,
+    "lon": 80.2290281
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "volleyball"
+  }
+},
+{
+  "type": "way",
+  "id": 1161612852,
+  "center": {
+    "lat": 26.5084937,
+    "lon": 80.2325058
+  },
+  "tags": {
+    "leisure": "pitch",
+    "name": "Tennis Wall",
+    "sport": "tennis"
+  }
+},
+{
+  "type": "way",
+  "id": 1162105833,
+  "center": {
+    "lat": 26.5103162,
+    "lon": 80.2287305
+  },
+  "tags": {
+    "amenity": "bicycle_parking",
+    "bicycle_parking": "shed",
+    "building": "yes",
+    "covered": "yes",
+    "fee": "no"
+  }
+},
+{
+  "type": "way",
+  "id": 1162116104,
+  "center": {
+    "lat": 26.5106765,
+    "lon": 80.2294581
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "restaurant",
+    "building": "yes",
+    "name": "Hall 2 Mess"
+  }
+},
+{
+  "type": "way",
+  "id": 1162995031,
+  "center": {
+    "lat": 26.5083901,
+    "lon": 80.2318125
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "volleyball"
+  }
+},
+{
+  "type": "way",
+  "id": 1162995032,
+  "center": {
+    "lat": 26.5085520,
+    "lon": 80.2318206
+  },
+  "tags": {
+    "leisure": "pitch",
+    "sport": "volleyball"
+  }
+},
+{
+  "type": "way",
+  "id": 1163530654,
+  "center": {
+    "lat": 26.5119320,
+    "lon": 80.2338453
+  },
+  "tags": {
+    "amenity": "fountain"
+  }
+},
+{
+  "type": "way",
+  "id": 1167531620,
+  "center": {
+    "lat": 26.5072259,
+    "lon": 80.2278623
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "restaurant",
+    "building": "yes",
+    "name": "Hall 7 Mess"
+  }
+},
+{
+  "type": "way",
+  "id": 1167533930,
+  "center": {
+    "lat": 26.5094946,
+    "lon": 80.2320189
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "amenity": "restaurant",
+    "building": "yes",
+    "name": "Hall 1 Mess"
+  }
+},
+{
+  "type": "way",
+  "id": 1169296957,
+  "center": {
+    "lat": 26.5149349,
+    "lon": 80.2342027
+  },
+  "tags": {
+    "amenity": "parking"
+  }
+},
+{
+  "type": "way",
+  "id": 1172337971,
+  "center": {
+    "lat": 26.5178723,
+    "lon": 80.2417171
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:housenumber": "6, Naramau",
+    "addr:postcode": "208016",
+    "amenity": "school",
+    "email": "wendyhighschoolnaramau@gmail.com",
+    "name": "Wendy High School",
+    "phone": "+91-7311133336",
+    "website": "https://www.wendyhighschool.com/"
+  }
+},
+{
+  "type": "way",
+  "id": 1172337972,
+  "center": {
+    "lat": 26.5186272,
+    "lon": 80.2412966
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "building": "yes",
+    "leisure": "fitness_centre",
+    "name": "Shri Purnananda Ajapa Yog Sansthan",
+    "name:en": "Shri Purnananda Ajapa Yog Sansthan",
+    "name:hi": "श्री पूर्णानन्द अजपा योग संस्थान",
+    "sport": "yoga",
+    "website": "https://ajapayog.org/"
+  }
+},
+{
+  "type": "way",
+  "id": 1256623109,
+  "center": {
+    "lat": 26.5052345,
+    "lon": 80.2337102
+  },
+  "tags": {
+    "addr:postcode": "208016",
+    "building": "hospital",
+    "description": "University clinic",
+    "name": "Health Centre",
+    "phone": "05122597777",
+    "short_name": "HC",
+    "website": "https://iitk.ac.in/hc",
+    "wheelchair": "yes"
+  }
+},
+{
+  "type": "way",
+  "id": 1351872214,
+  "center": {
+    "lat": 26.5027817,
+    "lon": 80.2325924
+  },
+  "tags": {
+    "leisure": "park"
+  }
+},
+{
+  "type": "way",
+  "id": 1394026546,
+  "center": {
+    "lat": 26.5155182,
+    "lon": 80.2325508
+  },
+  "tags": {
+    "building": "university",
+    "building:levels": "1",
+    "description": "Department of Aerospace Engineering",
+    "name": "Aeronautical Engineering Lab"
+  }
+},
+{
+  "type": "way",
+  "id": 1394027089,
+  "center": {
+    "lat": 26.5159297,
+    "lon": 80.2325782
+  },
+  "tags": {
+    "building": "university",
+    "building:levels": "1",
+    "name": "High Speed Aerodynamics Lab (HSAL)"
+  }
+},
+{
+  "type": "way",
+  "id": 1394029120,
+  "center": {
+    "lat": 26.5158589,
+    "lon": 80.2330965
+  },
+  "tags": {
+    "building": "university",
+    "name": "Propulsion Labs"
+  }
+},
+{
+  "type": "way",
+  "id": 1465113052,
+  "center": {
+    "lat": 26.5152353,
+    "lon": 80.2315465
+  },
+  "tags": {
+    "building": "yes",
+    "name": "House 1"
+  }
+},
+{
+  "type": "way",
+  "id": 1465113053,
+  "center": {
+    "lat": 26.5155734,
+    "lon": 80.2315551
+  },
+  "tags": {
+    "building": "yes",
+    "name": "House 2"
+  }
+},
+{
+  "type": "way",
+  "id": 1465113054,
+  "center": {
+    "lat": 26.5159853,
+    "lon": 80.2304156
+  },
+  "tags": {
+    "building": "yes",
+    "name": "Building 2"
+  }
+},
+{
+  "type": "way",
+  "id": 1486428403,
+  "center": {
+    "lat": 26.5107684,
+    "lon": 80.2348780
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:district": "Kanpur",
+    "addr:housenumber": "Unit No.04",
+    "addr:postcode": "208016",
+    "addr:street": "Ground Floor, Indian Institute of Technology Kanpur, Sixth Ave, Nankari, Kalyanpur",
+    "air_conditioning": "yes",
+    "amenity": "cafe",
+    "brand": "Starbucks",
+    "brand:wikidata": "Q37158",
+    "building": "yes",
+    "cuisine": "coffee_shop",
+    "internet_access": "wlan",
+    "internet_access:fee": "no",
+    "layer": "-1",
+    "level": "0",
+    "location": "surface",
+    "name": "Starbucks",
+    "official_name": "Starbucks Coffee",
+    "opening_hours": "Mo-Su 08:00-23:00",
+    "outdoor_seating": "no",
+    "phone": "+91 1860 266 0010",
+    "takeaway": "yes",
+    "website": "https://www.starbucks.in/"
+  }
+},
+{
+  "type": "way",
+  "id": 1486428582,
+  "center": {
+    "lat": 26.5082777,
+    "lon": 80.2298171
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:district": "Kanpur",
+    "addr:postcode": "208016",
+    "addr:street": "Hall 3, IIT Kanpur",
+    "building": "yes",
+    "building:levels": "1",
+    "name": "Electronics Club IITK",
+    "website": "https://electronicsclub-iitk.github.io/"
+  }
+},
+{
+  "type": "way",
+  "id": 1486429148,
+  "center": {
+    "lat": 26.5105874,
+    "lon": 80.2272234
+  },
+  "tags": {
+    "access": "yes",
+    "addr:city": "Kanpur",
+    "addr:district": "Kanpur",
+    "addr:postcode": "208016",
+    "addr:street": "Hall 12 back connector, IITK",
+    "amenity": "fast_food",
+    "building": "yes",
+    "fast_food": "cafeteria",
+    "name": "Hall12 Canteen",
+    "opening_hours": "Mo-Su 14:00-2:00"
+  }
+},
+{
+  "type": "way",
+  "id": 1486430418,
+  "center": {
+    "lat": 26.5106436,
+    "lon": 80.2277952
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:district": "Kanpur",
+    "addr:postcode": "208016",
+    "addr:street": "Hall 12 , IITK",
+    "building": "residential",
+    "building:levels": "7",
+    "name": "Hall 12 Block A"
+  }
+},
+{
+  "type": "way",
+  "id": 1486430419,
+  "center": {
+    "lat": 26.5109256,
+    "lon": 80.2273480
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:district": "Kanpur",
+    "addr:postcode": "208016",
+    "addr:street": "Hall 12 , IITK",
+    "building": "residential",
+    "building:levels": "7",
+    "name": "Hall 12 Block C"
+  }
+},
+{
+  "type": "way",
+  "id": 1486430420,
+  "center": {
+    "lat": 26.5109308,
+    "lon": 80.2277812
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:district": "Kanpur",
+    "addr:postcode": "208016",
+    "addr:street": "Hall 12 , IITK",
+    "building": "residential",
+    "building:levels": "7",
+    "name": "Hall 12 Block B"
+  }
+},
+{
+  "type": "way",
+  "id": 1486430421,
+  "center": {
+    "lat": 26.5112073,
+    "lon": 80.2277961
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:district": "Kanpur",
+    "addr:postcode": "208016",
+    "addr:street": "Hall 12 , IITK",
+    "building": "residential",
+    "building:levels": "7",
+    "name": "Hall 12 Block D"
+  }
+},
+{
+  "type": "way",
+  "id": 1486430422,
+  "center": {
+    "lat": 26.5112024,
+    "lon": 80.2273571
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:district": "Kanpur",
+    "addr:postcode": "208016",
+    "addr:street": "Hall 12 , IITK",
+    "building": "residential",
+    "building:levels": "7",
+    "name": "Hall 12 Block E"
+  }
+},
+{
+  "type": "way",
+  "id": 1486430423,
+  "center": {
+    "lat": 26.5114882,
+    "lon": 80.2277870
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:district": "Kanpur",
+    "addr:postcode": "208016",
+    "addr:street": "Hall 12 , IITK",
+    "building": "residential",
+    "building:levels": "7",
+    "name": "Hall 12 Block F"
+  }
+},
+{
+  "type": "way",
+  "id": 1486430424,
+  "center": {
+    "lat": 26.5114666,
+    "lon": 80.2271907
+  },
+  "tags": {
+    "access": "yes",
+    "addr:city": "Kanpur",
+    "addr:district": "Kanpur",
+    "addr:postcode": "208016",
+    "addr:street": "Hall 12, IITK",
+    "amenity": "fast_food",
+    "building": "yes",
+    "fast_food": "cafeteria",
+    "name": "Hall 12 Mess",
+    "opening_hours": "Mo-Su 07:30-21:30"
+  }
+},
+{
+  "type": "way",
+  "id": 1486430425,
+  "center": {
+    "lat": 26.5110570,
+    "lon": 80.2278754
+  },
+  "tags": {
+    "leisure": "pitch",
+    "name": "Hall 12 Badminton Court",
+    "sport": "badminton"
+  }
+},
+{
+  "type": "way",
+  "id": 1486430426,
+  "center": {
+    "lat": 26.5110063,
+    "lon": 80.2280806
+  },
+  "tags": {
+    "leisure": "pitch",
+    "name": "Hall 12 Volleyball Court",
+    "sport": "volleyball"
+  }
+},
+{
+  "type": "way",
+  "id": 1488772205,
+  "center": {
+    "lat": 26.5110572,
+    "lon": 80.2334338
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "indoor": "room",
+    "level": "1",
+    "name": "Lecture Hall 13",
+    "room": "class",
+    "short_name": "L13"
+  }
+},
+{
+  "type": "way",
+  "id": 1488772206,
+  "center": {
+    "lat": 26.5111631,
+    "lon": 80.2335413
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "1",
+    "name": "Lecture Hall 11",
+    "room": "class",
+    "short_name": "L11"
+  }
+},
+{
+  "type": "way",
+  "id": 1488772207,
+  "center": {
+    "lat": 26.5110572,
+    "lon": 80.2334338
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "indoor": "room",
+    "level": "0",
+    "name": "Lecture Hall 9",
+    "room": "class",
+    "short_name": "L9"
+  }
+},
+{
+  "type": "way",
+  "id": 1488772208,
+  "center": {
+    "lat": 26.5111724,
+    "lon": 80.2332954
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "indoor": "room",
+    "level": "1",
+    "name": "Lecture Hall 12",
+    "room": "class",
+    "short_name": "L12"
+  }
+},
+{
+  "type": "way",
+  "id": 1488772209,
+  "center": {
+    "lat": 26.5111724,
+    "lon": 80.2332954
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:place": "IIT Kanpur",
+    "addr:postcode": "208016",
+    "indoor": "room",
+    "level": "0",
+    "name": "Lecture Hall 8",
+    "room": "class",
+    "short_name": "L8"
+  }
+},
+{
+  "type": "way",
+  "id": 1488772210,
+  "center": {
+    "lat": 26.5112730,
+    "lon": 80.2334148
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "1",
+    "name": "Lecture Hall 10",
+    "room": "class",
+    "short_name": "L10"
+  }
+},
+{
+  "type": "way",
+  "id": 1488889185,
+  "center": {
+    "lat": 26.5111146,
+    "lon": 80.2334842
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "1",
+    "name": "Lecture Hall Complex Office Staff",
+    "room": "office"
+  }
+},
+{
+  "type": "way",
+  "id": 1488889201,
+  "center": {
+    "lat": 26.5112164,
+    "lon": 80.2333590
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "1",
+    "name": "Lecture Hall Complex Office Staff",
+    "room": "office"
+  }
+},
+{
+  "type": "way",
+  "id": 1488889203,
+  "center": {
+    "lat": 26.5054971,
+    "lon": 80.2309237
+  },
+  "tags": {
+    "leisure": "swimming_pool",
+    "sport": "swimming"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040304,
+  "center": {
+    "lat": 26.5109948,
+    "lon": 80.2321612
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "0",
+    "name": "107",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040307,
+  "center": {
+    "lat": 26.5111054,
+    "lon": 80.2323183
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "1",
+    "name": "210",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040308,
+  "center": {
+    "lat": 26.5108178,
+    "lon": 80.2324839
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "0",
+    "name": "101",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040309,
+  "center": {
+    "lat": 26.5107883,
+    "lon": 80.2324412
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "1",
+    "name": "202",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040310,
+  "center": {
+    "lat": 26.5108380,
+    "lon": 80.2321818
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "0",
+    "name": "105",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040311,
+  "center": {
+    "lat": 26.5110374,
+    "lon": 80.2321827
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "1",
+    "name": "208",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040312,
+  "center": {
+    "lat": 26.5107706,
+    "lon": 80.2323205
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "0",
+    "name": "103",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040313,
+  "center": {
+    "lat": 26.5110883,
+    "lon": 80.2324381
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "0",
+    "name": "111",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040314,
+  "center": {
+    "lat": 26.5108838,
+    "lon": 80.2321618
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "1",
+    "name": "206",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040315,
+  "center": {
+    "lat": 26.5111054,
+    "lon": 80.2323183
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "0",
+    "name": "110",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040316,
+  "center": {
+    "lat": 26.5110374,
+    "lon": 80.2321827
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "0",
+    "name": "108",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040317,
+  "center": {
+    "lat": 26.5107097,
+    "lon": 80.2324106
+  },
+  "tags": {
+    "access": "permissive",
+    "amenity": "toilets",
+    "fee": "no",
+    "female": "yes",
+    "level": "1",
+    "toilets:disposal": "flush",
+    "toilets:handwashing": "yes",
+    "toilets:position": "squat",
+    "wheelchair": "limited"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040318,
+  "center": {
+    "lat": 26.5107073,
+    "lon": 80.2323803
+  },
+  "tags": {
+    "access": "permissive",
+    "amenity": "toilets",
+    "fee": "no",
+    "level": "0",
+    "male": "yes",
+    "toilets:disposal": "flush",
+    "toilets:handwashing": "yes",
+    "toilets:position": "squat;urinal",
+    "wheelchair": "limited"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040319,
+  "center": {
+    "lat": 26.5108838,
+    "lon": 80.2321618
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "0",
+    "name": "106",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040321,
+  "center": {
+    "lat": 26.5110589,
+    "lon": 80.2324848
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "1",
+    "name": "212",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040324,
+  "center": {
+    "lat": 26.5110947,
+    "lon": 80.2322638
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "0",
+    "name": "109",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040325,
+  "center": {
+    "lat": 26.5109948,
+    "lon": 80.2321612
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "1",
+    "name": "207",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040326,
+  "center": {
+    "lat": 26.5110589,
+    "lon": 80.2324848
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "0",
+    "name": "112",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040327,
+  "center": {
+    "lat": 26.5110883,
+    "lon": 80.2324384
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "1",
+    "name": "211",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040328,
+  "center": {
+    "lat": 26.5108178,
+    "lon": 80.2324839
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "1",
+    "name": "201",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040329,
+  "center": {
+    "lat": 26.5107073,
+    "lon": 80.2323803
+  },
+  "tags": {
+    "access": "permissive",
+    "amenity": "toilets",
+    "fee": "no",
+    "level": "1",
+    "male": "yes",
+    "toilets:disposal": "flush",
+    "toilets:handwashing": "yes",
+    "toilets:position": "squat;urinal",
+    "wheelchair": "limited"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040330,
+  "center": {
+    "lat": 26.5107706,
+    "lon": 80.2323205
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "1",
+    "name": "203",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040331,
+  "center": {
+    "lat": 26.5110947,
+    "lon": 80.2322638
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "1",
+    "name": "209",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040332,
+  "center": {
+    "lat": 26.5107883,
+    "lon": 80.2324412
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "0",
+    "name": "102",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040334,
+  "center": {
+    "lat": 26.5108380,
+    "lon": 80.2321818
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "1",
+    "name": "205",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040335,
+  "center": {
+    "lat": 26.5107097,
+    "lon": 80.2324106
+  },
+  "tags": {
+    "access": "permissive",
+    "amenity": "toilets",
+    "fee": "no",
+    "female": "yes",
+    "level": "0",
+    "toilets:disposal": "flush",
+    "toilets:handwashing": "yes",
+    "toilets:position": "squat",
+    "wheelchair": "limited"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040336,
+  "center": {
+    "lat": 26.5107811,
+    "lon": 80.2322644
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "0",
+    "name": "104",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489040337,
+  "center": {
+    "lat": 26.5107811,
+    "lon": 80.2322644
+  },
+  "tags": {
+    "indoor": "room",
+    "level": "1",
+    "name": "204",
+    "room": "class"
+  }
+},
+{
+  "type": "way",
+  "id": 1489183404,
+  "center": {
+    "lat": 26.5109555,
+    "lon": 80.2329015
+  },
+  "tags": {
+    "amenity": "place_of_worship",
+    "religion": "hindu"
+  }
+},
+{
+  "type": "way",
+  "id": 1489183406,
+  "center": {
+    "lat": 26.5108720,
+    "lon": 80.2336638
+  },
+  "tags": {
+    "leisure": "bleachers"
+  }
+},
+{
+  "type": "relation",
+  "id": 5609184,
+  "center": {
+    "lat": 26.5048207,
+    "lon": 80.2321449
+  },
+  "tags": {
+    "building": "residential",
+    "building:levels": "2",
+    "name": "New RA Hostel",
+    "type": "multipolygon"
+  }
+},
+{
+  "type": "relation",
+  "id": 7219496,
+  "center": {
+    "lat": 26.5109376,
+    "lon": 80.2323135
+  },
+  "tags": {
+    "building": "university",
+    "building:levels": "2",
+    "name": "Tutorial Block",
+    "type": "multipolygon"
+  }
+},
+{
+  "type": "relation",
+  "id": 20322513,
+  "center": {
+    "lat": 26.5123849,
+    "lon": 80.2339019
+  },
+  "tags": {
+    "amenity": "library",
+    "building": "yes",
+    "internet_access": "wlan",
+    "internet_access:fee": "no",
+    "name": "P K Kelkar Library",
+    "opening_hours": "Mo-Fr 08:00-23:59; Sa 09:00-23:59; Su,PH 09:00-17:30",
+    "operator": "IIT Kanpur",
+    "type": "multipolygon",
+    "website": "https://pkklib.iitk.ac.in"
+  }
+},
+{
+  "type": "relation",
+  "id": 20327839,
+  "center": {
+    "lat": 26.5162857,
+    "lon": 80.2310607
+  },
+  "tags": {
+    "addr:city": "Kanpur",
+    "addr:postcode": "208016",
+    "building": "university",
+    "building:levels": "4",
+    "name": "New Core Labs",
+    "roof:shape": "flat",
+    "short_name": "NCL",
+    "type": "multipolygon"
+  }
+},
+{
+  "type": "relation",
+  "id": 20327840,
+  "center": {
+    "lat": 26.5163661,
+    "lon": 80.2318560
+  },
+  "tags": {
+    "building": "university",
+    "name": "Diamond Jubilee Academic Complex",
+    "short_name": "DJAC",
+    "type": "multipolygon"
+  }
+}
+
+  ]
+}

--- a/scripts/build-data.mjs
+++ b/scripts/build-data.mjs
@@ -46,6 +46,7 @@ export const CATEGORIES = {
   transport:{ label: 'Transport',     color: '#ff9bce', pin: false },
   admin:    { label: 'Admin & help',  color: '#9ea7b3', pin: false },
   green:    { label: 'Parks',         color: '#2ea043', pin: false },
+  light:    { label: 'Street lights',  color: '#ffd97a', pin: false },
 }
 
 function classify(t) {
@@ -76,6 +77,7 @@ function classify(t) {
   if (a === 'bicycle_parking' || a === 'bicycle_repair_station' || s === 'bicycle') return 'cycle'
   if (s === 'laundry' || s === 'dry_cleaning' || a === 'laundry' || /Laundry/i.test(name)) return 'laundry'
   if (s === 'copyshop' || a === 'printer' || /\b(xerox|photocopy|printout|print)\b/i.test(name)) return 'print'
+  if (t.highway === 'street_lamp' || t.man_made === 'street_lamp') return 'light'
   if (a === 'vending_machine') return 'vending'
   if (a === 'toilets') return 'toilet'
   if (a === 'place_of_worship' || /Temple|Mosque|Church|Gurudwara/i.test(name)) return 'worship'
@@ -256,7 +258,8 @@ async function main() {
   for (const el of pois.elements) {
     const t = el.tags || {}
     if (t.name) continue
-    if (!UNNAMED_OK.has(t.amenity) && t.man_made !== 'water_tap') continue
+    const isLamp = t.highway === 'street_lamp' || t.man_made === 'street_lamp'
+    if (!isLamp && !UNNAMED_OK.has(t.amenity) && t.man_made !== 'water_tap') continue
     const lon = el.type === 'node' ? el.lon : el.center?.lon
     const lat = el.type === 'node' ? el.lat : el.center?.lat
     if (lon == null || !inCampus(lon, lat)) continue
@@ -266,7 +269,7 @@ async function main() {
     const label = { bicycle_parking: 'Cycle parking', drinking_water: 'Drinking water',
       atm: 'ATM', toilets: 'Toilets', vending_machine: 'Vending machine',
       water_point: 'Water point', bicycle_repair_station: 'Cycle repair' }[t.amenity] ||
-      (t.man_made === 'water_tap' ? 'Water tap' : 'Facility')
+      (isLamp ? 'Street light' : t.man_made === 'water_tap' ? 'Water tap' : 'Facility')
     byId.set(id, {
       id, name: label, cat, unnamed: true,
       lon: +lon.toFixed(6), lat: +lat.toFixed(6),
@@ -276,7 +279,7 @@ async function main() {
       ...(t.capacity ? { capacity: t.capacity } : {}),
       ...(t.covered ? { covered: t.covered } : {}),
       ...(t.drinking_water === 'no' ? { potable: 'no' } : {}),
-      kind: t.amenity || t.man_made,
+      kind: t.amenity || t.man_made || t.highway,
     })
   }
 

--- a/scripts/fetch-osm.mjs
+++ b/scripts/fetch-osm.mjs
@@ -40,6 +40,7 @@ out geom tags;`,
   nwr["man_made"];
   nwr["indoor"]["name"];
   nwr["room"]["name"];
+  node["highway"="street_lamp"];
 );
 out center tags;`,
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -81,8 +81,12 @@ async function start() {
   /* ── layer state ──────────────────────────────────────────────────────── */
 
   // Everything on by default — a student looking for a water cooler should not
-  // have to discover a layer toggle first.
-  const active = new Set(Object.keys(campus.categories).filter((c) => campus.meta.counts[c]))
+  // have to discover a layer toggle first. Street lights are the exception:
+  // they are ambience, not a destination, and the glow competes with the pins.
+  const DEFAULT_OFF = new Set(['light'])
+  const active = new Set(
+    Object.keys(campus.categories).filter((c) => campus.meta.counts[c] && !DEFAULT_OFF.has(c)),
+  )
   let focusId: string | null = null
 
   function poiFeatures(): GeoJSON.FeatureCollection {

--- a/src/map/style.ts
+++ b/src/map/style.ts
@@ -30,6 +30,8 @@ const PALETTE = {
     routeHalo: '#0b0d10',
     route: '#58a6ff',
     focus: '#61d47c',
+    glow: '#ffcf6b',
+    glowCore: '#fff3cf',
   },
   // Deliberately not a white map. The campus is a warm paper tone, buildings a
   // half-step darker, and roads the only near-white — so the built area reads
@@ -54,6 +56,8 @@ const PALETTE = {
     routeHalo: '#fdfdfc',
     route: '#2b6cb8',
     focus: '#2a8a4d',
+    glow: '#e0a11f',
+    glowCore: '#8a6410',
   },
 } as const
 
@@ -178,8 +182,45 @@ export function buildStyle(
         paint: { 'line-color': C.route, 'line-width': 4 },
       },
 
+      // Street lamps read as a pool of light on the ground rather than a pin.
+      // Three stacked blurred circles: a wide falloff, a tighter halo, and a
+      // small bright core. Drawn under everything else so it lights the map
+      // instead of washing out the markers.
+      {
+        id: 'lamp-glow-far', type: 'circle', source: 'pois',
+        filter: ['==', ['get', 'cat'], 'light'],
+        paint: {
+          'circle-radius': ['interpolate', ['exponential', 2], ['zoom'], 14, 8, 17, 34, 19.5, 90],
+          'circle-color': C.glow,
+          'circle-blur': 1,
+          'circle-opacity': theme === 'dark' ? 0.20 : 0.13,
+          'circle-pitch-alignment': 'map',
+        },
+      },
+      {
+        id: 'lamp-glow-near', type: 'circle', source: 'pois',
+        filter: ['==', ['get', 'cat'], 'light'],
+        paint: {
+          'circle-radius': ['interpolate', ['exponential', 2], ['zoom'], 14, 3, 17, 14, 19.5, 38],
+          'circle-color': C.glow,
+          'circle-blur': 0.9,
+          'circle-opacity': theme === 'dark' ? 0.32 : 0.18,
+          'circle-pitch-alignment': 'map',
+        },
+      },
+      {
+        id: 'lamp-core', type: 'circle', source: 'pois',
+        filter: ['==', ['get', 'cat'], 'light'],
+        paint: {
+          'circle-radius': ['interpolate', ['linear'], ['zoom'], 14, 1.2, 17, 2.4, 19.5, 4],
+          'circle-color': C.glowCore,
+          'circle-blur': 0.3,
+          'circle-opacity': 0.95,
+        },
+      },
       {
         id: 'poi-dot', type: 'circle', source: 'pois',
+        filter: ['!=', ['get', 'cat'], 'light'],
         paint: {
           'circle-radius': ['interpolate', ['linear'], ['zoom'], 13, 2.5, 16, 4.5, 19, 7],
           'circle-color': ['get', 'color'],

--- a/src/search/engine.ts
+++ b/src/search/engine.ts
@@ -144,6 +144,9 @@ export class SearchIndex {
     this.campus = campus
 
     for (const p of campus.pois) {
+      // 23 identical "Street light" rows would drown the results. The layer
+      // entry below still makes them reachable by name.
+      if (p.cat === 'light') continue
       const alias = ALIASES[p.cat] ?? []
       // "Lecture Hall 20" should be reachable as L20, LH20, l 20.
       const short = /^Lecture Hall (\d+)$/.exec(p.name)
@@ -329,6 +332,7 @@ const ALIASES: Record<string, string[]> = {
   transport: ['bus', 'parking', 'fuel', 'petrol', 'auto', 'taxi', 'charging'],
   admin: ['office', 'admin', 'security', 'police', 'library', 'post', 'help', 'lost', 'found'],
   green: ['park', 'garden', 'green', 'lawn'],
+  light: ['light', 'lights', 'lamp', 'lamps', 'street light', 'streetlight', 'lit', 'dark', 'night'],
 }
 
 const ACTIONS = [


### PR DESCRIPTION
Adds `highway=street_lamp` to the Overpass query and renders the lamps as pools
of light rather than pins — three stacked blurred circles per lamp (wide
falloff, tighter halo, small bright core), drawn beneath every other marker so
they light the ground instead of washing out the pins.
`circle-pitch-alignment: map` keeps the pool flat. Amber in dark; a deeper amber
at lower opacity in light, where a pale glow would be invisible.

**Off by default.** Every layer was previously forced on, so there was nowhere
to express this — added a `DEFAULT_OFF` set. Lights are ambience, not a
destination, and the glow competes with the pins when everything is on.

**Not indexed individually.** 23 identical "Street light" rows would flood the
results. The layer entry still answers `lights`, `lamp`, `streetlight`, `night`.

### On coverage

23 is genuinely everything OSM has, not a fetch gap:

| Searched | Found |
|---|---|
| `highway=street_lamp` | 23, all LED on angled-mast poles |
| `tower:type=lighting` | 0 |
| `man_made=floodlight` | 0 |
| `amenity=lighting` | 0 |
| `lit=*` on any path | 0 of 962 |

The only towers on campus are 3 water towers and 2 communication masts, neither
of which is lighting, so they are left out. A couple of dozen lamps on a campus
this size is obviously incomplete — an empty-looking layer makes that case
better than a note in the README does.

Both styles validate, no undefined colours, 19 layer chips, browser
verification passes.

Not eyeballed in light theme yet — the palette is deliberately different there
and may want tuning.