### PR TITLE
feat(pixels): god-mode admin dashboard

### DIFF
--- a/functions/api/pixels/[[path]].ts
+++ b/functions/api/pixels/[[path]].ts
@@ -138,6 +138,36 @@ async function logPixels(env: Env, who: string, pixels: Pixel[], note = '') {
   }).catch(() => { /* logging must never break painting */ })
 }
 
+/* ── attribution ─────────────────────────────────────────────────────────── */
+
+/**
+ * A bounded record of who painted what, so a moderator can click a pixel and
+ * ban whoever put it there. Deliberately short-lived and capped: it is a
+ * moderation aid, not a history of the canvas.
+ */
+const RECENT_MAX = 600
+
+async function rememberPainter(env: Env, who: string, pixels: Pixel[]) {
+  const raw = await env.PIXELS.get('recent')
+  const list = raw ? (JSON.parse(raw) as [number, number, string, number][]) : []
+  for (const p of pixels) list.push([p.x, p.y, who, Date.now()])
+  if (list.length > RECENT_MAX) list.splice(0, list.length - RECENT_MAX)
+  await env.PIXELS.put('recent', JSON.stringify(list))
+}
+
+async function painterAt(env: Env, x: number, y: number) {
+  const raw = await env.PIXELS.get('recent')
+  if (!raw) return null
+  const list = JSON.parse(raw) as [number, number, string, number][]
+  // Last write wins, so walk backwards.
+  for (let i = list.length - 1; i >= 0; i--) {
+    if (list[i]![0] === x && list[i]![1] === y) {
+      return { id: list[i]![2], at: list[i]![3] }
+    }
+  }
+  return null
+}
+
 /* ── routes ──────────────────────────────────────────────────────────────── */
 
 export const onRequest: PagesFunction<Env> = async (ctx) => {
@@ -212,6 +242,7 @@ export const onRequest: PagesFunction<Env> = async (ctx) => {
 
     await applyPixels(env, pixels)
     ctx.waitUntil(logPixels(env, who, pixels))
+    ctx.waitUntil(rememberPainter(env, who, pixels))
 
     return json({
       ok: true,
@@ -293,6 +324,21 @@ export const onRequest: PagesFunction<Env> = async (ctx) => {
         else await env.PIXELS.delete(`ban:${id}`)
         ctx.waitUntil(logPixels(env, 'ADMIN', [], `${op} ${id} `))
         return json({ ok: true, op, id })
+      }
+
+      /* Who painted this pixel — powers click-to-ban in the admin UI. */
+      case 'who': {
+        const x = Number(body.x) | 0, y = Number(body.y) | 0
+        if (!inBounds(x, y)) return json({ error: 'out of bounds' }, 400)
+        const hit = await painterAt(env, x, y)
+        return json({ ok: true, x, y, painter: hit })
+      }
+
+      /* Recent activity feed for the dashboard. */
+      case 'recent': {
+        const raw = await env.PIXELS.get('recent')
+        const list = raw ? (JSON.parse(raw) as [number, number, string, number][]) : []
+        return json({ ok: true, recent: list.slice(-120).reverse() })
       }
 
       case 'bans': {

--- a/src/pixels/admin.ts
+++ b/src/pixels/admin.ts
@@ -1,0 +1,203 @@
+/**
+ * God mode for the pixel canvas.
+ *
+ * Same page, same tools, same map — moderation is done by painting, not by
+ * curling an API. Unlocking swaps the write path from /paint to /admin, which
+ * skips the rate limit and unlocks bulk operations.
+ *
+ * The token lives in sessionStorage only: it dies with the tab, so an unlocked
+ * dashboard is never left lying around on a shared machine.
+ */
+
+const KEY = 'campusmap.pixels.admin'
+
+export type Tool = 'paint' | 'rect-erase' | 'rect-fill' | 'inspect'
+
+export interface AdminHost {
+  /** Repaint the overlay after a bulk change. */
+  redraw(): void
+  /** Write straight into the local board without going through the queue. */
+  setLocal(x: number, y: number, c: number): void
+  /** Reload the canvas from the server. */
+  reload(): Promise<void>
+  status(text: string, tone?: '' | 'warn' | 'bad'): void
+  currentColour(): number
+}
+
+export class Admin {
+  token: string | null = null
+  tool: Tool = 'paint'
+  private host: AdminHost
+  private panel: HTMLElement
+  private base: string
+
+  constructor(host: AdminHost, base: string) {
+    this.host = host
+    this.base = base
+    this.token = sessionStorage.getItem(KEY)
+
+    this.panel = document.createElement('aside')
+    this.panel.id = 'px-admin'
+    this.panel.hidden = true
+    document.body.append(this.panel)
+    this.panel.addEventListener('click', (e) => this.onClick(e))
+
+    // Ctrl+Shift+A, or ?admin in the URL. Deliberately undiscoverable — there
+    // is no button for people to find and poke at.
+    addEventListener('keydown', (e) => {
+      if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'a') {
+        e.preventDefault()
+        this.unlocked ? this.lock() : this.promptUnlock()
+      }
+    })
+    if (new URLSearchParams(location.search).has('admin')) this.promptUnlock()
+    if (this.unlocked) this.open()
+  }
+
+  get unlocked() { return !!this.token }
+
+  private promptUnlock() {
+    const t = prompt('Admin token')
+    if (!t) return
+    this.token = t.trim()
+    sessionStorage.setItem(KEY, this.token)
+    this.open()
+    void this.call('stats').then((r) => {
+      if (r?.ok) this.host.status(`god mode · ${r.pixels} pixels, ${r.bans} bans`, '')
+      else { this.host.status('bad admin token', 'bad'); this.lock() }
+    })
+  }
+
+  lock() {
+    this.token = null
+    sessionStorage.removeItem(KEY)
+    this.panel.hidden = true
+    document.body.classList.remove('admin')
+    this.tool = 'paint'
+    this.host.status('locked', '')
+  }
+
+  private open() {
+    this.panel.hidden = false
+    document.body.classList.add('admin')
+    this.render()
+  }
+
+  /** Every admin operation goes through one authenticated POST. */
+  async call(op: string, extra: Record<string, unknown> = {}): Promise<any> {
+    if (!this.token) return null
+    try {
+      const res = await fetch(`${this.base}api/pixels/admin`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: `Bearer ${this.token}` },
+        body: JSON.stringify({ op, ...extra }),
+      })
+      const data = await res.json()
+      if (res.status === 401) { this.host.status('admin token rejected', 'bad'); this.lock() }
+      return data
+    } catch {
+      this.host.status('admin call failed', 'bad')
+      return null
+    }
+  }
+
+  private render(extra = '') {
+    this.panel.innerHTML = `
+      <div class="ad-head">
+        <b>god mode</b>
+        <button data-act="lock" title="Lock (Ctrl+Shift+A)">lock</button>
+      </div>
+      <div class="ad-tools" role="radiogroup" aria-label="Tool">
+        ${(['paint', 'rect-erase', 'rect-fill', 'inspect'] as Tool[]).map((t) =>
+          `<button data-tool="${t}" aria-checked="${this.tool === t}" role="radio">${
+            { paint: 'Paint', 'rect-erase': 'Erase area', 'rect-fill': 'Fill area', inspect: 'Inspect' }[t]
+          }</button>`).join('')}
+      </div>
+      <div class="ad-row">
+        <button data-act="stats">Stats</button>
+        <button data-act="bans">Bans</button>
+        <button data-act="reload">Reload</button>
+        <button data-act="clearAll" class="danger">Wipe all</button>
+      </div>
+      <div class="ad-out">${extra}</div>`
+  }
+
+  private async onClick(e: Event) {
+    const el = (e.target as HTMLElement).closest('button') as HTMLElement | null
+    if (!el) return
+
+    if (el.dataset.tool) {
+      this.tool = el.dataset.tool as Tool
+      this.render()
+      return
+    }
+
+    switch (el.dataset.act) {
+      case 'lock': this.lock(); break
+      case 'stats': {
+        const r = await this.call('stats')
+        this.render(r ? `<code>${r.pixels} pixels · ${r.chunks} chunks · ${r.bans} bans</code>` : '')
+        break
+      }
+      case 'bans': {
+        const r = await this.call('bans')
+        const list: string[] = r?.bans ?? []
+        this.render(list.length
+          ? list.map((id) => `<div class="ad-ban"><code>${id}</code><button data-unban="${id}">unban</button></div>`).join('')
+          : '<code>no bans</code>')
+        break
+      }
+      case 'reload':
+        await this.host.reload()
+        this.host.status('canvas reloaded', '')
+        break
+      case 'clearAll': {
+        // Irreversible and total, so make it deliberate.
+        if (!confirm('Erase every user-drawn pixel? The seeded art stays.')) break
+        const r = await this.call('clearAll')
+        if (r?.ok) { await this.host.reload(); this.host.status(`wiped ${r.chunksDeleted} chunks`, 'warn') }
+        break
+      }
+    }
+
+    if (el.dataset.unban) {
+      await this.call('unban', { id: el.dataset.unban })
+      ;(this.panel.querySelector('[data-act="bans"]') as HTMLElement)?.click()
+    }
+    if (el.dataset.ban) {
+      await this.call('ban', { id: el.dataset.ban })
+      this.host.status(`banned ${el.dataset.ban}`, 'warn')
+    }
+  }
+
+  /** Bulk apply over a rectangle. Returns false if the op was refused. */
+  async applyRect(x0: number, y0: number, x1: number, y1: number): Promise<boolean> {
+    const x = Math.min(x0, x1), y = Math.min(y0, y1)
+    const w = Math.abs(x1 - x0) + 1, h = Math.abs(y1 - y0) + 1
+    const c = this.tool === 'rect-fill' ? this.host.currentColour() : 0
+    const r = await this.call(this.tool === 'rect-fill' ? 'fillRect' : 'clearRect', { x, y, w, h, c })
+    if (!r?.ok) { this.host.status(r?.error ?? 'rectangle refused', 'bad'); return false }
+    for (let dy = 0; dy < h; dy++) for (let dx = 0; dx < w; dx++) this.host.setLocal(x + dx, y + dy, c)
+    this.host.redraw()
+    this.host.status(`${this.tool === 'rect-fill' ? 'filled' : 'erased'} ${r.affected} pixels`, '')
+    return true
+  }
+
+  /** Who painted this pixel, with a one-click ban if we know. */
+  async inspect(x: number, y: number) {
+    const r = await this.call('who', { x, y })
+    const p = r?.painter
+    this.render(p
+      ? `<code>(${x},${y}) by ${p.id}</code>
+         <div class="ad-ban"><span>${new Date(p.at).toLocaleString()}</span>
+         <button data-ban="${p.id}" class="danger">ban</button></div>`
+      : `<code>(${x},${y}) — no recent painter on record</code>`)
+  }
+
+  /** Admin paints bypass the rate limit entirely. */
+  async paint(pixels: [number, number, number][]) {
+    const r = await this.call('paint', { pixels })
+    if (!r?.ok) this.host.status(r?.error ?? 'paint refused', 'bad')
+    return !!r?.ok
+  }
+}

--- a/src/pixels/main.ts
+++ b/src/pixels/main.ts
@@ -8,6 +8,7 @@ import {
   GRID_W, GRID_H, PALETTE, TRANSPARENT,
   lonLatToPixel, pixelToLonLat, inBounds, unpackChunk,
 } from './grid'
+import { Admin } from './admin'
 
 const base = import.meta.env.BASE_URL
 const boot = document.getElementById('boot')!
@@ -176,7 +177,23 @@ async function start() {
       g.fillRect(pt.x, pt.y, sw + 1, sh + 1)
     }
 
-    if (hover && sw >= 4) {
+    if (dragFrom && dragTo) {
+      const rx0 = Math.min(dragFrom.x, dragTo.x), ry0 = Math.min(dragFrom.y, dragTo.y)
+      const rx1 = Math.max(dragFrom.x, dragTo.x) + 1, ry1 = Math.max(dragFrom.y, dragTo.y) + 1
+      const [lonS, latS] = pixelToLonLat(rx0, ry0)
+      const [lonE, latE] = pixelToLonLat(rx1, ry1)
+      const pA = map.project([lonS, latS])
+      const pB = map.project([lonE, latE])
+      g.fillStyle = 'rgba(255,123,114,.18)'
+      g.fillRect(pA.x, pA.y, pB.x - pA.x, pB.y - pA.y)
+      g.strokeStyle = '#ff7b72'
+      g.setLineDash([5, 4])
+      g.lineWidth = 1.5
+      g.strokeRect(pA.x + .5, pA.y + .5, pB.x - pA.x, pB.y - pA.y)
+      g.setLineDash([])
+    }
+
+    if (hover && sw >= 4 && !dragFrom) {
       const [lon, lat] = pixelToLonLat(hover.x, hover.y)
       const pt = map.project([lon, lat])
       g.strokeStyle = resolved() === 'dark' ? '#ffffff' : '#000000'
@@ -247,6 +264,55 @@ async function start() {
   }
   map.on('zoom', updateHint)
 
+  /* ── god mode ─────────────────────────────────────────────────────────── */
+
+  async function reloadCanvas() {
+    const server = await json<{ chunks: Record<string, string> }>(`${base}api/pixels`)
+    board.fill(0)
+    painted.clear()
+    for (const [x, y, c] of seed.pixels) set(x, y, c)
+    applyChunks(server.chunks)
+    draw()
+  }
+
+  const admin = new Admin({
+    redraw: draw,
+    setLocal: set,
+    reload: reloadCanvas,
+    status: setStatus,
+    currentColour: () => (erasing ? TRANSPARENT : colour),
+  }, base)
+
+  // Rectangle tools drag on the map, so panning has to yield while one is armed.
+  let dragFrom: { x: number; y: number } | null = null
+  let dragTo: { x: number; y: number } | null = null
+  const rectTool = () => admin.unlocked && (admin.tool === 'rect-erase' || admin.tool === 'rect-fill')
+
+  map.on('mousedown', (e) => {
+    if (!rectTool()) return
+    const { x, y } = lonLatToPixel(e.lngLat.lng, e.lngLat.lat)
+    if (!inBounds(x, y)) return
+    e.preventDefault()
+    map.dragPan.disable()
+    dragFrom = { x, y }
+    dragTo = { x, y }
+  })
+
+  map.on('mousemove', (e) => {
+    if (!dragFrom) return
+    const { x, y } = lonLatToPixel(e.lngLat.lng, e.lngLat.lat)
+    if (inBounds(x, y)) { dragTo = { x, y }; draw() }
+  })
+
+  map.on('mouseup', async () => {
+    if (!dragFrom || !dragTo) return
+    const a = dragFrom, b = dragTo
+    dragFrom = dragTo = null
+    map.dragPan.enable()
+    draw()
+    await admin.applyRect(a.x, a.y, b.x, b.y)
+  })
+
   /** Queue writes so a fast drag becomes one request, not twelve. */
   const queue: { x: number; y: number; c: number }[] = []
   let flushTimer: ReturnType<typeof setTimeout> | undefined
@@ -291,6 +357,17 @@ async function start() {
     const { x, y } = lonLatToPixel(lngLat.lng, lngLat.lat)
     if (!inBounds(x, y)) return
     const c = erasing ? TRANSPARENT : colour
+
+    // God mode writes straight through: no cooldown, no client-side budget.
+    if (admin.unlocked) {
+      if (admin.tool === 'inspect') { void admin.inspect(x, y); return }
+      if (admin.tool !== 'paint') return   // the rectangle tools drag instead
+      set(x, y, c)
+      draw()
+      void admin.paint([[x, y, c]])
+      return
+    }
+
     if (board[idx(x, y)] === c) return
 
     set(x, y, c)                    // optimistic: show it immediately
@@ -299,7 +376,7 @@ async function start() {
     if (!flushTimer) flushTimer = setTimeout(flush, 180)
   }
 
-  map.on('click', (e) => place(e.lngLat))
+  map.on('click', (e) => { if (!rectTool()) place(e.lngLat) })
 
   map.on('mousemove', (e) => {
     const { x, y } = lonLatToPixel(e.lngLat.lng, e.lngLat.lat)

--- a/src/pixels/pixels.css
+++ b/src/pixels/pixels.css
@@ -144,3 +144,64 @@ body.can-paint .maplibregl-canvas { cursor: crosshair; }
   #px-dock { gap: 6px; bottom: calc(var(--pad) + env(safe-area-inset-bottom)); }
   #px-status { font-size: 10px; }
 }
+
+/* ── god mode ────────────────────────────────────────────────────────────── */
+/* Deliberately red and always visible: forgetting you are in god mode and
+   wiping the canvas by accident should be hard. */
+
+#px-admin {
+  position: fixed;
+  top: calc(var(--pad) + 40px);
+  right: var(--pad);
+  z-index: 9;
+  width: 210px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  padding: 10px;
+  background: var(--bg-1);
+  border: 1px solid var(--danger);
+  border-radius: 7px;
+  box-shadow: var(--lift);
+  font-size: 12px;
+}
+#px-admin[hidden] { display: none; }
+
+body.admin::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  pointer-events: none;
+  border: 2px solid var(--danger);
+}
+
+.ad-head { display: flex; align-items: center; justify-content: space-between; }
+.ad-head b { color: var(--danger); letter-spacing: .04em; text-transform: uppercase; font-size: 11px; }
+
+#px-admin button {
+  padding: 5px 8px;
+  border: 1px solid var(--line-2);
+  border-radius: 4px;
+  color: var(--fg-2);
+  font-size: 11.5px;
+}
+#px-admin button:hover { color: var(--fg); border-color: var(--fg-3); }
+#px-admin button[aria-checked="true"] { color: var(--bg); background: var(--fg); border-color: var(--fg); }
+#px-admin button.danger { color: var(--danger); border-color: var(--danger); }
+#px-admin button.danger:hover { color: #fff; background: var(--danger); }
+
+.ad-tools, .ad-row { display: grid; grid-template-columns: 1fr 1fr; gap: 5px; }
+.ad-out { display: grid; gap: 5px; }
+.ad-out code {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--fg-2);
+  word-break: break-all;
+}
+.ad-ban { display: flex; align-items: center; justify-content: space-between; gap: 6px; }
+.ad-ban span { font-size: 10px; color: var(--fg-3); }
+
+@media (max-width: 760px) {
+  #px-admin { left: var(--pad); right: var(--pad); width: auto; }
+}


### PR DESCRIPTION
Moderation as a player, not as a curl script. Same page, same map, same
palette — unlocking swaps the write path from `/paint` to `/admin`, which skips
the rate limit and unlocks bulk tools.

### Unlocking

`Ctrl+Shift+A`, or `?admin` in the URL. No button, so there is nothing for
people to find and poke at. The token lives in **sessionStorage only** — it dies
with the tab, so an unlocked dashboard is never left sitting on a shared
machine. A bad token is rejected on the first call and re-locks itself.

While unlocked the whole viewport gets a red border and a red panel. Forgetting
you are in god mode and wiping the canvas by accident should be hard.

### Tools

| Tool | Behaviour |
|---|---|
| **Paint** | click to place, no cooldown, no budget |
| **Erase area** | drag a marquee, erases the rectangle |
| **Fill area** | drag a marquee, floods it with the selected colour |
| **Inspect** | click a pixel to see who painted it, with a one-click ban |

Plus Stats, Bans (with unban), Reload, and Wipe all — which is `confirm()`-gated
and only removes user pixels, since the seed is a static file rather than
storage.

Map panning yields while a rectangle tool is armed, otherwise the drag would
pan instead of select.

### Click-to-ban needed attribution

Bans key off a painter id, but nothing recorded which id painted which pixel.
Added a **bounded** record: the last 600 paints as `[x, y, id, t]`, capped and
overwritten in place.

That is deliberately a moderation aid, not a history of the canvas — it holds
minutes of activity, not months, and still contains no IP address. Inspecting a
pixel older than that window honestly reports "no recent painter on record"
rather than guessing.

Two new admin ops back it: `who` for a single pixel, `recent` for a feed.

### Notes

- Admin paints write through `applyPixels` like anyone else's, so there is no
  second code path that could drift from the normal one.
- `setLocal` reuses the same `set()` helper the player path uses, which keeps
  the painted-cell index in step — bulk edits would otherwise leave ghosts on
  screen until reload.
- Rectangles are capped at 40,000 cells server-side; larger asks are refused
  rather than silently truncated.