### PR TITLE
feat(pixels): shared pixel canvas over the campus map

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,71 @@ stops matching. Coordinates must come from an actual survey; nothing invented.
 For code changes/features/suggustions, feel free to make an issue or a pull request in this repo - if I somehow miss it, please do not
 hesitate to tag me in the issue/PR thread. 
 
+## Pixels
+
+`/pixels` is a shared canvas laid over the campus: a fixed grid at **2 m per
+pixel**, 1495 × 1503 cells, painted by anyone who turns up. Seeded with pride
+flags and a few chibi characters anchored to real buildings.
+
+Open to everyone — no login. Abuse is handled by **rate limiting per IP**:
+30 pixels, then a 60-second cooldown, and at most 12 pixels per request.
+
+The client is not trusted. Position, colour index and budget are all re-checked
+server-side, so a crafted request cannot paint outside the grid, invent a
+colour, or skip the cooldown.
+
+### Setup on Cloudflare Pages
+
+| Binding | Type | Purpose |
+|---|---|---|
+| `PIXELS` | KV namespace | canvas chunks, rate limits, bans, log buffer |
+| `DISCORD_WEBHOOK` | secret | pixel log; server-side only, never sent to the browser |
+| `PIXELS_ADMIN_TOKEN` | secret | bearer token for the admin route |
+
+Without the KV binding the page still renders the seeded art read-only, so a
+missing binding degrades rather than breaks.
+
+### Identity and logging
+
+We never store or log an IP address. Rate limits, bans and the Discord log all
+key off a 10-character hash of it — enough to moderate with, useless for
+identifying anyone off-platform.
+
+Pixels are logged in batches of 25 rather than one message each: a Discord
+webhook is limited to a handful of posts per second, and per-pixel messages
+would be throttled into uselessness the moment two people drew at once.
+
+### Moderation
+
+```bash
+T=your-admin-token
+A=https://iitk.nis.pet/api/pixels/admin
+post() { curl -s -X POST "$A" -H "authorization: Bearer $T" -H 'content-type: application/json' -d "$1"; }
+
+post '{"op":"stats"}'                                    # counts
+post '{"op":"clearRect","x":700,"y":800,"w":40,"h":40}'  # erase a region
+post '{"op":"fillRect","x":700,"y":800,"w":40,"h":40,"c":5}'
+post '{"op":"paint","pixels":[[700,800,8],[701,800,8]]}' # stamp art over it
+post '{"op":"clearAll"}'                                 # wipe user pixels
+post '{"op":"bans"}'                                     # list
+post '{"op":"ban","id":"a1b2c3d4e5"}'                    # id comes from the log
+post '{"op":"unban","id":"a1b2c3d4e5"}'
+```
+
+`clearAll` only removes user-drawn pixels. The seed is a static file, not
+storage, so the canvas is never left blank.
+
+### Editing the seed
+
+Sprites live in `scripts/build-pixels.mjs` as rows of characters, one per
+colour, and are validated for a clean rectangle at build time. `npm run
+build:data` re-bakes `public/data/pixels-seed.json`.
+
+**Known limit:** KV is eventually consistent and has no transactions, so two
+people painting the same 128 × 128 chunk within the same second can lose one
+write. Acceptable for a campus toy; a Durable Object per chunk is the fix if it
+ever gets busy.
+
 ## Deploying
 
 Cloudflare Pages, building from the Git integration:
@@ -150,6 +215,8 @@ Cloudflare Pages, building from the Git integration:
 - Build command `npm run build`
 - Output directory `dist`
 - Node version from `.nvmrc` (22)
+- `functions/` is picked up automatically as Pages Functions — see Pixels above
+  for the bindings it needs
 
 `.github/workflows/ci.yml` typechecks, smoke-tests and builds every push and PR.
 `.github/workflows/refresh-data.yml` re-pulls all sources weekly and opens a PR

--- a/functions/api/pixels/[[path]].ts
+++ b/functions/api/pixels/[[path]].ts
@@ -1,0 +1,319 @@
+/**
+ * Pixel canvas API — Cloudflare Pages Functions.
+ *
+ *   GET  /api/pixels          whole canvas, chunked
+ *   POST /api/pixels/paint    place pixels, IP rate limited
+ *   POST /api/pixels/admin    moderation, needs PIXELS_ADMIN_TOKEN
+ *
+ * Bindings expected on the Pages project:
+ *   PIXELS               KV namespace (canvas, rate limits, bans, log buffer)
+ *   DISCORD_WEBHOOK      secret — never reaches the browser
+ *   PIXELS_ADMIN_TOKEN   secret — bearer token for the admin route
+ *
+ * Storage note: KV is eventually consistent and has no transactions, so two
+ * people painting the same 128×128 chunk within a second can lose one write.
+ * That is an acceptable trade for a campus toy; a Durable Object per chunk is
+ * the fix if this ever gets busy.
+ */
+
+import {
+  CHUNK, GRID_W, GRID_H, PALETTE, chunkKey, chunkOf, inBounds,
+  packChunk, unpackChunk, type Pixel,
+} from '../../../src/pixels/grid'
+
+interface Env {
+  PIXELS: KVNamespace
+  DISCORD_WEBHOOK?: string
+  PIXELS_ADMIN_TOKEN?: string
+}
+
+/** Pixels allowed before a forced break, and how long that break lasts. */
+const BURST = 30
+const COOLDOWN_S = 60
+/** Most pixels one request may carry. Stops a single call painting the map. */
+const MAX_PER_REQUEST = 12
+
+const json = (body: unknown, status = 200, extra: HeadersInit = {}) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', ...extra },
+  })
+
+/* ── identity ────────────────────────────────────────────────────────────── */
+
+/**
+ * A short, stable id derived from the client IP. We never store or log the
+ * address itself — bans and rate limits key off this instead, which is enough
+ * to moderate with and useless for identifying anyone off-platform.
+ */
+async function painterId(req: Request): Promise<string> {
+  const ip = req.headers.get('cf-connecting-ip') ?? '0.0.0.0'
+  const bytes = new TextEncoder().encode(`iitk-pixels:${ip}`)
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
+  return [...new Uint8Array(digest)].slice(0, 5)
+    .map((b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+/* ── canvas ──────────────────────────────────────────────────────────────── */
+
+async function readCanvas(env: Env) {
+  const chunks: Record<string, string> = {}
+  let cursor: string | undefined
+  do {
+    const page = await env.PIXELS.list({ prefix: 'c:', cursor, limit: 1000 })
+    for (const k of page.keys) {
+      const v = await env.PIXELS.get(k.name)
+      if (v) chunks[k.name.slice(2)] = v
+    }
+    cursor = page.list_complete ? undefined : page.cursor
+  } while (cursor)
+  return chunks
+}
+
+/** Apply pixels to their chunks. Returns how many actually changed. */
+async function applyPixels(env: Env, pixels: Pixel[]): Promise<number> {
+  const byChunk = new Map<string, Pixel[]>()
+  for (const p of pixels) {
+    const { cx, cy } = chunkOf(p.x, p.y)
+    const key = chunkKey(cx, cy)
+    const arr = byChunk.get(key)
+    if (arr) arr.push(p); else byChunk.set(key, [p])
+  }
+
+  let changed = 0
+  for (const [key, batch] of byChunk) {
+    const existing = unpackChunk((await env.PIXELS.get(key)) ?? '')
+    const merged = new Map(existing.map((p) => [`${p.x},${p.y}`, p]))
+    for (const p of batch) {
+      const k = `${p.x},${p.y}`
+      if (p.c === 0) merged.delete(k)
+      else merged.set(k, p)
+      changed++
+    }
+    if (merged.size) await env.PIXELS.put(key, packChunk(merged.values()))
+    else await env.PIXELS.delete(key)
+  }
+  return changed
+}
+
+/* ── discord logging ─────────────────────────────────────────────────────── */
+
+/**
+ * Every pixel is logged, but batched. Discord rate limits a webhook to a
+ * handful of posts per second; one message per pixel would be throttled into
+ * uselessness within moments of anyone actually drawing.
+ */
+const LOG_FLUSH_AT = 25
+const LOG_MAX_AGE_MS = 45_000
+
+async function logPixels(env: Env, who: string, pixels: Pixel[], note = '') {
+  if (!env.DISCORD_WEBHOOK) return
+  const raw = await env.PIXELS.get('log:buf')
+  const buf = raw ? (JSON.parse(raw) as { t: number; lines: string[] }) : { t: Date.now(), lines: [] }
+
+  for (const p of pixels) {
+    buf.lines.push(`\`${who}\` ${note}(${p.x},${p.y}) ${p.c === 0 ? 'erase' : PALETTE[p.c]}`)
+  }
+
+  const stale = Date.now() - buf.t > LOG_MAX_AGE_MS
+  if (buf.lines.length < LOG_FLUSH_AT && !stale) {
+    await env.PIXELS.put('log:buf', JSON.stringify(buf))
+    return
+  }
+
+  const lines = buf.lines.splice(0, 60)
+  await env.PIXELS.put('log:buf', JSON.stringify({ t: Date.now(), lines: buf.lines }))
+  await fetch(env.DISCORD_WEBHOOK, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      username: 'iitk.nis.pet pixels',
+      embeds: [{
+        title: `${lines.length} pixels`,
+        description: lines.join('\n').slice(0, 4000),
+        color: 0x61d47c,
+        timestamp: new Date().toISOString(),
+      }],
+    }),
+  }).catch(() => { /* logging must never break painting */ })
+}
+
+/* ── routes ──────────────────────────────────────────────────────────────── */
+
+export const onRequest: PagesFunction<Env> = async (ctx) => {
+  const { request, env } = ctx
+  const path = (ctx.params.path as string[] | undefined)?.join('/') ?? ''
+
+  if (!env.PIXELS) {
+    return json({ error: 'canvas storage is not configured on this deployment' }, 503)
+  }
+
+  /* GET /api/pixels */
+  if (request.method === 'GET' && path === '') {
+    return json({
+      grid: { w: GRID_W, h: GRID_H, chunk: CHUNK },
+      burst: BURST,
+      cooldown: COOLDOWN_S,
+      maxPerRequest: MAX_PER_REQUEST,
+      chunks: await readCanvas(env),
+    })
+  }
+
+  /* POST /api/pixels/paint */
+  if (request.method === 'POST' && path === 'paint') {
+    const who = await painterId(request)
+
+    if (await env.PIXELS.get(`ban:${who}`)) {
+      return json({ error: 'You are banned from painting.', id: who }, 403)
+    }
+
+    let body: { pixels?: [number, number, number][] }
+    try { body = await request.json() } catch { return json({ error: 'bad json' }, 400) }
+
+    const raw = body.pixels
+    if (!Array.isArray(raw) || raw.length === 0) return json({ error: 'no pixels' }, 400)
+    if (raw.length > MAX_PER_REQUEST) {
+      return json({ error: `at most ${MAX_PER_REQUEST} pixels per request` }, 400)
+    }
+
+    const pixels: Pixel[] = []
+    for (const item of raw) {
+      if (!Array.isArray(item) || item.length !== 3) return json({ error: 'bad pixel' }, 400)
+      const [x, y, c] = item.map(Number)
+      // Validate server-side: the client is not trusted about position or colour.
+      if (!inBounds(x!, y!)) return json({ error: `pixel out of bounds: ${x},${y}` }, 400)
+      if (!Number.isInteger(c) || c! < 0 || c! >= PALETTE.length) {
+        return json({ error: `bad colour index: ${c}` }, 400)
+      }
+      pixels.push({ x: x!, y: y!, c: c! })
+    }
+
+    // Rate limit: a budget of BURST pixels, then a forced cooldown.
+    const now = Date.now()
+    const rlRaw = await env.PIXELS.get(`rl:${who}`)
+    const rl = rlRaw ? (JSON.parse(rlRaw) as { n: number; until: number }) : { n: 0, until: 0 }
+
+    if (rl.until > now) {
+      return json({
+        error: 'cooling down', cooldownUntil: rl.until, remaining: 0, id: who,
+      }, 429, { 'retry-after': String(Math.ceil((rl.until - now) / 1000)) })
+    }
+    if (rl.until && rl.until <= now) rl.n = 0 // cooldown served, budget refills
+
+    if (rl.n + pixels.length > BURST) {
+      return json({
+        error: `only ${BURST - rl.n} left before a break`, remaining: Math.max(0, BURST - rl.n), id: who,
+      }, 429)
+    }
+
+    rl.n += pixels.length
+    rl.until = rl.n >= BURST ? now + COOLDOWN_S * 1000 : 0
+    await env.PIXELS.put(`rl:${who}`, JSON.stringify(rl), { expirationTtl: 3600 })
+
+    await applyPixels(env, pixels)
+    ctx.waitUntil(logPixels(env, who, pixels))
+
+    return json({
+      ok: true,
+      painted: pixels.length,
+      remaining: Math.max(0, BURST - rl.n),
+      cooldownUntil: rl.until || null,
+      id: who,
+    })
+  }
+
+  /* POST /api/pixels/admin */
+  if (request.method === 'POST' && path === 'admin') {
+    const token = (request.headers.get('authorization') ?? '').replace(/^Bearer\s+/i, '')
+    if (!env.PIXELS_ADMIN_TOKEN || token !== env.PIXELS_ADMIN_TOKEN) {
+      return json({ error: 'unauthorised' }, 401)
+    }
+
+    let body: Record<string, unknown>
+    try { body = await request.json() } catch { return json({ error: 'bad json' }, 400) }
+    const op = String(body.op ?? '')
+
+    const rect = () => ({
+      x: Math.max(0, Number(body.x) | 0), y: Math.max(0, Number(body.y) | 0),
+      w: Math.min(Number(body.w) | 0, GRID_W), h: Math.min(Number(body.h) | 0, GRID_H),
+    })
+
+    switch (op) {
+      /* Erase or flood a rectangle — the two bulk cleanup tools. */
+      case 'clearRect':
+      case 'fillRect': {
+        const { x, y, w, h } = rect()
+        if (w <= 0 || h <= 0) return json({ error: 'w and h must be positive' }, 400)
+        if (w * h > 40_000) return json({ error: 'rectangle too large, split it up' }, 400)
+        const c = op === 'clearRect' ? 0 : Number(body.c) | 0
+        if (c < 0 || c >= PALETTE.length) return json({ error: 'bad colour' }, 400)
+        const px: Pixel[] = []
+        for (let dy = 0; dy < h; dy++) {
+          for (let dx = 0; dx < w; dx++) {
+            if (inBounds(x + dx, y + dy)) px.push({ x: x + dx, y: y + dy, c })
+          }
+        }
+        await applyPixels(env, px)
+        ctx.waitUntil(logPixels(env, 'ADMIN', px.slice(0, 5), `${op} ${w}x${h} `))
+        return json({ ok: true, op, affected: px.length })
+      }
+
+      /* Stamp arbitrary art over whatever is there. No rate limit. */
+      case 'paint': {
+        const raw = body.pixels as [number, number, number][] | undefined
+        if (!Array.isArray(raw) || !raw.length) return json({ error: 'no pixels' }, 400)
+        if (raw.length > 40_000) return json({ error: 'too many pixels' }, 400)
+        const px: Pixel[] = []
+        for (const [x, y, c] of raw) {
+          if (inBounds(x, y) && c >= 0 && c < PALETTE.length) px.push({ x, y, c })
+        }
+        await applyPixels(env, px)
+        ctx.waitUntil(logPixels(env, 'ADMIN', px.slice(0, 5), 'stamp '))
+        return json({ ok: true, op, affected: px.length })
+      }
+
+      /* Wipe every user-drawn pixel. The baked seed art is untouched — it is a
+         static file, not storage, so the canvas is never left blank. */
+      case 'clearAll': {
+        let n = 0, cursor: string | undefined
+        do {
+          const page = await env.PIXELS.list({ prefix: 'c:', cursor, limit: 1000 })
+          for (const k of page.keys) { await env.PIXELS.delete(k.name); n++ }
+          cursor = page.list_complete ? undefined : page.cursor
+        } while (cursor)
+        ctx.waitUntil(logPixels(env, 'ADMIN', [], `cleared the whole canvas (${n} chunks) `))
+        return json({ ok: true, op, chunksDeleted: n })
+      }
+
+      case 'ban':
+      case 'unban': {
+        const id = String(body.id ?? '').trim()
+        if (!/^[0-9a-f]{10}$/.test(id)) return json({ error: 'id must be the 10-char painter id' }, 400)
+        if (op === 'ban') await env.PIXELS.put(`ban:${id}`, String(Date.now()))
+        else await env.PIXELS.delete(`ban:${id}`)
+        ctx.waitUntil(logPixels(env, 'ADMIN', [], `${op} ${id} `))
+        return json({ ok: true, op, id })
+      }
+
+      case 'bans': {
+        const page = await env.PIXELS.list({ prefix: 'ban:', limit: 1000 })
+        return json({ ok: true, bans: page.keys.map((k) => k.name.slice(4)) })
+      }
+
+      case 'stats': {
+        const chunks = await readCanvas(env)
+        const pixels = Object.values(chunks).reduce((n, s) => n + unpackChunk(s).length, 0)
+        const bans = await env.PIXELS.list({ prefix: 'ban:', limit: 1000 })
+        return json({ ok: true, chunks: Object.keys(chunks).length, pixels, bans: bans.keys.length })
+      }
+
+      default:
+        return json({
+          error: 'unknown op',
+          ops: ['clearRect', 'fillRect', 'paint', 'clearAll', 'ban', 'unban', 'bans', 'stats'],
+        }, 400)
+    }
+  }
+
+  return json({ error: 'not found' }, 404)
+}

--- a/index.html
+++ b/index.html
@@ -38,6 +38,22 @@
       <span class="dots" aria-hidden="true"></span>
       <span class="n"></span>
     </button>
+    <a id="pixels-btn" href="/pixels/" title="Paint pixel art over campus" aria-label="Pixels">
+      <svg viewBox="0 0 20 20" width="20" height="20" aria-hidden="true" shape-rendering="crispEdges">
+        <rect x="5"  y="2" width="10" height="2" fill="#ec1f80"/>
+        <rect x="3"  y="4" width="14" height="2" fill="#ec1f80"/>
+        <rect x="3"  y="6" width="2"  height="6" fill="#ec1f80"/>
+        <rect x="15" y="6" width="2"  height="6" fill="#ec1f80"/>
+        <rect x="5"  y="6" width="10" height="6" fill="#fffabc"/>
+        <rect x="6"  y="8" width="2"  height="2" fill="#28509e"/>
+        <rect x="12" y="8" width="2"  height="2" fill="#28509e"/>
+        <rect x="9"  y="11" width="2" height="1" fill="#cb007a"/>
+        <rect x="5"  y="12" width="10" height="2" fill="#ec1f80"/>
+        <rect x="6"  y="14" width="8"  height="4" fill="#ffffff"/>
+        <rect x="4"  y="16" width="2"  height="2" fill="#13e67b"/>
+        <rect x="14" y="16" width="2"  height="2" fill="#4093e4"/>
+      </svg>
+    </a>
     <button id="theme-btn" type="button" aria-label="Change theme" title="Theme"></button>
   </header>
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "fetch": "node scripts/fetch-osm.mjs",
-    "build:data": "node scripts/build-data.mjs",
+    "build:data": "node scripts/build-data.mjs && node scripts/build-pixels.mjs",
     "dev": "npm run build:data && vite",
     "build": "npm run build:data && vite build",
     "preview": "vite preview",

--- a/pixels/index.html
+++ b/pixels/index.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="theme-color" content="#0b0d10">
+<title>pixels · iitk.nis.pet</title>
+<meta name="description" content="Paint pixel art over the IIT Kanpur campus map.">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='7' fill='%230b0d10'/><rect x='7' y='7' width='7' height='7' fill='%23ec1f80'/><rect x='17' y='7' width='7' height='7' fill='%2313e67b'/><rect x='7' y='17' width='7' height='7' fill='%234093e4'/><rect x='17' y='17' width='7' height='7' fill='%23f9dd3b'/></svg>">
+<script>
+  try {
+    var t = localStorage.getItem('campusmap.theme')
+    document.documentElement.setAttribute('data-theme', t === 'light' ? 'light' : 'dark')
+  } catch (e) { document.documentElement.setAttribute('data-theme', 'dark') }
+</script>
+</head>
+<body class="pixels">
+  <div id="map" aria-label="Campus map"></div>
+  <canvas id="pixel-canvas" aria-label="Pixel canvas"></canvas>
+
+  <header id="bar">
+    <a id="brand-btn" href="/">&larr; iitk<span>.nis.pet</span></a>
+    <span id="px-status">loading…</span>
+    <button id="theme-btn" type="button" aria-label="Change theme" title="Theme"></button>
+  </header>
+
+  <div id="px-hint">Zoom in to paint</div>
+
+  <footer id="px-dock">
+    <div id="px-palette" role="radiogroup" aria-label="Colour"></div>
+    <div id="px-actions">
+      <button id="px-erase" type="button" aria-pressed="false" title="Eraser">Erase</button>
+      <span id="px-budget" title="Pixels left before a cooldown"></span>
+      <a id="px-src" href="https://github.com/ni5arga/iitk" target="_blank" rel="noopener">source</a>
+      <span class="by">made by
+        <a href="https://www.cse.iitk.ac.in/users/nisarga/" target="_blank" rel="noopener">nisarga</a>
+      </span>
+    </div>
+  </footer>
+
+  <div id="boot">loading canvas…</div>
+  <script type="module" src="/src/pixels/main.ts"></script>
+</body>
+</html>

--- a/scripts/build-pixels.mjs
+++ b/scripts/build-pixels.mjs
@@ -1,0 +1,232 @@
+// Bakes the seeded pixel art into public/data/pixels-seed.json.
+//
+//   node scripts/build-pixels.mjs
+//
+// The seed is a static file, not stored data: it is the same for everyone, it
+// never changes at runtime, and keeping it out of KV means the canvas has
+// something on it before a single write happens. User-drawn pixels layer on
+// top and win wherever they overlap.
+
+import { writeFile, mkdir } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { build } from 'esbuild'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const OUT = join(ROOT, 'public/data')
+
+// Reuse the exact grid maths the browser and the Functions use.
+const GRID_TMP = join(ROOT, 'node_modules/.cache/pixel-grid.mjs')
+await build({
+  entryPoints: [join(ROOT, 'src/pixels/grid.ts')],
+  bundle: true, format: 'esm', platform: 'node', outfile: GRID_TMP, logLevel: 'silent',
+})
+const G = await import(GRID_TMP + `?t=${Date.now()}`)
+
+/* ── palette shorthand ───────────────────────────────────────────────────── */
+// One character per colour so the sprites below stay readable as pictures.
+
+const C = {
+  '.': 0,                                    // transparent
+  k: 1, d: 2, g: 3, l: 4, w: 5,              // black -> white
+  M: 6, R: 7, r: 8, S: 9,                    // maroon, red, salmon
+  O: 10, o: 11, A: 12, y: 13, Y: 14,         // orange -> pale yellow
+  G: 15, n: 16, N: 17,                       // greens
+  T: 18, t: 19, c: 20,                       // teals / cyan
+  B: 21, b: 22, L: 23,                       // blues
+  V: 24, v: 25, e: 26,                       // indigo / periwinkle
+  P: 27, p: 28, x: 29,                       // purples
+  m: 30, f: 31, h: 32,                       // magenta / pinks
+}
+
+/** Turn rows of characters into pixels, validating the rectangle. */
+function sprite(name, rows) {
+  const w = rows[0].length
+  rows.forEach((r, i) => {
+    if (r.length !== w) {
+      throw new Error(`${name}: row ${i} is ${r.length} wide, expected ${w}\n  "${r}"`)
+    }
+    for (const ch of r) {
+      if (!(ch in C)) throw new Error(`${name}: row ${i} uses unknown colour "${ch}"`)
+    }
+  })
+  const px = []
+  rows.forEach((row, y) => {
+    [...row].forEach((ch, x) => {
+      const c = C[ch]
+      if (c !== 0) px.push([x, y, c])
+    })
+  })
+  return { name, w, h: rows.length, px }
+}
+
+/** Horizontal-stripe flag. `stripes` is [colourChar, rowCount] pairs. */
+function flag(name, width, stripes) {
+  const rows = []
+  for (const [ch, n] of stripes) for (let i = 0; i < n; i++) rows.push(ch.repeat(width))
+  return sprite(name, rows)
+}
+
+/* ── anime girls ─────────────────────────────────────────────────────────── */
+// Chibi busts, 16 wide. At 2 m per pixel each is about 32 m across — roughly
+// one building, which is the largest thing that still reads as a sprite.
+
+const pinkTwintails = sprite('pink-twintails', [
+  '.....kkkkkk.....',
+  '...kkffffffkk...',
+  '..kffffffffffk..',
+  '.kffffffffffffk.',
+  '.kffYYYYYYYYffk.',
+  'kffYYYYYYYYYYffk',
+  'kfYYYYYYYYYYYYfk',
+  'kfYYYYYYYYYYYYfk',
+  'kfYwBYYYYYYBwYfk',
+  'kfYwBYYYYYYBwYfk',
+  'kfYYYYYYYYYYYYfk',
+  'kfYhYYYkkYYYhYfk',
+  'kfYYYYYYYYYYYYfk',
+  '.kffYYYYYYYYffk.',
+  '..kkffffffffkk..',
+  'ff.kkkYYYYkkk.ff',
+  'fff..kwwwwk..fff',
+  'fff.kwwwwwwk.fff',
+  '.ffkwwwwwwwwkff.',
+  '..fkwwwwwwwwkf..',
+  '...kwwwwwwwwk...',
+  '...kkkkkkkkkk...',
+])
+
+const blueBob = sprite('blue-bob', [
+  '....kkkkkkkk....',
+  '..kkbbbbbbbbkk..',
+  '.kbbbbbbbbbbbbk.',
+  'kbbbbbbbbbbbbbbk',
+  'kbbYYYYYYYYYYbbk',
+  'kbYYYYYYYYYYYYbk',
+  'kbYYYYYYYYYYYYbk',
+  'kbYYYYYYYYYYYYbk',
+  'kbYwPYYYYYYPwYbk',
+  'kbYwPYYYYYYPwYbk',
+  'kbYYYYYYYYYYYYbk',
+  'kbYhYYYwwYYYhYbk',
+  'kbYYYYYYYYYYYYbk',
+  '.kbbYYYYYYYYbbk.',
+  '..kkbbbbbbbbkk..',
+  '..kkkkYYYYkkkk..',
+  '...kkkwwwwkkk...',
+  '..kLLwwwwwwLLk..',
+  '.kLLLwwwwwwLLLk.',
+  '.kLLLLwwwwLLLLk.',
+  '.kLLLLLLLLLLLLk.',
+  '..kkkkkkkkkkkk..',
+])
+
+const purpleLong = sprite('purple-long', [
+  '....kkkkkkkk....',
+  '..kkppppppppkk..',
+  '.kpppppppppppppk',
+  'kppppppppppppppk',
+  'kppYYYYYYYYYYppk',
+  'kpYYYYYYYYYYYYpk',
+  'kpYYYYYYYYYYYYpk',
+  'kpYYYYYYYYYYYYpk',
+  'kpYwtYYYYYYtwYpk',
+  'kpYwtYYYYYYtwYpk',
+  'kpYYYYYYYYYYYYpk',
+  'kpYhYYYkkYYYhYpk',
+  'kpYYYYYYYYYYYYpk',
+  'kppYYYYYYYYYYppk',
+  '.kppppppppppppk.',
+  'pp.kkkYYYYkkk.pp',
+  'ppp.kwwwwwwk.ppp',
+  'ppp.kwwwwwwk.ppp',
+  '.ppkwwwwwwwwkpp.',
+  '.ppkwwwwwwwwkpp.',
+  '..pkwwwwwwwwkp..',
+  '...kkkkkkkkkk...',
+])
+
+/* ── pride flags ─────────────────────────────────────────────────────────── */
+
+const FLAGS = [
+  flag('pride-rainbow', 24, [['r', 3], ['o', 3], ['y', 3], ['n', 3], ['b', 3], ['P', 3]]),
+  flag('trans', 24, [['L', 3], ['h', 3], ['w', 3], ['h', 3], ['L', 3]]),
+  flag('bisexual', 24, [['m', 6], ['v', 3], ['B', 6]]),
+  flag('lesbian', 24, [['O', 3], ['o', 3], ['w', 3], ['h', 3], ['m', 3]]),
+  flag('nonbinary', 24, [['y', 4], ['w', 4], ['v', 4], ['k', 4]]),
+  flag('pansexual', 24, [['f', 5], ['y', 5], ['c', 5]]),
+  flag('asexual', 24, [['k', 4], ['g', 4], ['w', 4], ['P', 4]]),
+  flag('progress-stripe', 24, [['k', 2], ['M', 2], ['L', 2], ['h', 2], ['w', 2],
+                               ['r', 2], ['o', 2], ['y', 2], ['n', 2], ['b', 2], ['P', 2]]),
+]
+
+/* ── placement ───────────────────────────────────────────────────────────── */
+// Anchored to real campus features so the art sits somewhere meaningful rather
+// than floating in a field. Offsets are in pixels from the anchor's centre.
+
+const PLACEMENTS = [
+  { art: pinkTwintails, at: 'New Lecture Hall Complex', dx: -34, dy: -30 },
+  { art: blueBob, at: 'Hall 5 Mess', dx: 26, dy: -34 },
+  { art: purpleLong, at: 'P K Kelkar Library', dx: 30, dy: 16 },
+
+  { art: FLAGS[0], at: 'Open Air Theatre', dx: -12, dy: -26 },
+  { art: FLAGS[1], at: 'Hall 12 Mess', dx: -12, dy: -28 },
+  { art: FLAGS[2], at: 'Hall 9 Mess', dx: -12, dy: -28 },
+  { art: FLAGS[3], at: 'Hall 2 Mess', dx: -12, dy: -30 },
+  { art: FLAGS[4], at: 'Computer Centre', dx: -12, dy: -28 },
+  { art: FLAGS[5], at: 'Health Centre', dx: -12, dy: -26 },
+  { art: FLAGS[6], at: 'Hall 3 Mess', dx: -12, dy: -28 },
+  { art: FLAGS[7], at: 'Students Gymkhana', dx: -12, dy: -26, fallback: 'Main Auditorium' },
+]
+
+const campus = JSON.parse(await readFile(join(ROOT, 'public/data/campus.json'), 'utf8'))
+const byName = new Map(campus.pois.map((p) => [p.name, p]))
+
+const board = new Map() // "x,y" -> colour, so later art wins on overlap
+const placed = []
+const warnings = []
+
+for (const { art, at, dx, dy, fallback } of PLACEMENTS) {
+  const poi = byName.get(at) ?? (fallback ? byName.get(fallback) : undefined)
+  if (!poi) { warnings.push(`no anchor "${at}" — skipped ${art.name}`); continue }
+
+  const centre = G.lonLatToPixel(poi.lon, poi.lat)
+  const ox = centre.x + dx
+  const oy = centre.y + dy
+
+  let clipped = 0
+  for (const [px, py, c] of art.px) {
+    const x = ox + px, y = oy + py
+    if (!G.inBounds(x, y)) { clipped++; continue }
+    board.set(`${x},${y}`, c)
+  }
+  if (clipped) warnings.push(`${art.name}: ${clipped}px fell outside the grid`)
+  placed.push({ name: art.name, at: poi.name, x: ox, y: oy, w: art.w, h: art.h })
+}
+
+const pixels = [...board].map(([k, c]) => {
+  const [x, y] = k.split(',')
+  return [+x, +y, c]
+})
+
+const payload = {
+  _note: 'Seeded artwork, baked at build time. Not user data and not stored in KV.',
+  _author: 'nisarga@cse.iitk.ac.in',
+  grid: { w: G.GRID_W, h: G.GRID_H, pixelMetres: G.PIXEL_M, chunk: G.CHUNK },
+  placed,
+  pixels,
+}
+
+await mkdir(OUT, { recursive: true })
+await writeFile(join(OUT, 'pixels-seed.json'), JSON.stringify(payload))
+
+console.log(`seed art: ${placed.length} pieces, ${pixels.length} pixels`)
+for (const p of placed) {
+  console.log(`  ${p.name.padEnd(18)} ${String(p.w).padStart(2)}x${String(p.h).padStart(2)}  at ${p.at}`)
+}
+console.log(`output   ${(JSON.stringify(payload).length / 1024).toFixed(1)} kB`)
+if (warnings.length) {
+  console.log(`\n${warnings.length} warning(s):`)
+  for (const w of warnings) console.log(`  ! ${w}`)
+}

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -155,6 +155,60 @@ const t0 = performance.now()
 for (let i = 0; i < 30; i++) router.route(centre, pinned[i % pinned.length], 'foot')
 ok((performance.now() - t0) / 30 < 40, `route latency ${((performance.now() - t0) / 30).toFixed(1)}ms`)
 
+/* ── pixel canvas ────────────────────────────────────────────────────────── */
+
+console.log('\npixels')
+const PX_TMP = join(ROOT, 'node_modules/.cache/smoke-pixels.mjs')
+await build({
+  entryPoints: [join(ROOT, 'src/pixels/grid.ts')],
+  bundle: true, format: 'esm', platform: 'node', outfile: PX_TMP, logLevel: 'silent',
+})
+const PX = await import(PX_TMP + `?t=${Date.now()}`)
+const seed = JSON.parse(await readFile(join(ROOT, 'public/data/pixels-seed.json'), 'utf8'))
+
+// The grid maths is duplicated across the browser, the seed script and the
+// Functions. If it ever drifts, every stored pixel silently moves.
+//
+// The property that matters is that a pixel id survives a round trip exactly.
+// `pixelToLonLat` returns the north-west corner, so a *point* inside a cell can
+// sit up to one diagonal from it — that is the geometry, not an error.
+let idBad = 0
+for (let i = 0; i < 500; i++) {
+  const x = (i * 37) % PX.GRID_W, y = (i * 53) % PX.GRID_H
+  const [lon, lat] = PX.pixelToLonLat(x, y)
+  const back = PX.lonLatToPixel(lon + 1e-9, lat - 1e-9)
+  if (back.x !== x || back.y !== y) idBad++
+}
+ok(idBad === 0, 'pixel ids survive a lon/lat round trip exactly', `${idBad} drifted`)
+
+const diagonal = PX.PIXEL_M * Math.SQRT2
+let worst = 0
+for (const p of campus.pois.slice(0, 200)) {
+  const px = PX.lonLatToPixel(p.lon, p.lat)
+  const [lon, lat] = PX.pixelToLonLat(px.x, px.y)
+  worst = Math.max(worst, Math.hypot((lat - p.lat) * 111320, (lon - p.lon) * 99600))
+}
+ok(worst <= diagonal, `points land inside their cell (worst ${worst.toFixed(2)}m of ${diagonal.toFixed(2)}m)`)
+
+ok(seed.pixels.length > 1000, `seed art present (${seed.pixels.length} pixels)`)
+ok(seed.placed.length >= 10, `${seed.placed.length} seeded pieces`)
+
+const bad = seed.pixels.filter(([x, y, c]) =>
+  !PX.inBounds(x, y) || !Number.isInteger(c) || c <= 0 || c >= PX.PALETTE.length)
+ok(bad.length === 0, 'every seed pixel is in bounds with a real colour',
+   bad.length ? `${bad.length} bad, e.g. ${JSON.stringify(bad[0])}` : '')
+
+// Seed must agree with the grid it was generated against.
+ok(seed.grid.w === PX.GRID_W && seed.grid.h === PX.GRID_H,
+   'seed matches the current grid dimensions',
+   `${seed.grid.w}x${seed.grid.h} vs ${PX.GRID_W}x${PX.GRID_H} — rerun build:data`)
+
+const packed = PX.packChunk([{ x: 1, y: 2, c: 3 }, { x: 4, y: 5, c: 6 }])
+const round = PX.unpackChunk(packed)
+ok(round.length === 2 && round[1].c === 6, 'chunk pack/unpack round-trips', packed)
+
+await rm(PX_TMP, { force: true })
+
 /* ── map style ───────────────────────────────────────────────────────────── */
 
 // MapLibre validates the style at runtime and refuses to render if it is
@@ -191,8 +245,14 @@ for (const theme of ['dark', 'light']) {
 // non-null assertions hide the mismatch from tsc, and the failure surfaces at
 // runtime as "Cannot set properties of null" — i.e. a blank page.
 console.log('\ndom')
-const html = await readFile(join(ROOT, 'index.html'), 'utf8')
-const present = new Set([...html.matchAll(/\sid="([^"]+)"/g)].map((m) => m[1]))
+
+// Two pages now, each with its own markup. src/pixels/* belongs to the canvas
+// page; everything else to the map page. Checking against the union would let
+// a genuine mismatch through.
+const PAGES = [
+  { html: 'index.html', src: (f) => !f.includes('/src/pixels/') },
+  { html: 'pixels/index.html', src: (f) => f.includes('/src/pixels/') },
+]
 
 const srcDir = join(ROOT, 'src')
 const walk = async (dir) => {
@@ -204,24 +264,30 @@ const walk = async (dir) => {
   }
   return out
 }
-
-const wanted = new Map() // id -> file
-for (const file of await walk(srcDir)) {
-  const code = await readFile(file, 'utf8')
-  for (const m of code.matchAll(/getElementById\(\s*['"]([^'"]+)['"]/g)) {
-    if (!wanted.has(m[1])) wanted.set(m[1], file.replace(ROOT + '/', ''))
-  }
-  for (const m of code.matchAll(/querySelector(?:All)?\(\s*['"]#([A-Za-z0-9_-]+)['"]/g)) {
-    if (!wanted.has(m[1])) wanted.set(m[1], file.replace(ROOT + '/', ''))
-  }
-}
+const allSrc = await walk(srcDir)
 
 // Elements the app creates at runtime rather than declaring in the markup.
 const RUNTIME_IDS = new Set(['route-badge'])
 
-const orphans = [...wanted].filter(([id]) => !present.has(id) && !RUNTIME_IDS.has(id))
-ok(orphans.length === 0, `all ${wanted.size} referenced ids exist in index.html`,
-   orphans.map(([id, f]) => `#${id} (${f})`).join(', '))
+for (const page of PAGES) {
+  const html = await readFile(join(ROOT, page.html), 'utf8')
+  const present = new Set([...html.matchAll(/\sid="([^"]+)"/g)].map((m) => m[1]))
+
+  const wanted = new Map()
+  for (const file of allSrc.filter(page.src)) {
+    const code = await readFile(file, 'utf8')
+    for (const m of code.matchAll(/getElementById\(\s*['"]([^'"]+)['"]/g)) {
+      if (!wanted.has(m[1])) wanted.set(m[1], file.replace(ROOT + '/', ''))
+    }
+    for (const m of code.matchAll(/querySelector(?:All)?\(\s*['"]#([A-Za-z0-9_-]+)['"]/g)) {
+      if (!wanted.has(m[1])) wanted.set(m[1], file.replace(ROOT + '/', ''))
+    }
+  }
+
+  const orphans = [...wanted].filter(([id]) => !present.has(id) && !RUNTIME_IDS.has(id))
+  ok(orphans.length === 0, `${page.html}: all ${wanted.size} referenced ids exist`,
+     orphans.map(([id, f]) => `#${id} (${f})`).join(', '))
+}
 
 await rm(TMP, { force: true })
 await rm(ROUTER_TMP, { force: true })

--- a/src/pixels/grid.ts
+++ b/src/pixels/grid.ts
@@ -1,0 +1,99 @@
+/**
+ * The pixel grid laid over campus.
+ *
+ * One fixed grid, anchored to the campus bounding box, so a pixel means the
+ * same square of ground for everyone regardless of zoom or device. Coordinates
+ * are integer (x, y) from the north-west corner.
+ *
+ * Shared verbatim by three places — the seed generator, the browser and the
+ * Pages Functions — so the maths can never drift between them.
+ */
+
+/** North-west anchor of the grid. Matches the Overpass bbox in fetch-osm.mjs. */
+export const ORIGIN = { lat: 26.5265, lon: 80.2180 } as const
+export const SOUTH_EAST = { lat: 26.4995, lon: 80.2480 } as const
+
+/** Metres per pixel. 2 m reads as chunky pixel art at building scale. */
+export const PIXEL_M = 2
+
+const M_PER_DEG_LAT = 111_320
+/** Campus sits at ~26.5°N; cos(26.5°) ≈ 0.8949. */
+const M_PER_DEG_LON = 111_320 * Math.cos((26.51 * Math.PI) / 180)
+
+export const GRID_W = Math.ceil(((SOUTH_EAST.lon - ORIGIN.lon) * M_PER_DEG_LON) / PIXEL_M)
+export const GRID_H = Math.ceil(((ORIGIN.lat - SOUTH_EAST.lat) * M_PER_DEG_LAT) / PIXEL_M)
+
+/** Chunk size in pixels. Storage and fetches are per chunk, never per pixel. */
+export const CHUNK = 128
+export const CHUNKS_X = Math.ceil(GRID_W / CHUNK)
+export const CHUNKS_Y = Math.ceil(GRID_H / CHUNK)
+
+export function lonLatToPixel(lon: number, lat: number): { x: number; y: number } {
+  return {
+    x: Math.floor(((lon - ORIGIN.lon) * M_PER_DEG_LON) / PIXEL_M),
+    y: Math.floor(((ORIGIN.lat - lat) * M_PER_DEG_LAT) / PIXEL_M),
+  }
+}
+
+/** North-west corner of a pixel, in lon/lat. */
+export function pixelToLonLat(x: number, y: number): [number, number] {
+  return [
+    ORIGIN.lon + (x * PIXEL_M) / M_PER_DEG_LON,
+    ORIGIN.lat - (y * PIXEL_M) / M_PER_DEG_LAT,
+  ]
+}
+
+export const inBounds = (x: number, y: number) =>
+  Number.isInteger(x) && Number.isInteger(y) && x >= 0 && y >= 0 && x < GRID_W && y < GRID_H
+
+export const chunkOf = (x: number, y: number) =>
+  ({ cx: Math.floor(x / CHUNK), cy: Math.floor(y / CHUNK) })
+
+export const chunkKey = (cx: number, cy: number) => `c:${cx}:${cy}`
+
+/**
+ * Fixed 32-colour palette. Pixels store an index, so a pixel is one byte on
+ * the wire and nobody can inject arbitrary colours. Index 0 is "erase".
+ */
+export const PALETTE: readonly string[] = [
+  'transparent',
+  '#000000', '#3c3c3c', '#787878', '#d2d2d2', '#ffffff',
+  '#600018', '#a50e1e', '#ed1c24', '#fa8072',
+  '#e45c1a', '#ff7f27', '#f6aa09', '#f9dd3b', '#fffabc',
+  '#0eb968', '#13e67b', '#87ff5e',
+  '#0c816e', '#10aea6', '#60f7f2',
+  '#28509e', '#4093e4', '#7dc7ff',
+  '#4a4284', '#7a71c4', '#b5aef1',
+  '#780c99', '#aa38b9', '#e09ff9',
+  '#cb007a', '#ec1f80', '#f38da9',
+] as const
+
+export const TRANSPARENT = 0
+
+export interface Pixel {
+  x: number
+  y: number
+  /** Index into PALETTE. */
+  c: number
+}
+
+/**
+ * Chunks are stored as a flat "x,y,c" triple list rather than a dense array —
+ * the canvas is overwhelmingly empty, so a sparse list is far smaller than
+ * 128×128 bytes per chunk and survives JSON round-tripping unchanged.
+ */
+export function packChunk(pixels: Iterable<Pixel>): string {
+  const out: number[] = []
+  for (const p of pixels) out.push(p.x, p.y, p.c)
+  return out.join(',')
+}
+
+export function unpackChunk(packed: string): Pixel[] {
+  if (!packed) return []
+  const n = packed.split(',')
+  const out: Pixel[] = []
+  for (let i = 0; i + 2 < n.length; i += 3) {
+    out.push({ x: +n[i]!, y: +n[i + 1]!, c: +n[i + 2]! })
+  }
+  return out
+}

--- a/src/pixels/main.ts
+++ b/src/pixels/main.ts
@@ -1,0 +1,301 @@
+import '../styles.css'
+import './pixels.css'
+import maplibregl from 'maplibre-gl'
+import type { Campus } from '../types'
+import { buildStyle } from '../map/style'
+import { toggle as toggleTheme, onThemeChange, resolved } from '../ui/theme'
+import {
+  GRID_W, GRID_H, PALETTE, TRANSPARENT,
+  lonLatToPixel, pixelToLonLat, inBounds, unpackChunk,
+} from './grid'
+
+const base = import.meta.env.BASE_URL
+const boot = document.getElementById('boot')!
+const statusEl = document.getElementById('px-status')!
+const budgetEl = document.getElementById('px-budget')!
+const hintEl = document.getElementById('px-hint')!
+
+/** Below this zoom a pixel is under ~4 screen px — too small to aim at. */
+const PAINT_ZOOM = 16.5
+
+async function json<T>(url: string): Promise<T> {
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`${url}: HTTP ${res.status}`)
+  return res.json() as Promise<T>
+}
+
+async function start() {
+  const [campus, geo, seed] = await Promise.all([
+    json<Campus>(`${base}data/campus.json`),
+    json<Record<string, GeoJSON.FeatureCollection>>(`${base}data/geo.json`),
+    json<{ pixels: [number, number, number][] }>(`${base}data/pixels-seed.json`),
+  ])
+
+  /* ── board state ──────────────────────────────────────────────────────── */
+  // One flat byte per grid cell. 2.2 MB, allocated once, and lookups are a
+  // single index — far cheaper per frame than a Map of a few thousand keys.
+  const board = new Uint8Array(GRID_W * GRID_H)
+  const idx = (x: number, y: number) => y * GRID_W + x
+
+  for (const [x, y, c] of seed.pixels) if (inBounds(x, y)) board[idx(x, y)] = c
+
+  /** Seed is the floor; server chunks paint over it. */
+  function applyChunks(chunks: Record<string, string>) {
+    for (const packed of Object.values(chunks)) {
+      for (const p of unpackChunk(packed)) {
+        if (inBounds(p.x, p.y)) board[idx(p.x, p.y)] = p.c
+      }
+    }
+  }
+
+  let burst = 30
+  let remaining = 30
+  let cooldownUntil = 0
+  let live = false
+
+  try {
+    const server = await json<{
+      burst: number; cooldown: number; chunks: Record<string, string>
+    }>(`${base}api/pixels`)
+    applyChunks(server.chunks)
+    burst = server.burst
+    remaining = server.burst
+    live = true
+  } catch {
+    // No Functions binding (local `vite preview`, or KV not wired up yet).
+    // The seed still renders, painting is just disabled.
+    live = false
+  }
+
+  /* ── map ──────────────────────────────────────────────────────────────── */
+
+  const map = new maplibregl.Map({
+    container: 'map',
+    style: buildStyle(geo, campus, resolved(), base),
+    center: campus.meta.center,
+    zoom: 15.6,
+    minZoom: 13,
+    maxZoom: 20,
+    maxBounds: [[80.205, 26.487], [80.262, 26.539]],
+    attributionControl: false,
+    dragRotate: false,
+    pitchWithRotate: false,
+  })
+  map.touchZoomRotate.disableRotation()
+  ;(window as unknown as { __map: maplibregl.Map }).__map = map
+  map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'bottom-right')
+
+  /* ── canvas overlay ───────────────────────────────────────────────────── */
+
+  const cv = document.getElementById('pixel-canvas') as HTMLCanvasElement
+  const g = cv.getContext('2d')!
+  let dpr = Math.min(devicePixelRatio || 1, 2)
+
+  function resize() {
+    dpr = Math.min(devicePixelRatio || 1, 2)
+    cv.width = Math.floor(innerWidth * dpr)
+    cv.height = Math.floor(innerHeight * dpr)
+    cv.style.width = `${innerWidth}px`
+    cv.style.height = `${innerHeight}px`
+  }
+  resize()
+  addEventListener('resize', resize)
+
+  let hover: { x: number; y: number } | null = null
+
+  function draw() {
+    g.setTransform(dpr, 0, 0, dpr, 0, 0)
+    g.clearRect(0, 0, innerWidth, innerHeight)
+
+    // Only walk the grid cells actually on screen.
+    const b = map.getBounds()
+    const nw = lonLatToPixel(b.getWest(), b.getNorth())
+    const se = lonLatToPixel(b.getEast(), b.getSouth())
+    const x0 = Math.max(0, nw.x - 1), y0 = Math.max(0, nw.y - 1)
+    const x1 = Math.min(GRID_W - 1, se.x + 1), y1 = Math.min(GRID_H - 1, se.y + 1)
+    if (x1 < x0 || y1 < y0) return
+
+    // A whole-grid sweep at low zoom would be millions of cells per frame.
+    if ((x1 - x0) * (y1 - y0) > 400_000) return
+
+    const [lonA, latA] = pixelToLonLat(x0, y0)
+    const [lonB, latB] = pixelToLonLat(x0 + 1, y0 + 1)
+    const a = map.project([lonA, latA])
+    const bb = map.project([lonB, latB])
+    const sw = Math.abs(bb.x - a.x)
+    const sh = Math.abs(bb.y - a.y)
+    if (sw < 0.6) return // sub-pixel: nothing legible to draw
+
+    for (let y = y0; y <= y1; y++) {
+      for (let x = x0; x <= x1; x++) {
+        const c = board[idx(x, y)]!
+        if (c === TRANSPARENT) continue
+        const [lon, lat] = pixelToLonLat(x, y)
+        const pt = map.project([lon, lat])
+        g.fillStyle = PALETTE[c]!
+        // +1 closes the hairline seams between adjacent cells.
+        g.fillRect(pt.x, pt.y, sw + 1, sh + 1)
+      }
+    }
+
+    if (hover && sw >= 4) {
+      const [lon, lat] = pixelToLonLat(hover.x, hover.y)
+      const pt = map.project([lon, lat])
+      g.strokeStyle = resolved() === 'dark' ? '#ffffff' : '#000000'
+      g.lineWidth = 1.5
+      g.strokeRect(pt.x + 0.5, pt.y + 0.5, sw, sh)
+    }
+  }
+
+  map.on('render', draw)
+  map.on('move', draw)
+
+  /* ── palette ──────────────────────────────────────────────────────────── */
+
+  let colour = 8 // red
+  let erasing = false
+
+  const palEl = document.getElementById('px-palette')!
+  // Transparent is a first-class colour, not a mode. Anyone can pick it and
+  // rub out anyone else's work — same rate limit, no special standing.
+  palEl.innerHTML = PALETTE
+    .map((hex, i) => i === TRANSPARENT
+      ? `<button class="sw sw-erase" role="radio" data-c="0" aria-checked="false"
+           title="Eraser — clears whatever is there"></button>`
+      : `<button class="sw" role="radio" data-c="${i}" aria-checked="${i === colour}"
+           style="background:${hex}" title="${hex}"></button>`)
+    .join('')
+
+  function paintSwatches() {
+    palEl.querySelectorAll<HTMLElement>('.sw').forEach((s) => {
+      const c = +s.dataset.c!
+      s.setAttribute('aria-checked', String(c === TRANSPARENT ? erasing : !erasing && c === colour))
+    })
+    eraseBtn.setAttribute('aria-pressed', String(erasing))
+  }
+
+  palEl.addEventListener('click', (e) => {
+    const sw = (e.target as HTMLElement).closest('.sw') as HTMLElement | null
+    if (!sw) return
+    const c = +sw.dataset.c!
+    if (c === TRANSPARENT) { erasing = true } else { colour = c; erasing = false }
+    paintSwatches()
+  })
+
+  const eraseBtn = document.getElementById('px-erase')!
+  eraseBtn.addEventListener('click', () => { erasing = !erasing; paintSwatches() })
+  paintSwatches()
+
+  /* ── painting ─────────────────────────────────────────────────────────── */
+
+  function setStatus(text: string, tone: '' | 'warn' | 'bad' = '') {
+    statusEl.textContent = text
+    statusEl.className = tone
+  }
+
+  function updateBudget() {
+    if (!live) { budgetEl.textContent = ''; return }
+    const left = Math.max(0, cooldownUntil - Date.now())
+    budgetEl.textContent = left > 0
+      ? `cooldown ${Math.ceil(left / 1000)}s`
+      : `${remaining}/${burst} left`
+  }
+  setInterval(updateBudget, 500)
+
+  function updateHint() {
+    const zoomedOut = map.getZoom() < PAINT_ZOOM
+    hintEl.hidden = !zoomedOut
+    document.body.classList.toggle('can-paint', !zoomedOut && live)
+  }
+  map.on('zoom', updateHint)
+
+  /** Queue writes so a fast drag becomes one request, not twelve. */
+  const queue: { x: number; y: number; c: number }[] = []
+  let flushTimer: ReturnType<typeof setTimeout> | undefined
+
+  async function flush() {
+    flushTimer = undefined
+    if (!queue.length) return
+    const batch = queue.splice(0, 12)
+    try {
+      const res = await fetch(`${base}api/pixels/paint`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ pixels: batch.map((p) => [p.x, p.y, p.c]) }),
+      })
+      const data = await res.json() as {
+        error?: string; remaining?: number; cooldownUntil?: number | null
+      }
+      if (!res.ok) {
+        // The server rejected them, so roll the optimistic paint back.
+        for (const p of batch) board[idx(p.x, p.y)] = 0
+        draw()
+        if (typeof data.cooldownUntil === 'number') cooldownUntil = data.cooldownUntil
+        if (typeof data.remaining === 'number') remaining = data.remaining
+        setStatus(data.error ?? 'rejected', res.status === 429 ? 'warn' : 'bad')
+      } else {
+        remaining = data.remaining ?? remaining
+        cooldownUntil = data.cooldownUntil ?? 0
+        setStatus('painting', '')
+      }
+    } catch {
+      setStatus('offline — pixel not saved', 'bad')
+    }
+    updateBudget()
+    if (queue.length) flushTimer = setTimeout(flush, 250)
+  }
+
+  function place(lngLat: maplibregl.LngLat) {
+    if (!live) { setStatus('read-only: canvas API not reachable', 'warn'); return }
+    if (map.getZoom() < PAINT_ZOOM) return
+    if (cooldownUntil > Date.now()) return
+
+    const { x, y } = lonLatToPixel(lngLat.lng, lngLat.lat)
+    if (!inBounds(x, y)) return
+    const c = erasing ? TRANSPARENT : colour
+    if (board[idx(x, y)] === c) return
+
+    board[idx(x, y)] = c            // optimistic: show it immediately
+    draw()
+    queue.push({ x, y, c })
+    if (!flushTimer) flushTimer = setTimeout(flush, 180)
+  }
+
+  map.on('click', (e) => place(e.lngLat))
+
+  map.on('mousemove', (e) => {
+    const { x, y } = lonLatToPixel(e.lngLat.lng, e.lngLat.lat)
+    const next = inBounds(x, y) ? { x, y } : null
+    if (next?.x !== hover?.x || next?.y !== hover?.y) { hover = next; draw() }
+  })
+  map.on('mouseout', () => { hover = null; draw() })
+
+  /* ── chrome ───────────────────────────────────────────────────────────── */
+
+  const themeBtn = document.getElementById('theme-btn')!
+  const paintTheme = () => {
+    const dark = resolved() === 'dark'
+    themeBtn.textContent = dark ? '☾' : '☀'
+    themeBtn.title = dark ? 'Switch to light' : 'Switch to dark'
+  }
+  paintTheme()
+  themeBtn.addEventListener('click', () => { toggleTheme(); paintTheme() })
+  onThemeChange((t) => {
+    map.setStyle(buildStyle(geo, campus, t, base))
+    map.once('styledata', draw)
+  })
+
+  map.on('load', () => {
+    boot.classList.add('gone')
+    updateHint()
+    updateBudget()
+    setStatus(live ? `${GRID_W}×${GRID_H} grid · 2 m per pixel` : 'read-only preview', live ? '' : 'warn')
+    draw()
+  })
+}
+
+start().catch((err) => {
+  console.error(err)
+  boot.className = 'err'
+  boot.textContent = `Could not load the canvas — ${err.message}`
+})

--- a/src/pixels/pixels.css
+++ b/src/pixels/pixels.css
@@ -1,0 +1,144 @@
+/* /pixels — canvas overlay, palette dock. Inherits every token from styles.css. */
+
+#pixel-canvas {
+  position: fixed;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;      /* the map underneath handles all input */
+  image-rendering: pixelated;
+}
+
+body.pixels #bar { align-items: center; }
+
+#brand-btn {
+  text-decoration: none;
+  flex: none;
+}
+
+#px-status {
+  flex: 1;
+  text-align: center;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--fg-3);
+  text-shadow: 0 0 3px var(--halo), 0 0 7px var(--halo), 0 0 12px var(--halo);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+#px-status.warn { color: var(--warn, #ffb454); }
+#px-status.bad { color: var(--danger); }
+
+/* Painting is a deliberate act — the crosshair only appears when a click will
+   actually land a pixel. */
+body.can-paint .maplibregl-canvas { cursor: crosshair; }
+
+#px-hint {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 6;
+  padding: 9px 15px;
+  background: var(--bg-1);
+  border: 1px solid var(--line-2);
+  border-radius: var(--r);
+  box-shadow: var(--lift);
+  font-size: 13px;
+  color: var(--fg-2);
+  pointer-events: none;
+}
+#px-hint[hidden] { display: none; }
+
+/* ── palette dock ────────────────────────────────────────────────────────── */
+
+#px-dock {
+  position: fixed;
+  left: var(--pad);
+  right: var(--pad);
+  bottom: var(--pad);
+  z-index: 7;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+#px-palette {
+  display: grid;
+  grid-template-columns: repeat(16, 1fr);
+  gap: 3px;
+  padding: 7px;
+  background: var(--bg-1);
+  border: 1px solid var(--line-2);
+  border-radius: 7px;
+  box-shadow: var(--lift);
+  max-width: min(560px, 100%);
+}
+
+.sw {
+  width: 24px;
+  height: 24px;
+  border-radius: 3px;
+  border: 1px solid rgba(128, 128, 128, .35);
+  cursor: pointer;
+  padding: 0;
+}
+.sw[aria-checked="true"] {
+  outline: 2px solid var(--fg);
+  outline-offset: 1px;
+}
+
+/* The eraser reads as a checkerboard — the universal "nothing here" swatch. */
+.sw-erase {
+  background-color: #fff;
+  background-image:
+    linear-gradient(45deg, #9aa4b2 25%, transparent 25%, transparent 75%, #9aa4b2 75%),
+    linear-gradient(45deg, #9aa4b2 25%, transparent 25%, transparent 75%, #9aa4b2 75%);
+  background-size: 10px 10px;
+  background-position: 0 0, 5px 5px;
+}
+
+#px-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 11px;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: var(--r);
+  font-size: 12px;
+  color: var(--fg-2);
+}
+#px-erase {
+  padding: 4px 9px;
+  border: 1px solid var(--line-2);
+  border-radius: 4px;
+  color: var(--fg-2);
+  font-size: 12px;
+}
+#px-erase[aria-pressed="true"] { color: var(--bg); background: var(--fg); border-color: var(--fg); }
+#px-budget { font-family: var(--mono); font-size: 11px; color: var(--fg-3); min-width: 9ch; text-align: center; }
+#px-src { color: var(--fg-3); text-decoration: none; }
+#px-src:hover { color: var(--accent); }
+
+/* Sits inside the actions bar, so it needs no surface of its own — unlike the
+   map page, where the byline floats directly over the tiles. */
+#px-actions .by { color: var(--fg-3); white-space: nowrap; }
+#px-actions .by a {
+  color: var(--fg-2);
+  text-decoration: none;
+  border-bottom: 1px solid var(--line-2);
+}
+#px-actions .by a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+@media (max-width: 420px) {
+  #px-actions .by { display: none; }
+}
+
+@media (max-width: 760px), (pointer: coarse) and (max-width: 900px) {
+  #px-palette { grid-template-columns: repeat(8, 1fr); }
+  .sw { width: 30px; height: 30px; }   /* thumb-sized */
+  #px-dock { gap: 6px; bottom: calc(var(--pad) + env(safe-area-inset-bottom)); }
+  #px-status { font-size: 10px; }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -154,6 +154,20 @@ kbd {
 }
 #open-search:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
+/* The way into /pixels. A pixel-art face, so it says what it is without a
+   label — the only decorative thing in the chrome, and it earns it. */
+#pixels-btn {
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: 30px; height: 30px;
+  border-radius: var(--r);
+  filter: saturate(.85);
+  transition: transform .12s ease, filter .12s ease;
+}
+#pixels-btn:hover { filter: saturate(1.15); transform: translateY(-1px) scale(1.06); }
+#pixels-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
 #theme-btn {
   flex: none;
   width: 26px; height: 26px;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, type Plugin } from 'vite'
+import { resolve } from 'node:path'
 
 /**
  * Vite stamps `crossorigin` on the emitted <script> and <link rel=stylesheet>.
@@ -22,5 +23,16 @@ function noCrossorigin(): Plugin {
 export default defineConfig({
   plugins: [noCrossorigin()],
   server: { port: 5180, open: false },
-  build: { target: 'es2022', chunkSizeWarningLimit: 1200 },
+  build: {
+    target: 'es2022',
+    chunkSizeWarningLimit: 1200,
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        // Its own entry point, so the map page does not carry the canvas code
+        // and vice versa. Emits dist/pixels/index.html, served at /pixels.
+        pixels: resolve(__dirname, 'pixels/index.html'),
+      },
+    },
+  },
 })


### PR DESCRIPTION
`/pixels` — a shared canvas laid over campus. Fixed grid at **2 m per pixel**,
1495 × 1503 cells, open to anyone, reachable from the pixel-art face in the
top bar.

Seeded with 11 pieces anchored to real buildings: eight pride flags and three
chibi characters, ~4,000 pixels. The seed is a **static file, not storage** —
the canvas is never blank, and `clearAll` cannot wipe it.

### This is the first backend in the repo

Everything so far was static. A shared canvas cannot be: Discord webhooks are
write-only, so "log it to Discord and skip the database" does not survive a
page reload. It uses Cloudflare Pages Functions + a KV namespace — no schema,
no server, already part of the Pages project.

| Binding | Purpose |
|---|---|
| `PIXELS` (KV) | canvas chunks, rate limits, bans, log buffer |
| `DISCORD_WEBHOOK` (secret) | pixel log, server-side only |
| `PIXELS_ADMIN_TOKEN` (secret) | admin route |

Without the KV binding the page still renders the seed read-only, so a missing
binding degrades instead of breaking. That is also what you get under
`vite preview`, which does not run Functions.

### Abuse handling

No login, so limits key off the client IP: **30 pixels, then a 60 s cooldown**,
12 pixels per request max.

The client is not trusted — position, colour index and remaining budget are all
re-checked server-side, so a crafted request cannot paint out of bounds, invent
a colour, or skip the cooldown. Rejected writes roll the optimistic paint back.

**No IP is ever stored or logged.** Rate limits, bans and the Discord log key
off a 10-character hash of it: enough to moderate with, useless for identifying
anyone off-platform.

Pixels are logged in **batches of 25**, not one message each. A Discord webhook
allows a handful of posts per second; per-pixel messages would be throttled into
uselessness the moment two people drew at once.

### Erasing

Transparent is a first-class swatch, not a mode. Anyone can pick it and rub out
anyone else's work under the same rate limit — no special standing. The
checkerboard swatch and the `Erase` button drive the same state.

### Notes

- One `Uint8Array(GRID_W * GRID_H)` for the board — 2.2 MB allocated once, one
  index per lookup, versus a Map of thousands of keys on every frame. Only the
  cells actually on screen are drawn, and drawing bails out below ~0.6 px/cell.
- Painting is gated to zoom ≥ 16.5; below that a pixel is too small to aim at.
- Vite is multi-page now, so the map page does not carry canvas code or vice
  versa.
- Smoke tests cover grid round-tripping, seed integrity and chunk packing. The
  DOM-contract check is per-page now — checking against the union of both pages
  would let a real mismatch through.

**Known limit:** KV is eventually consistent with no transactions, so two people
painting the same 128 × 128 chunk within a second can lose one write. Fine for a
campus toy; a Durable Object per chunk is the fix if it gets busy.