### PR TITLE
feat(pixels): live canvas updates without reloading

### DIFF
--- a/functions/api/pixels/[[path]].ts
+++ b/functions/api/pixels/[[path]].ts
@@ -138,6 +138,32 @@ async function logPixels(env: Env, who: string, pixels: Pixel[], note = '') {
   }).catch(() => { /* logging must never break painting */ })
 }
 
+/* ── live feed ───────────────────────────────────────────────────────────── */
+
+/**
+ * A rolling log of recent edits so clients can catch up without re-downloading
+ * the whole canvas. Each entry carries a monotonic sequence number; a client
+ * says "I have up to N" and gets only what came after.
+ *
+ * Cloudflare Pages Functions cannot hold a WebSocket, so this is polled — but
+ * polling a few hundred bytes every couple of seconds is far cheaper than
+ * re-fetching every chunk, and it means an edit shows up without a reload.
+ */
+const FEED_MAX = 500
+
+async function pushFeed(env: Env, pixels: Pixel[]) {
+  const raw = await env.PIXELS.get('feed')
+  const feed = raw
+    ? (JSON.parse(raw) as { seq: number; items: [number, number, number, number][] })
+    : { seq: 0, items: [] }
+  for (const p of pixels) {
+    feed.seq++
+    feed.items.push([feed.seq, p.x, p.y, p.c])
+  }
+  if (feed.items.length > FEED_MAX) feed.items.splice(0, feed.items.length - FEED_MAX)
+  await env.PIXELS.put('feed', JSON.stringify(feed))
+}
+
 /* ── attribution ─────────────────────────────────────────────────────────── */
 
 /**
@@ -180,13 +206,40 @@ export const onRequest: PagesFunction<Env> = async (ctx) => {
 
   /* GET /api/pixels */
   if (request.method === 'GET' && path === '') {
+    const [chunks, feedRaw, epoch] = await Promise.all([
+      readCanvas(env),
+      env.PIXELS.get('feed'),
+      env.PIXELS.get('epoch'),
+    ])
+    const feed = feedRaw ? JSON.parse(feedRaw) as { seq: number } : { seq: 0 }
     return json({
       grid: { w: GRID_W, h: GRID_H, chunk: CHUNK },
       burst: BURST,
       cooldown: COOLDOWN_S,
       maxPerRequest: MAX_PER_REQUEST,
-      chunks: await readCanvas(env),
+      seq: feed.seq,
+      epoch: epoch ?? '0',
+      chunks,
     })
+  }
+
+  /* GET /api/pixels/since?seq=N — just what changed. */
+  if (request.method === 'GET' && path === 'since') {
+    const since = Number(new URL(request.url).searchParams.get('seq') ?? 0)
+    const [raw, epoch] = await Promise.all([env.PIXELS.get('feed'), env.PIXELS.get('epoch')])
+    const feed = raw
+      ? (JSON.parse(raw) as { seq: number; items: [number, number, number, number][] })
+      : { seq: 0, items: [] }
+
+    // Behind the window the feed still holds? Only a full reload is correct.
+    const oldest = feed.items.length ? feed.items[0]![0] : feed.seq
+    const stale = since > 0 && since < oldest - 1
+    return json({
+      seq: feed.seq,
+      epoch: epoch ?? '0',
+      stale,
+      pixels: stale ? [] : feed.items.filter((i) => i[0] > since).map((i) => [i[1], i[2], i[3]]),
+    }, 200, { 'cache-control': 'no-store' })
   }
 
   /* POST /api/pixels/paint */
@@ -243,6 +296,7 @@ export const onRequest: PagesFunction<Env> = async (ctx) => {
     await applyPixels(env, pixels)
     ctx.waitUntil(logPixels(env, who, pixels))
     ctx.waitUntil(rememberPainter(env, who, pixels))
+    ctx.waitUntil(pushFeed(env, pixels))
 
     return json({
       ok: true,
@@ -285,6 +339,7 @@ export const onRequest: PagesFunction<Env> = async (ctx) => {
           }
         }
         await applyPixels(env, px)
+        ctx.waitUntil(pushFeed(env, px))
         ctx.waitUntil(logPixels(env, 'ADMIN', px.slice(0, 5), `${op} ${w}x${h} `))
         return json({ ok: true, op, affected: px.length })
       }
@@ -299,6 +354,7 @@ export const onRequest: PagesFunction<Env> = async (ctx) => {
           if (inBounds(x, y) && c >= 0 && c < PALETTE.length) px.push({ x, y, c })
         }
         await applyPixels(env, px)
+        ctx.waitUntil(pushFeed(env, px))
         ctx.waitUntil(logPixels(env, 'ADMIN', px.slice(0, 5), 'stamp '))
         return json({ ok: true, op, affected: px.length })
       }
@@ -312,6 +368,10 @@ export const onRequest: PagesFunction<Env> = async (ctx) => {
           for (const k of page.keys) { await env.PIXELS.delete(k.name); n++ }
           cursor = page.list_complete ? undefined : page.cursor
         } while (cursor)
+        // A full wipe cannot be sent as a diff; bump the epoch and every client
+        // reloads from scratch on its next poll.
+        await env.PIXELS.put('epoch', String(Date.now()))
+        await env.PIXELS.delete('feed')
         ctx.waitUntil(logPixels(env, 'ADMIN', [], `cleared the whole canvas (${n} chunks) `))
         return json({ ok: true, op, chunksDeleted: n })
       }

--- a/src/pixels/main.ts
+++ b/src/pixels/main.ts
@@ -63,14 +63,20 @@ async function start() {
   let remaining = 30
   let cooldownUntil = 0
   let live = false
+  /** Cursor into the server's edit feed; everything up to here is applied. */
+  let seq = 0
+  let epoch = '0'
 
   try {
     const server = await json<{
-      burst: number; cooldown: number; chunks: Record<string, string>
+      burst: number; cooldown: number; seq?: number; epoch?: string
+      chunks: Record<string, string>
     }>(`${base}api/pixels`)
     applyChunks(server.chunks)
     burst = server.burst
     remaining = server.burst
+    seq = server.seq ?? 0
+    epoch = server.epoch ?? '0'
     live = true
   } catch {
     // No Functions binding (local `vite preview`, or KV not wired up yet).
@@ -326,13 +332,68 @@ async function start() {
   /* ── god mode ─────────────────────────────────────────────────────────── */
 
   async function reloadCanvas() {
-    const server = await json<{ chunks: Record<string, string> }>(`${base}api/pixels`)
+    const server = await json<{
+      chunks: Record<string, string>; seq?: number; epoch?: string
+    }>(`${base}api/pixels`)
     board.fill(0)
     painted.clear()
     for (const [x, y, c] of seed.pixels) set(x, y, c)
     applyChunks(server.chunks)
+    seq = server.seq ?? seq
+    epoch = server.epoch ?? epoch
     draw()
   }
+
+  /* ── live updates ─────────────────────────────────────────────────────── */
+
+  /**
+   * Poll the edit feed and apply just the difference.
+   *
+   * Pages Functions cannot hold a WebSocket open, so this polls — but it asks
+   * for "everything after sequence N" and usually gets an empty array, which is
+   * a few hundred bytes rather than the whole canvas. Backs right off when the
+   * tab is hidden, so a forgotten tab is not hammering the worker all day.
+   */
+  const POLL_ACTIVE_MS = 2500
+  const POLL_HIDDEN_MS = 30_000
+  let pollTimer: ReturnType<typeof setTimeout> | undefined
+  let failures = 0
+
+  async function poll() {
+    if (!live) return
+    try {
+      const r = await json<{
+        seq: number; epoch: string; stale: boolean; pixels: [number, number, number][]
+      }>(`${base}api/pixels/since?seq=${seq}`)
+
+      // A wipe, or we fell behind the feed window — only a full reload is right.
+      if (r.epoch !== epoch || r.stale) {
+        await reloadCanvas()
+        setStatus('canvas reset by a moderator', 'warn')
+      } else if (r.pixels.length) {
+        for (const [x, y, c] of r.pixels) set(x, y, c)
+        seq = r.seq
+        draw()
+        // Only announce other people's edits; your own already showed instantly.
+        const mine = queue.length
+        if (!mine) setStatus(`${r.pixels.length} pixel${r.pixels.length > 1 ? 's' : ''} just changed`, '')
+      } else {
+        seq = r.seq
+      }
+      failures = 0
+    } catch {
+      // Keep polling, just slower, so a blip does not permanently kill live mode.
+      failures++
+    }
+    const base_ms = document.hidden ? POLL_HIDDEN_MS : POLL_ACTIVE_MS
+    pollTimer = setTimeout(poll, Math.min(base_ms * (1 + failures), 60_000))
+  }
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden || !live) return
+    clearTimeout(pollTimer)
+    poll()                      // catch up the moment the tab comes back
+  })
 
   const admin = new Admin({
     redraw: draw,
@@ -545,8 +606,9 @@ async function start() {
     boot.classList.add('gone')
     updateHint()
     updateBudget()
-    setStatus(live ? `${GRID_W}×${GRID_H} grid · 2 m per pixel` : 'read-only preview', live ? '' : 'warn')
+    setStatus(live ? `${GRID_W}×${GRID_H} grid · 2 m per pixel · live` : 'read-only preview', live ? '' : 'warn')
     draw()
+    if (live) pollTimer = setTimeout(poll, POLL_ACTIVE_MS)
   })
 }
 


### PR DESCRIPTION
Other people's pixels now appear as they are painted — you can watch someone
draw, or watch someone rub your work out, without touching reload.

### Polling, not sockets

Pages Functions cannot hold a WebSocket open, so this polls. The trick is that
it polls a **cursor**, not the canvas: the server keeps a rolling log of the
last 500 edits, each with a monotonic sequence number, and the client asks
"everything after N". The usual answer is an empty array — a few hundred bytes
every 2.5 s, against ~100 kB to refetch every chunk.

A hidden tab drops to one poll every 30 s and catches up instantly on
`visibilitychange`, so a tab left open overnight is not hammering the worker.
Failures back off rather than killing live mode, up to a 60 s ceiling.

### Two cases a diff cannot express

**A moderator wipe.** `clearAll` bumps an `epoch` key and drops the feed;
clients notice the epoch changed and reload from scratch, showing
"canvas reset by a moderator".

**Falling behind the window.** If you were away long enough that your cursor is
older than the oldest entry still in the feed, the server says `stale: true`
rather than silently sending a partial diff that would leave your canvas
subtly wrong. Client reloads.

### Verified against a simulated second painter

| | result |
|---|---|
| another painter's 144 px arrive | 0 → 8281 lit pixels, no reload |
| epoch bump (wipe) | full reload triggered, status explains why |
| hidden tab over 7 s | 1 poll instead of ~3 |

Your own pixels are unaffected — they already render optimistically, and the
status line only announces changes when your own queue is empty, so you never
get told about your own edits.